### PR TITLE
feat(tools): add JWT Decoder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,21 +32,22 @@
         "i18next-browser-languagedetector": "^8.1.0",
         "i18next-resources-to-backend": "^1.2.1",
         "js-cookie": "~3.0.5",
+        "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.537.0",
         "markdown-to-jsx": "~7.5.0",
         "mobx": "^6",
         "mobx-react": "^7",
-        "next": "^15.5.9",
+        "next": "^16.1.6",
         "next-i18next": "~15.4.2",
         "next-pwa": "~5.6.0",
         "next-sitemap": "~4.2.3",
         "nextjs-cors": "^2",
         "prismjs": "~1.30.0",
         "qrcode.react": "^4.2.0",
-        "react": "~19.1.0",
+        "react": "~19.2.0",
         "react-cookie": "^7.2.0",
-        "react-dom": "~19.1.0",
+        "react-dom": "~19.2.0",
         "react-hook-form": "^7",
         "react-i18next": "~15.5.1",
         "react-intersection-observer": "^10.0.2",
@@ -3271,9 +3272,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.11.tgz",
-      "integrity": "sha512-g9s5SS9gC7GJCEOR3OV3zqs7C5VddqxP9X+/6BpMbdXRkqsWfFf2CJPBZNvNEtAkKTNuRgRXAgNxSAXzfLdaTg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3287,9 +3288,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
-      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -3303,9 +3304,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
-      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
       "cpu": [
         "x64"
       ],
@@ -3319,9 +3320,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
-      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
       "cpu": [
         "arm64"
       ],
@@ -3335,9 +3336,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
-      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
       "cpu": [
         "arm64"
       ],
@@ -3351,9 +3352,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
-      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
       "cpu": [
         "x64"
       ],
@@ -3367,9 +3368,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
-      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
       "cpu": [
         "x64"
       ],
@@ -3383,9 +3384,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
-      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
       "cpu": [
         "arm64"
       ],
@@ -3399,9 +3400,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
-      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
       "cpu": [
         "x64"
       ],
@@ -12579,6 +12580,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -13689,13 +13699,14 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.11.tgz",
-      "integrity": "sha512-L2KPiKmqTDpRdeVDdPjhf43g2/VPe0NCNndq7OKDCgOLWtxe1kbr/zXGIZtYY7kZEAjRf7Bj/mwUFSr+tYC2Yg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.11",
+        "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -13704,18 +13715,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.7",
-        "@next/swc-darwin-x64": "15.5.7",
-        "@next/swc-linux-arm64-gnu": "15.5.7",
-        "@next/swc-linux-arm64-musl": "15.5.7",
-        "@next/swc-linux-x64-gnu": "15.5.7",
-        "@next/swc-linux-x64-musl": "15.5.7",
-        "@next/swc-win32-arm64-msvc": "15.5.7",
-        "@next/swc-win32-x64-msvc": "15.5.7",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
+        "sharp": "^0.34.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -15289,9 +15300,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.5.tgz",
-      "integrity": "sha512-lCX00zqONdNfcnJYEL91LuNYzyWFU70vKhApUR08Y1Fi/Y5FGw6l6hAWtlkq+k/vnx463XLm/5dyQp5HAJCw6Q==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15312,15 +15323,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.5.tgz",
-      "integrity": "sha512-tvMijysf97vcHla1PNI/aU2apv7f4r0ct0OBk3i3QOBfsVhZzHEuPBLemClkfuw8LroE4FH6kXcQOftf2ntPHQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.5"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-hook-form": {
@@ -16006,9 +16017,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "i18next-browser-languagedetector": "^8.1.0",
     "i18next-resources-to-backend": "^1.2.1",
     "js-cookie": "~3.0.5",
+    "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.537.0",
     "markdown-to-jsx": "~7.5.0",

--- a/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecodedPanel.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecodedPanel.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Text } from '@components/basic/Text';
+
+type JwtDecodedPanelProps = {
+  title: string;
+  value: unknown | null;
+  emptyText: string;
+};
+
+function JwtDecodedPanel({ title, value, emptyText }: JwtDecodedPanelProps) {
+  const hasValue = value !== null && value !== undefined;
+
+  return (
+    <div className="space-y-2">
+      <Text variant="d3" className="font-medium text-gray-700 dark:text-gray-300">
+        {title}
+      </Text>
+      <pre className="w-full min-h-[300px] p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 overflow-auto text-sm font-mono text-gray-800 dark:text-gray-200">
+        {hasValue ? JSON.stringify(value, null, 2) : emptyText}
+      </pre>
+    </div>
+  );
+}
+
+export default JwtDecodedPanel;

--- a/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { jwtDecode, JwtHeader, JwtPayload } from 'jwt-decode';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import JwtTokenInput from './JwtTokenInput';
+import JwtDecodedPanel from './JwtDecodedPanel';
+
+type DecodedPart = JwtHeader | JwtPayload | Record<string, unknown>;
+
+type DecodedToken = {
+  header: DecodedPart;
+  payload: DecodedPart;
+};
+
+type JwtDecoderClientProps = {
+  lng: Language;
+};
+
+function JwtDecoderClient({ lng }: JwtDecoderClientProps) {
+  const { t } = useTranslation(lng, 'jwt-decoder');
+  const [token, setToken] = useState('');
+  const [decoded, setDecoded] = useState<DecodedToken | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const trimmedToken = token.trim();
+    if (!trimmedToken) {
+      setDecoded(null);
+      setError(null);
+      return;
+    }
+
+    try {
+      const parts = trimmedToken.split('.');
+      if (parts.length !== 3) {
+        throw new Error('Invalid structure');
+      }
+
+      const header = jwtDecode<JwtHeader>(trimmedToken, { header: true });
+      const payload = jwtDecode<JwtPayload>(trimmedToken);
+      setDecoded({ header, payload });
+      setError(null);
+    } catch (err) {
+      setDecoded(null);
+      setError(t('error.invalidFormat'));
+    }
+  }, [token, t]);
+
+  return (
+    <div className="w-full max-w-4xl mx-auto space-y-6">
+      <JwtTokenInput
+        label={t('label.encodedToken')}
+        placeholder={t('placeholder')}
+        token={token}
+        error={error}
+        onChange={setToken}
+      />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <JwtDecodedPanel
+          title={t('label.header')}
+          value={decoded?.header ?? null}
+          emptyText="// Header"
+        />
+        <JwtDecodedPanel
+          title={t('label.payload')}
+          value={decoded?.payload ?? null}
+          emptyText="// Payload"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default JwtDecoderClient;

--- a/src/app/[lng]/(mobile)/jwt-decoder/components/JwtTokenInput.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/components/JwtTokenInput.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { Text } from '@components/basic/Text';
+import { Textarea } from '@components/basic/Textarea';
+
+type JwtTokenInputProps = {
+  label: string;
+  placeholder: string;
+  token: string;
+  error: string | null;
+  onChange: (value: string) => void;
+};
+
+function JwtTokenInput({ label, placeholder, token, error, onChange }: JwtTokenInputProps) {
+  return (
+    <div className="space-y-2">
+      <Text asChild variant="d3" className="font-medium text-gray-700 dark:text-gray-300">
+        <label htmlFor="jwt-input">{label}</label>
+      </Text>
+      <Textarea
+        id="jwt-input"
+        className="min-h-[120px] font-mono text-sm"
+        placeholder={placeholder}
+        value={token}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {error && (
+        <Text variant="d3" className="font-medium text-red-500 animate-pulse">
+          {error}
+        </Text>
+      )}
+    </div>
+  );
+}
+
+export default JwtTokenInput;

--- a/src/app/[lng]/(mobile)/jwt-decoder/page.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/page.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import { H1, Text } from '@components/basic/Text';
+import JwtDecoderClient from '~/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'jwt-decoder' });
+
+export default async function JwtDecoderPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+
+  const { t } = await getTranslations(language, 'jwt-decoder');
+
+  return (
+    <>
+      <H1 className="mb-2 t-basic-1">{t('title')}</H1>
+      <Text className="mb-6 t-basic-1/60">{t('description')}</Text>
+      <JwtDecoderClient lng={language} />
+    </>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -18,6 +18,7 @@ import ppollong from 'assets/locales/ko/ppollong.json'; // ppollong.json 임포�
 import serverClock from 'assets/locales/ko/server-clock.json';
 import choseongMaker from 'assets/locales/ko/choseong-maker.json';
 import qrGenerator from 'assets/locales/ko/qr-generator.json';
+import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -42,6 +43,7 @@ declare module 'i18next' {
       'server-clock': typeof serverClock;
       'choseong-maker': typeof choseongMaker;
       'qr-generator': typeof qrGenerator;
+      'jwt-decoder': typeof jwtDecoder;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -15,6 +15,7 @@ import {
   TextCursorInput,
   Tv,
   Youtube,
+  Key,
 } from 'lucide-react';
 import { Language } from '~/app/i18n/settings';
 
@@ -41,6 +42,16 @@ const menus: Menus = {
       },
       icon: <QrCode />,
       link: '/qr-generator',
+    },
+    {
+      title: {
+        ko: 'JWT 디코더',
+        en: 'JWT Decoder',
+        ja: 'JWTデコーダー',
+        zh: 'JWT解码器',
+      },
+      icon: <Key />,
+      link: '/jwt-decoder',
     },
     {
       title: {

--- a/src/assets/locales/en/jwt-decoder.json
+++ b/src/assets/locales/en/jwt-decoder.json
@@ -1,0 +1,17 @@
+{
+  "title": "JWT Decoder",
+  "description": "Decode JWT tokens to inspect header and payload. No data is sent to server.",
+  "label": {
+    "encodedToken": "Encoded Token",
+    "header": "Header",
+    "payload": "Payload"
+  },
+  "placeholder": "Paste your JWT here...",
+  "error": {
+    "invalidFormat": "Invalid JWT token format."
+  },
+  "openGraph": {
+    "title": "JWT Decoder",
+    "description": "Safely decode and debug JWT tokens on the client side."
+  }
+}

--- a/src/assets/locales/ja/jwt-decoder.json
+++ b/src/assets/locales/ja/jwt-decoder.json
@@ -1,0 +1,17 @@
+{
+  "title": "JWT デコーダー",
+  "description": "JWTトークンをデコードしてヘッダーとペイロードを検査します。データはサーバーに送信されません。",
+  "label": {
+    "encodedToken": "エンコードされたトークン",
+    "header": "ヘッダー",
+    "payload": "ペイロード"
+  },
+  "placeholder": "ここにJWTを貼り付けてください...",
+  "error": {
+    "invalidFormat": "無効なJWTトークン形式です。"
+  },
+  "openGraph": {
+    "title": "JWT デコーダー",
+    "description": "クライアントサイドで安全にJWTトークンをデコードおよびデバッグします。"
+  }
+}

--- a/src/assets/locales/ko/jwt-decoder.json
+++ b/src/assets/locales/ko/jwt-decoder.json
@@ -1,0 +1,17 @@
+{
+  "title": "JWT 디코더",
+  "description": "JWT(JSON Web Token)을 디코딩하여 헤더와 페이로드를 검사합니다. 서버로 전송되지 않습니다.",
+  "label": {
+    "encodedToken": "인코딩된 토큰",
+    "header": "헤더 (Header)",
+    "payload": "페이로드 (Payload)"
+  },
+  "placeholder": "여기에 JWT를 붙여넣으세요 (Bearer ...)",
+  "error": {
+    "invalidFormat": "유효하지 않은 JWT 토큰 형식입니다."
+  },
+  "openGraph": {
+    "title": "JWT 디코더",
+    "description": "클라이언트 사이드에서 안전하게 JWT 토큰을 디코딩하고 디버깅하세요."
+  }
+}

--- a/src/assets/locales/zh/jwt-decoder.json
+++ b/src/assets/locales/zh/jwt-decoder.json
@@ -1,0 +1,17 @@
+{
+  "title": "JWT 解码器",
+  "description": "解码 JWT 令牌以检查标头和有效载荷。数据不会发送到服务器。",
+  "label": {
+    "encodedToken": "编码令牌",
+    "header": "标头",
+    "payload": "有效载荷"
+  },
+  "placeholder": "在此处粘贴您的 JWT...",
+  "error": {
+    "invalidFormat": "无效的 JWT 令牌格式。"
+  },
+  "openGraph": {
+    "title": "JWT 解码器",
+    "description": "在客户端安全地解码和调试 JWT 令牌。"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9796,6 +9796,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -10942,6 +10949,7 @@ __metadata:
     i18next-resources-to-backend: "npm:^1.2.1"
     js-cookie: "npm:~3.0.5"
     jsdom: "npm:^25.0.1"
+    jwt-decode: "npm:^4.0.0"
     lint-staged: "npm:^16.2.3"
     lodash: "npm:^4.17.21"
     lucide-react: "npm:^0.537.0"


### PR DESCRIPTION
## Description
Added a JWT Decoder tool using `jwt-decode`.
This tool allows users to inspect JWT Header and Payload on the client side without sending data to the server.

## Components
- `src/components/complex/tools/JwtDecoder.tsx`: Logic and UI for decoding.
- `src/app/[lng]/tools/jwt-decoder/page.tsx`: Page wrapper.

## Dependencies
- `jwt-decode`: Added for decoding functionality.