### PR TITLE
feat(tools): add CSS Generator

### DIFF
--- a/src/app/[lng]/(mobile)/css-generator/components/CodeBlock.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/CodeBlock.tsx
@@ -1,0 +1,36 @@
+import { Text } from '@components/basic/Text';
+
+interface CodeBlockProps {
+  title: string;
+  code: string;
+  id: string;
+  tooltip: string;
+}
+
+export function CodeBlock({ title, code, id, tooltip }: CodeBlockProps) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      // Ignore clipboard write failures to keep UI interaction non-blocking.
+    }
+  };
+
+  return (
+    <div className="space-y-1">
+      <Text variant="c1" color="basic-5" className="font-medium">
+        {title}
+      </Text>
+      <button
+        id={id}
+        type="button"
+        className="w-full cursor-pointer break-all rounded-lg bg-gray-900 p-3 text-left font-mono text-xs text-gray-100 transition-opacity hover:opacity-90"
+        onClick={handleCopy}
+        title={tooltip}
+        aria-label={`Copy ${title} code`}
+      >
+        {code}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/css-generator/components/Control.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/Control.tsx
@@ -1,0 +1,34 @@
+import { Text } from '@components/basic/Text';
+
+interface ControlProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (val: number) => void;
+  id: string;
+}
+
+export function Control({ label, value, min, max, onChange, id }: ControlProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between">
+        <Text asChild variant="c1" color="basic-5" className="font-medium">
+          <label htmlFor={id}>{label}</label>
+        </Text>
+        <Text variant="c1" color="basic-1" className="font-normal">
+          {value}px
+        </Text>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(event) => onChange(Number.parseInt(event.target.value, 10))}
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 dark:bg-gray-700"
+      />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
@@ -1,152 +1,94 @@
 'use client';
 
-import React, { useState, useId } from 'react';
+import React, { useId, useMemo, useState } from 'react';
 import { Input } from '@components/basic/Input';
+import { Text } from '@components/basic/Text';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
+import { CodeBlock } from './CodeBlock';
+import { Control } from './Control';
+import { GeneratorTabs } from './GeneratorTabs';
+import { GradientDirectionSelect } from './GradientDirectionSelect';
+import {
+  buildGradientCss,
+  buildGradientTailwind,
+  buildShadowCss,
+  buildShadowTailwind,
+} from './generatorUtils';
+import { GeneratorTab, GradientState, ShadowState } from './types';
 
 interface CssGeneratorProps {
   lng: Language;
 }
 
-function Control({
-  label,
-  value,
-  min,
-  max,
-  onChange,
-  id,
-}: {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  onChange: (val: number) => void;
-  id: string;
-}) {
-  return (
-    <div className="space-y-1">
-      <div className="flex justify-between">
-        <label htmlFor={id} className="text-xs font-medium text-gray-500">
-          {label}
-        </label>
-        <span className="text-xs text-gray-900 dark:text-gray-100">{value}px</span>
-      </div>
-      <input
-        id={id}
-        type="range"
-        min={min}
-        max={max}
-        value={value}
-        onChange={(e) => onChange(parseInt(e.target.value, 10))}
-        className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
-      />
-    </div>
-  );
-}
+const INITIAL_SHADOW: ShadowState = {
+  x: 0,
+  y: 4,
+  blur: 6,
+  spread: -1,
+  color: '#000000',
+  opacity: 0.1,
+};
 
-function CodeBlock({
-  title,
-  code,
-  id,
-  tooltip,
-}: {
-  title: string;
-  code: string;
-  id: string;
-  tooltip: string;
-}) {
-  return (
-    <div className="space-y-1">
-      <span className="text-xs font-medium text-gray-500">{title}</span>
-      <button
-        id={id}
-        type="button"
-        className="w-full text-left p-3 bg-gray-900 text-gray-100 rounded-lg text-xs font-mono break-all cursor-pointer hover:opacity-90 transition-opacity"
-        onClick={() => navigator.clipboard.writeText(code)}
-        title={tooltip}
-        aria-label={`Copy ${title} code`}
-      >
-        {code}
-      </button>
-    </div>
-  );
-}
+const INITIAL_GRADIENT: GradientState = {
+  direction: 'to right',
+  from: '#3b82f6',
+  to: '#ef4444',
+};
 
 export default function CssGenerator({ lng }: CssGeneratorProps) {
   const { t } = useTranslation(lng, 'css-generator');
-  const [activeTab, setActiveTab] = useState<'shadow' | 'gradient'>('shadow');
   const baseId = useId();
+  const [activeTab, setActiveTab] = useState<GeneratorTab>('shadow');
+  const [shadow, setShadow] = useState<ShadowState>(INITIAL_SHADOW);
+  const [gradient, setGradient] = useState<GradientState>(INITIAL_GRADIENT);
 
-  // Shadow State
-  const [shadow, setShadow] = useState({
-    x: 0,
-    y: 4,
-    blur: 6,
-    spread: -1,
-    color: '#000000',
-    opacity: 0.1,
-  });
+  const shadowCss = useMemo(() => buildShadowCss(shadow), [shadow]);
+  const shadowTailwind = useMemo(() => buildShadowTailwind(shadow), [shadow]);
+  const gradientCss = useMemo(() => buildGradientCss(gradient), [gradient]);
+  const gradientTailwind = useMemo(() => buildGradientTailwind(gradient), [gradient]);
 
-  // Gradient State
-  const [gradient, setGradient] = useState({
-    type: 'linear',
-    direction: 'to right',
-    from: '#3b82f6', // blue-500
-    to: '#ef4444', // red-500
-  });
+  const gradientDirectionOptions = useMemo(
+    () => [
+      { value: 'to right', label: t('gradient.toRight') },
+      { value: 'to left', label: t('gradient.toLeft') },
+      { value: 'to bottom', label: t('gradient.toBottom') },
+      { value: 'to top', label: t('gradient.toTop') },
+      { value: 'to bottom right', label: t('gradient.toBottomRight') },
+      { value: 'to top right', label: t('gradient.toTopRight') },
+    ],
+    [t],
+  );
 
-  // Shadow Logic
-  const shadowColorHexToRgba = (hex: string, alpha: number) => {
-    const r = parseInt(hex.slice(1, 3), 16);
-    const g = parseInt(hex.slice(3, 5), 16);
-    const b = parseInt(hex.slice(5, 7), 16);
-    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  const updateShadow = <K extends keyof ShadowState>(key: K, value: ShadowState[K]) => {
+    setShadow((prev) => ({ ...prev, [key]: value }));
   };
 
-  const shadowCss = `${shadow.x}px ${shadow.y}px ${shadow.blur}px ${
-    shadow.spread
-  }px ${shadowColorHexToRgba(shadow.color, shadow.opacity)}`;
-  const shadowTailwind = `shadow-[${shadow.x}px_${shadow.y}px_${shadow.blur}px_${
-    shadow.spread
-  }px_${shadowColorHexToRgba(shadow.color, shadow.opacity).replace(/ /g, '')}]`;
+  const updateGradient = <K extends keyof GradientState>(key: K, value: GradientState[K]) => {
+    setGradient((prev) => ({ ...prev, [key]: value }));
+  };
 
-  // Gradient Logic
-  const gradientCssValid = `linear-gradient(${gradient.direction}, ${gradient.from}, ${gradient.to})`;
-  const gradientTailwind = `bg-[linear-gradient(${gradient.direction.replace(' ', '_')},${
-    gradient.from
-  },${gradient.to})]`;
+  const handleOpacityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextOpacity = Number.parseFloat(event.target.value);
+
+    if (Number.isNaN(nextOpacity)) {
+      return;
+    }
+
+    updateShadow('opacity', nextOpacity);
+  };
 
   return (
-    <div className="w-full max-w-4xl mx-auto space-y-8">
-      {/* Tabs */}
-      <div className="flex border-b border-gray-200 dark:border-gray-700">
-        <button
-          type="button"
-          className={`px-4 py-2 text-sm font-medium ${
-            activeTab === 'shadow'
-              ? 'border-b-2 border-point-1 text-point-1'
-              : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-          }`}
-          onClick={() => setActiveTab('shadow')}
-        >
-          {t('tab.shadow')}
-        </button>
-        <button
-          type="button"
-          className={`px-4 py-2 text-sm font-medium ${
-            activeTab === 'gradient'
-              ? 'border-b-2 border-point-1 text-point-1'
-              : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
-          }`}
-          onClick={() => setActiveTab('gradient')}
-        >
-          {t('tab.gradient')}
-        </button>
-      </div>
+    <div className="mx-auto w-full max-w-4xl space-y-8">
+      <GeneratorTabs
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        shadowLabel={t('tab.shadow')}
+        gradientLabel={t('tab.gradient')}
+      />
 
       {activeTab === 'shadow' && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
           <div className="space-y-6">
             <div className="space-y-4">
               <Control
@@ -155,7 +97,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                 value={shadow.x}
                 min={-100}
                 max={100}
-                onChange={(v) => setShadow({ ...shadow, x: v })}
+                onChange={(value) => updateShadow('x', value)}
               />
               <Control
                 id={`${baseId}-shadow-y`}
@@ -163,7 +105,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                 value={shadow.y}
                 min={-100}
                 max={100}
-                onChange={(v) => setShadow({ ...shadow, y: v })}
+                onChange={(value) => updateShadow('y', value)}
               />
               <Control
                 id={`${baseId}-shadow-blur`}
@@ -171,7 +113,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                 value={shadow.blur}
                 min={0}
                 max={100}
-                onChange={(v) => setShadow({ ...shadow, blur: v })}
+                onChange={(value) => updateShadow('blur', value)}
               />
               <Control
                 id={`${baseId}-shadow-spread`}
@@ -179,22 +121,19 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                 value={shadow.spread}
                 min={-100}
                 max={100}
-                onChange={(v) => setShadow({ ...shadow, spread: v })}
+                onChange={(value) => updateShadow('spread', value)}
               />
               <div className="space-y-1">
-                <label
-                  htmlFor={`${baseId}-shadow-color`}
-                  className="text-xs font-medium text-gray-500 block"
-                >
-                  {t('shadow.color')}
-                </label>
+                <Text asChild variant="c1" color="basic-5" className="block font-medium">
+                  <label htmlFor={`${baseId}-shadow-color`}>{t('shadow.color')}</label>
+                </Text>
                 <div className="flex items-center gap-2">
                   <input
                     id={`${baseId}-shadow-color`}
                     type="color"
                     title={t('shadow.color')}
                     value={shadow.color}
-                    onChange={(e) => setShadow({ ...shadow, color: e.target.value })}
+                    onChange={(event) => updateShadow('color', event.target.value)}
                     className="h-8 w-8 rounded cursor-pointer"
                   />
                   <Input
@@ -203,16 +142,13 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                     min={0}
                     max={1}
                     step={0.01}
-                    onChange={(e) =>
-                      setShadow({
-                        ...shadow,
-                        opacity: parseFloat(e.target.value),
-                      })
-                    }
+                    onChange={handleOpacityChange}
                     className="w-20"
                     aria-label={t('shadow.opacity')}
                   />
-                  <span className="text-sm text-gray-500">{t('shadow.opacity')}</span>
+                  <Text variant="d3" color="basic-5">
+                    {t('shadow.opacity')}
+                  </Text>
                 </div>
               </div>
             </div>
@@ -242,72 +178,52 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
       )}
 
       {activeTab === 'gradient' && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
           <div className="space-y-6">
             <div className="space-y-4">
+              <GradientDirectionSelect
+                id={`${baseId}-gradient-direction`}
+                label={t('gradient.direction')}
+                value={gradient.direction}
+                options={gradientDirectionOptions}
+                onChange={(value) => updateGradient('direction', value)}
+              />
               <div className="space-y-1">
-                <label
-                  htmlFor={`${baseId}-gradient-direction`}
-                  className="text-xs font-medium text-gray-500 block"
-                >
-                  {t('gradient.direction')}
-                </label>
-                <select
-                  id={`${baseId}-gradient-direction`}
-                  className="w-full p-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
-                  value={gradient.direction}
-                  onChange={(e) => setGradient({ ...gradient, direction: e.target.value })}
-                >
-                  <option value="to right">{t('gradient.toRight')}</option>
-                  <option value="to left">{t('gradient.toLeft')}</option>
-                  <option value="to bottom">{t('gradient.toBottom')}</option>
-                  <option value="to top">{t('gradient.toTop')}</option>
-                  <option value="to bottom right">{t('gradient.toBottomRight')}</option>
-                  <option value="to top right">{t('gradient.toTopRight')}</option>
-                </select>
-              </div>
-              <div className="space-y-1">
-                <label
-                  htmlFor={`${baseId}-gradient-from`}
-                  className="text-xs font-medium text-gray-500 block"
-                >
-                  {t('gradient.from')}
-                </label>
+                <Text asChild variant="c1" color="basic-5" className="block font-medium">
+                  <label htmlFor={`${baseId}-gradient-from`}>{t('gradient.from')}</label>
+                </Text>
                 <div className="flex items-center gap-2">
                   <input
                     id={`${baseId}-gradient-from`}
                     type="color"
                     title={t('gradient.from')}
                     value={gradient.from}
-                    onChange={(e) => setGradient({ ...gradient, from: e.target.value })}
+                    onChange={(event) => updateGradient('from', event.target.value)}
                     className="h-8 w-8 rounded cursor-pointer"
                   />
                   <Input
                     value={gradient.from}
-                    onChange={(e) => setGradient({ ...gradient, from: e.target.value })}
+                    onChange={(event) => updateGradient('from', event.target.value)}
                     aria-label={t('gradient.from')}
                   />
                 </div>
               </div>
               <div className="space-y-1">
-                <label
-                  htmlFor={`${baseId}-gradient-to`}
-                  className="text-xs font-medium text-gray-500 block"
-                >
-                  {t('gradient.to')}
-                </label>
+                <Text asChild variant="c1" color="basic-5" className="block font-medium">
+                  <label htmlFor={`${baseId}-gradient-to`}>{t('gradient.to')}</label>
+                </Text>
                 <div className="flex items-center gap-2">
                   <input
                     id={`${baseId}-gradient-to`}
                     type="color"
                     title={t('gradient.to')}
                     value={gradient.to}
-                    onChange={(e) => setGradient({ ...gradient, to: e.target.value })}
+                    onChange={(event) => updateGradient('to', event.target.value)}
                     className="h-8 w-8 rounded cursor-pointer"
                   />
                   <Input
                     value={gradient.to}
-                    onChange={(e) => setGradient({ ...gradient, to: e.target.value })}
+                    onChange={(event) => updateGradient('to', event.target.value)}
                     aria-label={t('gradient.to')}
                   />
                 </div>
@@ -317,12 +233,12 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
 
           <div className="space-y-6">
             <div className="flex items-center justify-center h-64 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-              <div className="w-48 h-48 rounded-lg" style={{ background: gradientCssValid }} />
+              <div className="w-48 h-48 rounded-lg" style={{ background: gradientCss }} />
             </div>
             <CodeBlock
               id={`${baseId}-code-grad-css`}
               title={t('code.css')}
-              code={`background: ${gradientCssValid};`}
+              code={`background: ${gradientCss};`}
               tooltip={t('code.copy')}
             />
             <CodeBlock

--- a/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
@@ -10,12 +10,25 @@ import { Control } from './Control';
 import { GeneratorTabs } from './GeneratorTabs';
 import { GradientDirectionSelect } from './GradientDirectionSelect';
 import {
+  buildFlexCss,
+  buildFlexTailwind,
   buildGradientCss,
   buildGradientTailwind,
+  buildGridCss,
+  buildGridTailwind,
+  buildRadiusCss,
+  buildRadiusTailwind,
   buildShadowCss,
   buildShadowTailwind,
 } from './generatorUtils';
-import { GeneratorTab, GradientState, ShadowState } from './types';
+import {
+  FlexState,
+  GeneratorTab,
+  GradientState,
+  GridState,
+  RadiusState,
+  ShadowState,
+} from './types';
 
 interface CssGeneratorProps {
   lng: Language;
@@ -36,17 +49,56 @@ const INITIAL_GRADIENT: GradientState = {
   to: '#ef4444',
 };
 
+const INITIAL_RADIUS: RadiusState = {
+  topLeft: 16,
+  topRight: 16,
+  bottomRight: 16,
+  bottomLeft: 16,
+};
+
+const INITIAL_FLEX: FlexState = {
+  direction: 'row',
+  wrap: 'nowrap',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: 12,
+};
+
+const INITIAL_GRID: GridState = {
+  columns: 3,
+  rows: 2,
+  justifyItems: 'center',
+  alignItems: 'center',
+  gap: 12,
+};
+
+const FLEX_PREVIEW_ITEMS = [1, 2, 3, 4, 5];
+
 export default function CssGenerator({ lng }: CssGeneratorProps) {
   const { t } = useTranslation(lng, 'css-generator');
   const baseId = useId();
   const [activeTab, setActiveTab] = useState<GeneratorTab>('shadow');
   const [shadow, setShadow] = useState<ShadowState>(INITIAL_SHADOW);
   const [gradient, setGradient] = useState<GradientState>(INITIAL_GRADIENT);
+  const [radius, setRadius] = useState<RadiusState>(INITIAL_RADIUS);
+  const [flex, setFlex] = useState<FlexState>(INITIAL_FLEX);
+  const [grid, setGrid] = useState<GridState>(INITIAL_GRID);
 
   const shadowCss = useMemo(() => buildShadowCss(shadow), [shadow]);
   const shadowTailwind = useMemo(() => buildShadowTailwind(shadow), [shadow]);
   const gradientCss = useMemo(() => buildGradientCss(gradient), [gradient]);
   const gradientTailwind = useMemo(() => buildGradientTailwind(gradient), [gradient]);
+  const radiusCss = useMemo(() => buildRadiusCss(radius), [radius]);
+  const radiusTailwind = useMemo(() => buildRadiusTailwind(radius), [radius]);
+  const flexCss = useMemo(() => buildFlexCss(flex), [flex]);
+  const flexTailwind = useMemo(() => buildFlexTailwind(flex), [flex]);
+  const gridCss = useMemo(() => buildGridCss(grid), [grid]);
+  const gridTailwind = useMemo(() => buildGridTailwind(grid), [grid]);
+
+  const gridPreviewItemCount = useMemo(
+    () => Math.max(1, Math.min(24, grid.columns * grid.rows)),
+    [grid.columns, grid.rows],
+  );
 
   const gradientDirectionOptions = useMemo(
     () => [
@@ -60,12 +112,75 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
     [t],
   );
 
+  const flexDirectionOptions = useMemo(
+    () => [
+      { value: 'row', label: t('flex.row') },
+      { value: 'row-reverse', label: t('flex.rowReverse') },
+      { value: 'column', label: t('flex.column') },
+      { value: 'column-reverse', label: t('flex.columnReverse') },
+    ],
+    [t],
+  );
+
+  const flexWrapOptions = useMemo(
+    () => [
+      { value: 'nowrap', label: t('flex.noWrap') },
+      { value: 'wrap', label: t('flex.wrap') },
+    ],
+    [t],
+  );
+
+  const flexJustifyOptions = useMemo(
+    () => [
+      { value: 'flex-start', label: t('flex.justifyStart') },
+      { value: 'center', label: t('flex.justifyCenter') },
+      { value: 'flex-end', label: t('flex.justifyEnd') },
+      { value: 'space-between', label: t('flex.justifyBetween') },
+      { value: 'space-around', label: t('flex.justifyAround') },
+      { value: 'space-evenly', label: t('flex.justifyEvenly') },
+    ],
+    [t],
+  );
+
+  const flexAlignOptions = useMemo(
+    () => [
+      { value: 'stretch', label: t('flex.alignStretch') },
+      { value: 'flex-start', label: t('flex.alignStart') },
+      { value: 'center', label: t('flex.alignCenter') },
+      { value: 'flex-end', label: t('flex.alignEnd') },
+      { value: 'baseline', label: t('flex.alignBaseline') },
+    ],
+    [t],
+  );
+
+  const gridAlignOptions = useMemo(
+    () => [
+      { value: 'stretch', label: t('grid.stretch') },
+      { value: 'start', label: t('grid.start') },
+      { value: 'center', label: t('grid.center') },
+      { value: 'end', label: t('grid.end') },
+    ],
+    [t],
+  );
+
   const updateShadow = <K extends keyof ShadowState>(key: K, value: ShadowState[K]) => {
     setShadow((prev) => ({ ...prev, [key]: value }));
   };
 
   const updateGradient = <K extends keyof GradientState>(key: K, value: GradientState[K]) => {
     setGradient((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const updateRadius = <K extends keyof RadiusState>(key: K, value: RadiusState[K]) => {
+    setRadius((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const updateFlex = <K extends keyof FlexState>(key: K, value: FlexState[K]) => {
+    setFlex((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const updateGrid = <K extends keyof GridState>(key: K, value: GridState[K]) => {
+    setGrid((prev) => ({ ...prev, [key]: value }));
   };
 
   const handleOpacityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -85,6 +200,9 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
         onTabChange={setActiveTab}
         shadowLabel={t('tab.shadow')}
         gradientLabel={t('tab.gradient')}
+        radiusLabel={t('tab.radius')}
+        flexLabel={t('tab.flex')}
+        gridLabel={t('tab.grid')}
       />
 
       {activeTab === 'shadow' && (
@@ -134,7 +252,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                     title={t('shadow.color')}
                     value={shadow.color}
                     onChange={(event) => updateShadow('color', event.target.value)}
-                    className="h-8 w-8 rounded cursor-pointer"
+                    className="h-8 w-8 cursor-pointer rounded"
                   />
                   <Input
                     type="number"
@@ -155,9 +273,9 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
           </div>
 
           <div className="space-y-6">
-            <div className="flex items-center justify-center h-64 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="flex h-64 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
               <div
-                className="w-32 h-32 bg-white dark:bg-gray-700 rounded-lg"
+                className="h-32 w-32 rounded-lg bg-white dark:bg-gray-700"
                 style={{ boxShadow: shadowCss }}
               />
             </div>
@@ -199,7 +317,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                     title={t('gradient.from')}
                     value={gradient.from}
                     onChange={(event) => updateGradient('from', event.target.value)}
-                    className="h-8 w-8 rounded cursor-pointer"
+                    className="h-8 w-8 cursor-pointer rounded"
                   />
                   <Input
                     value={gradient.from}
@@ -219,7 +337,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
                     title={t('gradient.to')}
                     value={gradient.to}
                     onChange={(event) => updateGradient('to', event.target.value)}
-                    className="h-8 w-8 rounded cursor-pointer"
+                    className="h-8 w-8 cursor-pointer rounded"
                   />
                   <Input
                     value={gradient.to}
@@ -232,8 +350,8 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
           </div>
 
           <div className="space-y-6">
-            <div className="flex items-center justify-center h-64 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-              <div className="w-48 h-48 rounded-lg" style={{ background: gradientCss }} />
+            <div className="flex h-64 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
+              <div className="h-48 w-48 rounded-lg" style={{ background: gradientCss }} />
             </div>
             <CodeBlock
               id={`${baseId}-code-grad-css`}
@@ -245,6 +363,244 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
               id={`${baseId}-code-grad-tw`}
               title={`${t('code.tailwind')} (Arbitrary)`}
               code={gradientTailwind}
+              tooltip={t('code.copy')}
+            />
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'radius' && (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <Control
+                id={`${baseId}-radius-top-left`}
+                label={t('radius.topLeft')}
+                value={radius.topLeft}
+                min={0}
+                max={200}
+                onChange={(value) => updateRadius('topLeft', value)}
+              />
+              <Control
+                id={`${baseId}-radius-top-right`}
+                label={t('radius.topRight')}
+                value={radius.topRight}
+                min={0}
+                max={200}
+                onChange={(value) => updateRadius('topRight', value)}
+              />
+              <Control
+                id={`${baseId}-radius-bottom-right`}
+                label={t('radius.bottomRight')}
+                value={radius.bottomRight}
+                min={0}
+                max={200}
+                onChange={(value) => updateRadius('bottomRight', value)}
+              />
+              <Control
+                id={`${baseId}-radius-bottom-left`}
+                label={t('radius.bottomLeft')}
+                value={radius.bottomLeft}
+                min={0}
+                max={200}
+                onChange={(value) => updateRadius('bottomLeft', value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="flex h-64 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
+              <div
+                className="h-40 w-40 border-2 border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700"
+                style={{ borderRadius: radiusCss }}
+              />
+            </div>
+            <CodeBlock
+              id={`${baseId}-code-radius-css`}
+              title={t('code.css')}
+              code={`border-radius: ${radiusCss};`}
+              tooltip={t('code.copy')}
+            />
+            <CodeBlock
+              id={`${baseId}-code-radius-tailwind`}
+              title={`${t('code.tailwind')} (Arbitrary)`}
+              code={radiusTailwind}
+              tooltip={t('code.copy')}
+            />
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'flex' && (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <GradientDirectionSelect
+                id={`${baseId}-flex-direction`}
+                label={t('flex.direction')}
+                value={flex.direction}
+                options={flexDirectionOptions}
+                onChange={(value) => updateFlex('direction', value as FlexState['direction'])}
+              />
+              <GradientDirectionSelect
+                id={`${baseId}-flex-wrap`}
+                label={t('flex.wrapMode')}
+                value={flex.wrap}
+                options={flexWrapOptions}
+                onChange={(value) => updateFlex('wrap', value as FlexState['wrap'])}
+              />
+              <GradientDirectionSelect
+                id={`${baseId}-flex-justify`}
+                label={t('flex.justifyContent')}
+                value={flex.justifyContent}
+                options={flexJustifyOptions}
+                onChange={(value) =>
+                  updateFlex('justifyContent', value as FlexState['justifyContent'])
+                }
+              />
+              <GradientDirectionSelect
+                id={`${baseId}-flex-align`}
+                label={t('flex.alignItems')}
+                value={flex.alignItems}
+                options={flexAlignOptions}
+                onChange={(value) => updateFlex('alignItems', value as FlexState['alignItems'])}
+              />
+              <Control
+                id={`${baseId}-flex-gap`}
+                label={t('flex.gap')}
+                value={flex.gap}
+                min={0}
+                max={48}
+                onChange={(value) => updateFlex('gap', value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
+              <div
+                className="h-56 rounded-lg border border-dashed border-gray-300 bg-white/80 p-2 dark:border-gray-600 dark:bg-gray-700/70"
+                style={{
+                  display: 'flex',
+                  flexDirection: flex.direction,
+                  flexWrap: flex.wrap,
+                  justifyContent: flex.justifyContent,
+                  alignItems: flex.alignItems,
+                  gap: `${flex.gap}px`,
+                }}
+              >
+                {FLEX_PREVIEW_ITEMS.map((item) => (
+                  <div
+                    key={item}
+                    className="flex min-w-10 items-center justify-center rounded-md border border-point-1/40 bg-point-1/10 px-3 py-2 text-xs font-semibold text-point-1"
+                  >
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <CodeBlock
+              id={`${baseId}-code-flex-css`}
+              title={t('code.css')}
+              code={flexCss}
+              tooltip={t('code.copy')}
+            />
+            <CodeBlock
+              id={`${baseId}-code-flex-tailwind`}
+              title={`${t('code.tailwind')} (Arbitrary)`}
+              code={flexTailwind}
+              tooltip={t('code.copy')}
+            />
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'grid' && (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <Control
+                id={`${baseId}-grid-columns`}
+                label={t('grid.columns')}
+                value={grid.columns}
+                min={1}
+                max={6}
+                onChange={(value) => updateGrid('columns', value)}
+              />
+              <Control
+                id={`${baseId}-grid-rows`}
+                label={t('grid.rows')}
+                value={grid.rows}
+                min={1}
+                max={6}
+                onChange={(value) => updateGrid('rows', value)}
+              />
+              <GradientDirectionSelect
+                id={`${baseId}-grid-justify-items`}
+                label={t('grid.justifyItems')}
+                value={grid.justifyItems}
+                options={gridAlignOptions}
+                onChange={(value) => updateGrid('justifyItems', value as GridState['justifyItems'])}
+              />
+              <GradientDirectionSelect
+                id={`${baseId}-grid-align-items`}
+                label={t('grid.alignItems')}
+                value={grid.alignItems}
+                options={gridAlignOptions}
+                onChange={(value) => updateGrid('alignItems', value as GridState['alignItems'])}
+              />
+              <Control
+                id={`${baseId}-grid-gap`}
+                label={t('grid.gap')}
+                value={grid.gap}
+                min={0}
+                max={48}
+                onChange={(value) => updateGrid('gap', value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
+              <div
+                className="h-56 rounded-lg border border-dashed border-gray-300 bg-white/80 p-2 dark:border-gray-600 dark:bg-gray-700/70"
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: `repeat(${grid.columns}, minmax(0, 1fr))`,
+                  gridTemplateRows: `repeat(${grid.rows}, minmax(0, 1fr))`,
+                  justifyItems: grid.justifyItems,
+                  alignItems: grid.alignItems,
+                  gap: `${grid.gap}px`,
+                }}
+              >
+                {Array.from({ length: gridPreviewItemCount }, (_, index) => index + 1).map(
+                  (item) => (
+                    <div
+                      key={item}
+                      className="flex rounded-md border border-point-1/40 bg-point-1/10 text-xs font-semibold text-point-1"
+                      style={{
+                        width: grid.justifyItems === 'stretch' ? '100%' : '2.5rem',
+                        height: grid.alignItems === 'stretch' ? '100%' : '2.5rem',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      {item}
+                    </div>
+                  ),
+                )}
+              </div>
+            </div>
+            <CodeBlock
+              id={`${baseId}-code-grid-css`}
+              title={t('code.css')}
+              code={gridCss}
+              tooltip={t('code.copy')}
+            />
+            <CodeBlock
+              id={`${baseId}-code-grid-tailwind`}
+              title={`${t('code.tailwind')} (Arbitrary)`}
+              code={gridTailwind}
               tooltip={t('code.copy')}
             />
           </div>

--- a/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
@@ -1,0 +1,339 @@
+'use client';
+
+import React, { useState, useId } from 'react';
+import { Input } from '@components/basic/Input';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+
+interface CssGeneratorProps {
+  lng: Language;
+}
+
+function Control({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+  id,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (val: number) => void;
+  id: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between">
+        <label htmlFor={id} className="text-xs font-medium text-gray-500">
+          {label}
+        </label>
+        <span className="text-xs text-gray-900 dark:text-gray-100">{value}px</span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(parseInt(e.target.value, 10))}
+        className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+      />
+    </div>
+  );
+}
+
+function CodeBlock({
+  title,
+  code,
+  id,
+  tooltip,
+}: {
+  title: string;
+  code: string;
+  id: string;
+  tooltip: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <span className="text-xs font-medium text-gray-500">{title}</span>
+      <button
+        id={id}
+        type="button"
+        className="w-full text-left p-3 bg-gray-900 text-gray-100 rounded-lg text-xs font-mono break-all cursor-pointer hover:opacity-90 transition-opacity"
+        onClick={() => navigator.clipboard.writeText(code)}
+        title={tooltip}
+        aria-label={`Copy ${title} code`}
+      >
+        {code}
+      </button>
+    </div>
+  );
+}
+
+export default function CssGenerator({ lng }: CssGeneratorProps) {
+  const { t } = useTranslation(lng, 'css-generator');
+  const [activeTab, setActiveTab] = useState<'shadow' | 'gradient'>('shadow');
+  const baseId = useId();
+
+  // Shadow State
+  const [shadow, setShadow] = useState({
+    x: 0,
+    y: 4,
+    blur: 6,
+    spread: -1,
+    color: '#000000',
+    opacity: 0.1,
+  });
+
+  // Gradient State
+  const [gradient, setGradient] = useState({
+    type: 'linear',
+    direction: 'to right',
+    from: '#3b82f6', // blue-500
+    to: '#ef4444', // red-500
+  });
+
+  // Shadow Logic
+  const shadowColorHexToRgba = (hex: string, alpha: number) => {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  };
+
+  const shadowCss = `${shadow.x}px ${shadow.y}px ${shadow.blur}px ${
+    shadow.spread
+  }px ${shadowColorHexToRgba(shadow.color, shadow.opacity)}`;
+  const shadowTailwind = `shadow-[${shadow.x}px_${shadow.y}px_${shadow.blur}px_${
+    shadow.spread
+  }px_${shadowColorHexToRgba(shadow.color, shadow.opacity).replace(/ /g, '')}]`;
+
+  // Gradient Logic
+  const gradientCssValid = `linear-gradient(${gradient.direction}, ${gradient.from}, ${gradient.to})`;
+  const gradientTailwind = `bg-[linear-gradient(${gradient.direction.replace(' ', '_')},${
+    gradient.from
+  },${gradient.to})]`;
+
+  return (
+    <div className="w-full max-w-4xl mx-auto space-y-8">
+      {/* Tabs */}
+      <div className="flex border-b border-gray-200 dark:border-gray-700">
+        <button
+          type="button"
+          className={`px-4 py-2 text-sm font-medium ${
+            activeTab === 'shadow'
+              ? 'border-b-2 border-point-1 text-point-1'
+              : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+          }`}
+          onClick={() => setActiveTab('shadow')}
+        >
+          {t('tab.shadow')}
+        </button>
+        <button
+          type="button"
+          className={`px-4 py-2 text-sm font-medium ${
+            activeTab === 'gradient'
+              ? 'border-b-2 border-point-1 text-point-1'
+              : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+          }`}
+          onClick={() => setActiveTab('gradient')}
+        >
+          {t('tab.gradient')}
+        </button>
+      </div>
+
+      {activeTab === 'shadow' && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <Control
+                id={`${baseId}-shadow-x`}
+                label={t('shadow.offsetX')}
+                value={shadow.x}
+                min={-100}
+                max={100}
+                onChange={(v) => setShadow({ ...shadow, x: v })}
+              />
+              <Control
+                id={`${baseId}-shadow-y`}
+                label={t('shadow.offsetY')}
+                value={shadow.y}
+                min={-100}
+                max={100}
+                onChange={(v) => setShadow({ ...shadow, y: v })}
+              />
+              <Control
+                id={`${baseId}-shadow-blur`}
+                label={t('shadow.blur')}
+                value={shadow.blur}
+                min={0}
+                max={100}
+                onChange={(v) => setShadow({ ...shadow, blur: v })}
+              />
+              <Control
+                id={`${baseId}-shadow-spread`}
+                label={t('shadow.spread')}
+                value={shadow.spread}
+                min={-100}
+                max={100}
+                onChange={(v) => setShadow({ ...shadow, spread: v })}
+              />
+              <div className="space-y-1">
+                <label
+                  htmlFor={`${baseId}-shadow-color`}
+                  className="text-xs font-medium text-gray-500 block"
+                >
+                  {t('shadow.color')}
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`${baseId}-shadow-color`}
+                    type="color"
+                    title={t('shadow.color')}
+                    value={shadow.color}
+                    onChange={(e) => setShadow({ ...shadow, color: e.target.value })}
+                    className="h-8 w-8 rounded cursor-pointer"
+                  />
+                  <Input
+                    type="number"
+                    value={shadow.opacity}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    onChange={(e) =>
+                      setShadow({
+                        ...shadow,
+                        opacity: parseFloat(e.target.value),
+                      })
+                    }
+                    className="w-20"
+                    aria-label={t('shadow.opacity')}
+                  />
+                  <span className="text-sm text-gray-500">{t('shadow.opacity')}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="flex items-center justify-center h-64 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div
+                className="w-32 h-32 bg-white dark:bg-gray-700 rounded-lg"
+                style={{ boxShadow: shadowCss }}
+              />
+            </div>
+            <CodeBlock
+              id={`${baseId}-code-css`}
+              title={t('code.css')}
+              code={`box-shadow: ${shadowCss};`}
+              tooltip={t('code.copy')}
+            />
+            <CodeBlock
+              id={`${baseId}-code-tailwind`}
+              title={t('code.tailwind')}
+              code={shadowTailwind}
+              tooltip={t('code.copy')}
+            />
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'gradient' && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <label
+                  htmlFor={`${baseId}-gradient-direction`}
+                  className="text-xs font-medium text-gray-500 block"
+                >
+                  {t('gradient.direction')}
+                </label>
+                <select
+                  id={`${baseId}-gradient-direction`}
+                  className="w-full p-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+                  value={gradient.direction}
+                  onChange={(e) => setGradient({ ...gradient, direction: e.target.value })}
+                >
+                  <option value="to right">{t('gradient.toRight')}</option>
+                  <option value="to left">{t('gradient.toLeft')}</option>
+                  <option value="to bottom">{t('gradient.toBottom')}</option>
+                  <option value="to top">{t('gradient.toTop')}</option>
+                  <option value="to bottom right">{t('gradient.toBottomRight')}</option>
+                  <option value="to top right">{t('gradient.toTopRight')}</option>
+                </select>
+              </div>
+              <div className="space-y-1">
+                <label
+                  htmlFor={`${baseId}-gradient-from`}
+                  className="text-xs font-medium text-gray-500 block"
+                >
+                  {t('gradient.from')}
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`${baseId}-gradient-from`}
+                    type="color"
+                    title={t('gradient.from')}
+                    value={gradient.from}
+                    onChange={(e) => setGradient({ ...gradient, from: e.target.value })}
+                    className="h-8 w-8 rounded cursor-pointer"
+                  />
+                  <Input
+                    value={gradient.from}
+                    onChange={(e) => setGradient({ ...gradient, from: e.target.value })}
+                    aria-label={t('gradient.from')}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <label
+                  htmlFor={`${baseId}-gradient-to`}
+                  className="text-xs font-medium text-gray-500 block"
+                >
+                  {t('gradient.to')}
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`${baseId}-gradient-to`}
+                    type="color"
+                    title={t('gradient.to')}
+                    value={gradient.to}
+                    onChange={(e) => setGradient({ ...gradient, to: e.target.value })}
+                    className="h-8 w-8 rounded cursor-pointer"
+                  />
+                  <Input
+                    value={gradient.to}
+                    onChange={(e) => setGradient({ ...gradient, to: e.target.value })}
+                    aria-label={t('gradient.to')}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="flex items-center justify-center h-64 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div className="w-48 h-48 rounded-lg" style={{ background: gradientCssValid }} />
+            </div>
+            <CodeBlock
+              id={`${baseId}-code-grad-css`}
+              title={t('code.css')}
+              code={`background: ${gradientCssValid};`}
+              tooltip={t('code.copy')}
+            />
+            <CodeBlock
+              id={`${baseId}-code-grad-tw`}
+              title={`${t('code.tailwind')} (Arbitrary)`}
+              code={gradientTailwind}
+              tooltip={t('code.copy')}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/css-generator/components/GeneratorTabs.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/GeneratorTabs.tsx
@@ -1,0 +1,51 @@
+import { Text } from '@components/basic/Text';
+import { cn } from '@utils/cn';
+import { GeneratorTab } from './types';
+
+interface GeneratorTabsProps {
+  activeTab: GeneratorTab;
+  onTabChange: (tab: GeneratorTab) => void;
+  shadowLabel: string;
+  gradientLabel: string;
+}
+
+export function GeneratorTabs({
+  activeTab,
+  onTabChange,
+  shadowLabel,
+  gradientLabel,
+}: GeneratorTabsProps) {
+  const tabs: Array<{ key: GeneratorTab; label: string }> = [
+    { key: 'shadow', label: shadowLabel },
+    { key: 'gradient', label: gradientLabel },
+  ];
+
+  return (
+    <div className="flex border-b border-gray-200 dark:border-gray-700">
+      {tabs.map((tab) => {
+        const isActive = tab.key === activeTab;
+
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            className={cn('px-4 py-2', isActive && 'border-b-2 border-point-1')}
+            onClick={() => onTabChange(tab.key)}
+          >
+            <Text
+              variant="d3"
+              className={cn(
+                'font-medium',
+                isActive
+                  ? 'text-point-1'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+              )}
+            >
+              {tab.label}
+            </Text>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/css-generator/components/GeneratorTabs.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/GeneratorTabs.tsx
@@ -7,6 +7,9 @@ interface GeneratorTabsProps {
   onTabChange: (tab: GeneratorTab) => void;
   shadowLabel: string;
   gradientLabel: string;
+  radiusLabel: string;
+  flexLabel: string;
+  gridLabel: string;
 }
 
 export function GeneratorTabs({
@@ -14,10 +17,16 @@ export function GeneratorTabs({
   onTabChange,
   shadowLabel,
   gradientLabel,
+  radiusLabel,
+  flexLabel,
+  gridLabel,
 }: GeneratorTabsProps) {
   const tabs: Array<{ key: GeneratorTab; label: string }> = [
     { key: 'shadow', label: shadowLabel },
     { key: 'gradient', label: gradientLabel },
+    { key: 'radius', label: radiusLabel },
+    { key: 'flex', label: flexLabel },
+    { key: 'grid', label: gridLabel },
   ];
 
   return (

--- a/src/app/[lng]/(mobile)/css-generator/components/GradientDirectionSelect.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/GradientDirectionSelect.tsx
@@ -1,0 +1,49 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/basic/Select';
+import { Text } from '@components/basic/Text';
+
+interface DirectionOption {
+  label: string;
+  value: string;
+}
+
+interface GradientDirectionSelectProps {
+  id: string;
+  label: string;
+  value: string;
+  options: DirectionOption[];
+  onChange: (value: string) => void;
+}
+
+export function GradientDirectionSelect({
+  id,
+  label,
+  value,
+  options,
+  onChange,
+}: GradientDirectionSelectProps) {
+  return (
+    <div className="space-y-1">
+      <Text asChild variant="c1" color="basic-5" className="block font-medium">
+        <label htmlFor={id}>{label}</label>
+      </Text>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id={id}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/css-generator/components/generatorUtils.ts
+++ b/src/app/[lng]/(mobile)/css-generator/components/generatorUtils.ts
@@ -1,0 +1,27 @@
+import { GradientState, ShadowState } from './types';
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+export const buildShadowCss = (shadow: ShadowState) =>
+  `${shadow.x}px ${shadow.y}px ${shadow.blur}px ${shadow.spread}px ${hexToRgba(
+    shadow.color,
+    shadow.opacity,
+  )}`;
+
+export const buildShadowTailwind = (shadow: ShadowState) =>
+  `shadow-[${shadow.x}px_${shadow.y}px_${shadow.blur}px_${shadow.spread}px_${hexToRgba(
+    shadow.color,
+    shadow.opacity,
+  ).replace(/ /g, '')}]`;
+
+export const buildGradientCss = (gradient: GradientState) =>
+  `linear-gradient(${gradient.direction}, ${gradient.from}, ${gradient.to})`;
+
+export const buildGradientTailwind = (gradient: GradientState) =>
+  `bg-[linear-gradient(${gradient.direction.replace(' ', '_')},${gradient.from},${gradient.to})]`;

--- a/src/app/[lng]/(mobile)/css-generator/components/generatorUtils.ts
+++ b/src/app/[lng]/(mobile)/css-generator/components/generatorUtils.ts
@@ -1,4 +1,4 @@
-import { GradientState, ShadowState } from './types';
+import { FlexState, GradientState, GridState, RadiusState, ShadowState } from './types';
 
 const hexToRgba = (hex: string, alpha: number) => {
   const r = Number.parseInt(hex.slice(1, 3), 16);
@@ -25,3 +25,61 @@ export const buildGradientCss = (gradient: GradientState) =>
 
 export const buildGradientTailwind = (gradient: GradientState) =>
   `bg-[linear-gradient(${gradient.direction.replace(' ', '_')},${gradient.from},${gradient.to})]`;
+
+export const buildRadiusCss = (radius: RadiusState) =>
+  `${radius.topLeft}px ${radius.topRight}px ${radius.bottomRight}px ${radius.bottomLeft}px`;
+
+export const buildRadiusTailwind = (radius: RadiusState) =>
+  `rounded-[${radius.topLeft}px_${radius.topRight}px_${radius.bottomRight}px_${radius.bottomLeft}px]`;
+
+const FLEX_DIRECTION_CLASS_MAP: Record<FlexState['direction'], string> = {
+  row: 'flex-row',
+  'row-reverse': 'flex-row-reverse',
+  column: 'flex-col',
+  'column-reverse': 'flex-col-reverse',
+};
+
+const FLEX_WRAP_CLASS_MAP: Record<FlexState['wrap'], string> = {
+  nowrap: 'flex-nowrap',
+  wrap: 'flex-wrap',
+};
+
+const FLEX_JUSTIFY_CLASS_MAP: Record<FlexState['justifyContent'], string> = {
+  'flex-start': 'justify-start',
+  center: 'justify-center',
+  'flex-end': 'justify-end',
+  'space-between': 'justify-between',
+  'space-around': 'justify-around',
+  'space-evenly': 'justify-evenly',
+};
+
+const FLEX_ALIGN_CLASS_MAP: Record<FlexState['alignItems'], string> = {
+  stretch: 'items-stretch',
+  'flex-start': 'items-start',
+  center: 'items-center',
+  'flex-end': 'items-end',
+  baseline: 'items-baseline',
+};
+
+const GRID_ALIGN_CLASS_MAP: Record<GridState['justifyItems'], string> = {
+  stretch: 'stretch',
+  start: 'start',
+  center: 'center',
+  end: 'end',
+};
+
+export const buildFlexCss = (flex: FlexState) =>
+  `display: flex; flex-direction: ${flex.direction}; flex-wrap: ${flex.wrap}; justify-content: ${flex.justifyContent}; align-items: ${flex.alignItems}; gap: ${flex.gap}px;`;
+
+export const buildFlexTailwind = (flex: FlexState) =>
+  `flex ${FLEX_DIRECTION_CLASS_MAP[flex.direction]} ${FLEX_WRAP_CLASS_MAP[flex.wrap]} ${
+    FLEX_JUSTIFY_CLASS_MAP[flex.justifyContent]
+  } ${FLEX_ALIGN_CLASS_MAP[flex.alignItems]} gap-[${flex.gap}px]`;
+
+export const buildGridCss = (grid: GridState) =>
+  `display: grid; grid-template-columns: repeat(${grid.columns}, minmax(0, 1fr)); grid-template-rows: repeat(${grid.rows}, minmax(0, 1fr)); justify-items: ${grid.justifyItems}; align-items: ${grid.alignItems}; gap: ${grid.gap}px;`;
+
+export const buildGridTailwind = (grid: GridState) =>
+  `grid grid-cols-${grid.columns} grid-rows-${grid.rows} justify-items-${
+    GRID_ALIGN_CLASS_MAP[grid.justifyItems]
+  } items-${GRID_ALIGN_CLASS_MAP[grid.alignItems]} gap-[${grid.gap}px]`;

--- a/src/app/[lng]/(mobile)/css-generator/components/types.ts
+++ b/src/app/[lng]/(mobile)/css-generator/components/types.ts
@@ -1,0 +1,16 @@
+export type GeneratorTab = 'shadow' | 'gradient';
+
+export interface ShadowState {
+  x: number;
+  y: number;
+  blur: number;
+  spread: number;
+  color: string;
+  opacity: number;
+}
+
+export interface GradientState {
+  direction: string;
+  from: string;
+  to: string;
+}

--- a/src/app/[lng]/(mobile)/css-generator/components/types.ts
+++ b/src/app/[lng]/(mobile)/css-generator/components/types.ts
@@ -1,4 +1,17 @@
-export type GeneratorTab = 'shadow' | 'gradient';
+export type GeneratorTab = 'shadow' | 'gradient' | 'radius' | 'flex' | 'grid';
+
+export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type FlexWrap = 'nowrap' | 'wrap';
+export type FlexJustify =
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly';
+export type FlexAlign = 'stretch' | 'flex-start' | 'center' | 'flex-end' | 'baseline';
+
+export type GridAlign = 'stretch' | 'start' | 'center' | 'end';
 
 export interface ShadowState {
   x: number;
@@ -13,4 +26,27 @@ export interface GradientState {
   direction: string;
   from: string;
   to: string;
+}
+
+export interface RadiusState {
+  topLeft: number;
+  topRight: number;
+  bottomRight: number;
+  bottomLeft: number;
+}
+
+export interface FlexState {
+  direction: FlexDirection;
+  wrap: FlexWrap;
+  justifyContent: FlexJustify;
+  alignItems: FlexAlign;
+  gap: number;
+}
+
+export interface GridState {
+  columns: number;
+  rows: number;
+  justifyItems: GridAlign;
+  alignItems: GridAlign;
+  gap: number;
 }

--- a/src/app/[lng]/(mobile)/css-generator/page.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/page.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import CssGenerator from '~/app/[lng]/(mobile)/css-generator/components/CssGenerator';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { useTranslation as getServerTranslation } from '~/app/i18n';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language } from '~/app/i18n/settings';
+
+export const generateMetadata: GenerateMetadata = async ({ params }) => {
+  return translationsMetadata({
+    params,
+    ns: 'css-generator',
+  });
+};
+
+export default async function CssGeneratorPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getServerTranslation(language, 'css-generator');
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">{t('title')}</h1>
+        <p className="text-gray-600 dark:text-gray-400">{t('description')}</p>
+      </div>
+      <CssGenerator lng={language} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -18,6 +18,7 @@ import ppollong from 'assets/locales/ko/ppollong.json'; // ppollong.json 임포�
 import serverClock from 'assets/locales/ko/server-clock.json';
 import choseongMaker from 'assets/locales/ko/choseong-maker.json';
 import qrGenerator from 'assets/locales/ko/qr-generator.json';
+import cssGenerator from 'assets/locales/ko/css-generator.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -42,6 +43,7 @@ declare module 'i18next' {
       'server-clock': typeof serverClock;
       'choseong-maker': typeof choseongMaker;
       'qr-generator': typeof qrGenerator;
+      'css-generator': typeof cssGenerator;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -8,6 +8,7 @@ import {
   Linkedin,
   List,
   MonitorPlay,
+  Palette,
   QrCode,
   Server,
   Smile,
@@ -41,6 +42,16 @@ const menus: Menus = {
       },
       icon: <QrCode />,
       link: '/qr-generator',
+    },
+    {
+      title: {
+        ko: 'CSS 생성기',
+        en: 'CSS Generator',
+        ja: 'CSSジェネレーター',
+        zh: 'CSS生成器',
+      },
+      icon: <Palette />,
+      link: '/css-generator',
     },
     {
       title: {

--- a/src/assets/locales/en/css-generator.json
+++ b/src/assets/locales/en/css-generator.json
@@ -1,9 +1,12 @@
 {
   "title": "CSS Generator",
-  "description": "Design CSS Box Shadows and Linear Gradients visually and copy the code.",
+  "description": "Design CSS Box Shadows, Linear Gradients, Border Radius, Flex, and Grid visually and copy the code.",
   "tab": {
     "shadow": "Box Shadow",
-    "gradient": "Gradient"
+    "gradient": "Gradient",
+    "radius": "Border Radius",
+    "flex": "Flex",
+    "grid": "Grid"
   },
   "shadow": {
     "offsetX": "Offset X",
@@ -24,6 +27,47 @@
     "toBottomRight": "To Bottom Right",
     "toTopRight": "To Top Right"
   },
+  "radius": {
+    "topLeft": "Top Left Radius",
+    "topRight": "Top Right Radius",
+    "bottomRight": "Bottom Right Radius",
+    "bottomLeft": "Bottom Left Radius"
+  },
+  "flex": {
+    "direction": "Direction",
+    "wrapMode": "Wrap",
+    "justifyContent": "Justify Content",
+    "alignItems": "Align Items",
+    "gap": "Gap",
+    "row": "Row",
+    "rowReverse": "Row Reverse",
+    "column": "Column",
+    "columnReverse": "Column Reverse",
+    "noWrap": "No Wrap",
+    "wrap": "Wrap",
+    "justifyStart": "Start",
+    "justifyCenter": "Center",
+    "justifyEnd": "End",
+    "justifyBetween": "Space Between",
+    "justifyAround": "Space Around",
+    "justifyEvenly": "Space Evenly",
+    "alignStretch": "Stretch",
+    "alignStart": "Start",
+    "alignCenter": "Center",
+    "alignEnd": "End",
+    "alignBaseline": "Baseline"
+  },
+  "grid": {
+    "columns": "Columns",
+    "rows": "Rows",
+    "justifyItems": "Justify Items",
+    "alignItems": "Align Items",
+    "gap": "Gap",
+    "stretch": "Stretch",
+    "start": "Start",
+    "center": "Center",
+    "end": "End"
+  },
   "code": {
     "css": "CSS",
     "tailwind": "Tailwind",
@@ -31,6 +75,6 @@
   },
   "openGraph": {
     "title": "CSS Generator",
-    "description": "Free Online CSS Generator. Visually design complex CSS Box Shadows and Linear Gradients with ease. Copy the generated code with a single click. Supports both pure CSS and Tailwind CSS classes to boost your web development productivity. Create and apply your unique styles instantly."
+    "description": "Free Online CSS Generator. Visually design CSS Box Shadows, Linear Gradients, Border Radius, Flex, and Grid with ease. Copy the generated code with a single click. Supports both pure CSS and Tailwind CSS classes to boost your web development productivity. Create and apply your unique styles instantly."
   }
 }

--- a/src/assets/locales/en/css-generator.json
+++ b/src/assets/locales/en/css-generator.json
@@ -1,0 +1,36 @@
+{
+  "title": "CSS Generator",
+  "description": "Design CSS Box Shadows and Linear Gradients visually and copy the code.",
+  "tab": {
+    "shadow": "Box Shadow",
+    "gradient": "Gradient"
+  },
+  "shadow": {
+    "offsetX": "Offset X",
+    "offsetY": "Offset Y",
+    "blur": "Blur Radius",
+    "spread": "Spread Radius",
+    "color": "Color",
+    "opacity": "Opacity"
+  },
+  "gradient": {
+    "direction": "Direction",
+    "from": "From Color",
+    "to": "To Color",
+    "toRight": "To Right",
+    "toLeft": "To Left",
+    "toBottom": "To Bottom",
+    "toTop": "To Top",
+    "toBottomRight": "To Bottom Right",
+    "toTopRight": "To Top Right"
+  },
+  "code": {
+    "css": "CSS",
+    "tailwind": "Tailwind",
+    "copy": "Click to copy"
+  },
+  "openGraph": {
+    "title": "CSS Generator",
+    "description": "Free Online CSS Generator. Visually design complex CSS Box Shadows and Linear Gradients with ease. Copy the generated code with a single click. Supports both pure CSS and Tailwind CSS classes to boost your web development productivity. Create and apply your unique styles instantly."
+  }
+}

--- a/src/assets/locales/ja/css-generator.json
+++ b/src/assets/locales/ja/css-generator.json
@@ -1,0 +1,36 @@
+{
+  "title": "CSSジェネレーター",
+  "description": "CSSボックスシャドウと線形グラデーションを視覚的にデザインし、コードをコピーします。",
+  "tab": {
+    "shadow": "ボックスシャドウ",
+    "gradient": "グラデーション"
+  },
+  "shadow": {
+    "offsetX": "オフセット X",
+    "offsetY": "オフセット Y",
+    "blur": "ぼかし半径",
+    "spread": "広がり半径",
+    "color": "色",
+    "opacity": "不透明度"
+  },
+  "gradient": {
+    "direction": "方向",
+    "from": "開始色",
+    "to": "終了色",
+    "toRight": "右へ",
+    "toLeft": "左へ",
+    "toBottom": "下へ",
+    "toTop": "上へ",
+    "toBottomRight": "右下へ",
+    "toTopRight": "右上へ"
+  },
+  "code": {
+    "css": "CSS",
+    "tailwind": "Tailwind",
+    "copy": "クリックしてコピー"
+  },
+  "openGraph": {
+    "title": "CSSジェネレーター",
+    "description": "無料オンラインCSSジェネレーター。複雑なCSSボックスシャドウや線形グラデーションを視覚的に簡単にデザインできます。生成されたコードはワンクリックでコピー可能。純粋なCSSだけでなく、Tailwind CSSクラスもサポートしており、Web開発の生産性を向上させます。今すぐ独自のスタイルを作成して適用しましょう。"
+  }
+}

--- a/src/assets/locales/ja/css-generator.json
+++ b/src/assets/locales/ja/css-generator.json
@@ -1,9 +1,12 @@
 {
   "title": "CSSジェネレーター",
-  "description": "CSSボックスシャドウと線形グラデーションを視覚的にデザインし、コードをコピーします。",
+  "description": "CSSボックスシャドウ、線形グラデーション、Border Radius、Flex、Gridを視覚的にデザインし、コードをコピーします。",
   "tab": {
     "shadow": "ボックスシャドウ",
-    "gradient": "グラデーション"
+    "gradient": "グラデーション",
+    "radius": "Border Radius",
+    "flex": "Flex",
+    "grid": "Grid"
   },
   "shadow": {
     "offsetX": "オフセット X",
@@ -24,6 +27,47 @@
     "toBottomRight": "右下へ",
     "toTopRight": "右上へ"
   },
+  "radius": {
+    "topLeft": "左上の半径",
+    "topRight": "右上の半径",
+    "bottomRight": "右下の半径",
+    "bottomLeft": "左下の半径"
+  },
+  "flex": {
+    "direction": "方向",
+    "wrapMode": "折り返し",
+    "justifyContent": "横方向の配置",
+    "alignItems": "縦方向の配置",
+    "gap": "間隔",
+    "row": "横",
+    "rowReverse": "横（反転）",
+    "column": "縦",
+    "columnReverse": "縦（反転）",
+    "noWrap": "折り返しなし",
+    "wrap": "折り返し",
+    "justifyStart": "開始",
+    "justifyCenter": "中央",
+    "justifyEnd": "終了",
+    "justifyBetween": "両端揃え",
+    "justifyAround": "周囲均等",
+    "justifyEvenly": "均等配置",
+    "alignStretch": "伸縮",
+    "alignStart": "開始",
+    "alignCenter": "中央",
+    "alignEnd": "終了",
+    "alignBaseline": "ベースライン"
+  },
+  "grid": {
+    "columns": "列数",
+    "rows": "行数",
+    "justifyItems": "横方向の配置",
+    "alignItems": "縦方向の配置",
+    "gap": "間隔",
+    "stretch": "伸縮",
+    "start": "開始",
+    "center": "中央",
+    "end": "終了"
+  },
   "code": {
     "css": "CSS",
     "tailwind": "Tailwind",
@@ -31,6 +75,6 @@
   },
   "openGraph": {
     "title": "CSSジェネレーター",
-    "description": "無料オンラインCSSジェネレーター。複雑なCSSボックスシャドウや線形グラデーションを視覚的に簡単にデザインできます。生成されたコードはワンクリックでコピー可能。純粋なCSSだけでなく、Tailwind CSSクラスもサポートしており、Web開発の生産性を向上させます。今すぐ独自のスタイルを作成して適用しましょう。"
+    "description": "無料オンラインCSSジェネレーター。CSSボックスシャドウ、線形グラデーション、Border Radius、Flex、Gridを視覚的に簡単にデザインできます。生成されたコードはワンクリックでコピー可能。純粋なCSSだけでなく、Tailwind CSSクラスもサポートしており、Web開発の生産性を向上させます。今すぐ独自のスタイルを作成して適用しましょう。"
   }
 }

--- a/src/assets/locales/ko/css-generator.json
+++ b/src/assets/locales/ko/css-generator.json
@@ -1,0 +1,36 @@
+{
+  "title": "CSS 생성기",
+  "description": "CSS Box Shadow와 Linear Gradient를 시각적으로 디자인하고 코드를 복사하세요.",
+  "tab": {
+    "shadow": "Box Shadow",
+    "gradient": "Gradient"
+  },
+  "shadow": {
+    "offsetX": "오프셋 X",
+    "offsetY": "오프셋 Y",
+    "blur": "블러 반경",
+    "spread": "확산 반경",
+    "color": "색상",
+    "opacity": "투명도"
+  },
+  "gradient": {
+    "direction": "방향",
+    "from": "시작 색상",
+    "to": "종료 색상",
+    "toRight": "오른쪽으로",
+    "toLeft": "왼쪽으로",
+    "toBottom": "아래로",
+    "toTop": "위로",
+    "toBottomRight": "오른쪽 아래로",
+    "toTopRight": "오른쪽 위로"
+  },
+  "code": {
+    "css": "CSS",
+    "tailwind": "Tailwind",
+    "copy": "복사하려면 클릭하세요"
+  },
+  "openGraph": {
+    "title": "CSS 생성기",
+    "description": "무료 온라인 CSS 생성기입니다. 복잡한 CSS Box Shadow와 Linear Gradient를 시각적으로 쉽게 디자인하고, 생성된 코드를 클릭 한 번으로 복사하세요. 순수 CSS 코드뿐만 아니라 Tailwind CSS 클래스도 지원하여 웹 개발 생산성을 높여줍니다. 지금 바로 나만의 스타일을 만들고 적용해보세요."
+  }
+}

--- a/src/assets/locales/ko/css-generator.json
+++ b/src/assets/locales/ko/css-generator.json
@@ -1,9 +1,12 @@
 {
   "title": "CSS 생성기",
-  "description": "CSS Box Shadow와 Linear Gradient를 시각적으로 디자인하고 코드를 복사하세요.",
+  "description": "CSS Box Shadow, Linear Gradient, Border Radius, Flex, Grid를 시각적으로 디자인하고 코드를 복사하세요.",
   "tab": {
     "shadow": "Box Shadow",
-    "gradient": "Gradient"
+    "gradient": "Gradient",
+    "radius": "Border Radius",
+    "flex": "Flex",
+    "grid": "Grid"
   },
   "shadow": {
     "offsetX": "오프셋 X",
@@ -24,6 +27,47 @@
     "toBottomRight": "오른쪽 아래로",
     "toTopRight": "오른쪽 위로"
   },
+  "radius": {
+    "topLeft": "좌상단 반경",
+    "topRight": "우상단 반경",
+    "bottomRight": "우하단 반경",
+    "bottomLeft": "좌하단 반경"
+  },
+  "flex": {
+    "direction": "방향",
+    "wrapMode": "줄바꿈",
+    "justifyContent": "가로 정렬",
+    "alignItems": "세로 정렬",
+    "gap": "간격",
+    "row": "가로",
+    "rowReverse": "가로 반전",
+    "column": "세로",
+    "columnReverse": "세로 반전",
+    "noWrap": "줄바꿈 없음",
+    "wrap": "줄바꿈",
+    "justifyStart": "시작",
+    "justifyCenter": "가운데",
+    "justifyEnd": "끝",
+    "justifyBetween": "양끝 정렬",
+    "justifyAround": "주변 균등",
+    "justifyEvenly": "균등 배치",
+    "alignStretch": "채우기",
+    "alignStart": "시작",
+    "alignCenter": "가운데",
+    "alignEnd": "끝",
+    "alignBaseline": "베이스라인"
+  },
+  "grid": {
+    "columns": "열 수",
+    "rows": "행 수",
+    "justifyItems": "가로 정렬",
+    "alignItems": "세로 정렬",
+    "gap": "간격",
+    "stretch": "채우기",
+    "start": "시작",
+    "center": "가운데",
+    "end": "끝"
+  },
   "code": {
     "css": "CSS",
     "tailwind": "Tailwind",
@@ -31,6 +75,6 @@
   },
   "openGraph": {
     "title": "CSS 생성기",
-    "description": "무료 온라인 CSS 생성기입니다. 복잡한 CSS Box Shadow와 Linear Gradient를 시각적으로 쉽게 디자인하고, 생성된 코드를 클릭 한 번으로 복사하세요. 순수 CSS 코드뿐만 아니라 Tailwind CSS 클래스도 지원하여 웹 개발 생산성을 높여줍니다. 지금 바로 나만의 스타일을 만들고 적용해보세요."
+    "description": "무료 온라인 CSS 생성기입니다. CSS Box Shadow, Linear Gradient, Border Radius, Flex, Grid를 시각적으로 쉽게 디자인하고, 생성된 코드를 클릭 한 번으로 복사하세요. 순수 CSS 코드뿐만 아니라 Tailwind CSS 클래스도 지원하여 웹 개발 생산성을 높여줍니다. 지금 바로 나만의 스타일을 만들고 적용해보세요."
   }
 }

--- a/src/assets/locales/zh/css-generator.json
+++ b/src/assets/locales/zh/css-generator.json
@@ -1,0 +1,36 @@
+{
+  "title": "CSS生成器",
+  "description": "可视化设计CSS方框阴影和线性渐变并复制生成代码。",
+  "tab": {
+    "shadow": "方框阴影",
+    "gradient": "渐变"
+  },
+  "shadow": {
+    "offsetX": "偏移 X",
+    "offsetY": "偏移 Y",
+    "blur": "模糊半径",
+    "spread": "扩散半径",
+    "color": "颜色",
+    "opacity": "不透明度"
+  },
+  "gradient": {
+    "direction": "方向",
+    "from": "起始颜色",
+    "to": "结束颜色",
+    "toRight": "向右",
+    "toLeft": "向左",
+    "toBottom": "向下",
+    "toTop": "向上",
+    "toBottomRight": "向右下",
+    "toTopRight": "向右上"
+  },
+  "code": {
+    "css": "CSS",
+    "tailwind": "Tailwind",
+    "copy": "点击复制"
+  },
+  "openGraph": {
+    "title": "CSS生成器",
+    "description": "免费在线CSS生成器。可视化轻松设计复杂的CSS方框阴影和线性渐变。一键复制生成的代码。支持纯CSS和Tailwind CSS类，提升您的Web开发效率。立即创建并应用您的独特风格。"
+  }
+}

--- a/src/assets/locales/zh/css-generator.json
+++ b/src/assets/locales/zh/css-generator.json
@@ -1,9 +1,12 @@
 {
   "title": "CSS生成器",
-  "description": "可视化设计CSS方框阴影和线性渐变并复制生成代码。",
+  "description": "可视化设计CSS方框阴影、线性渐变、Border Radius、Flex 和 Grid 并复制生成代码。",
   "tab": {
     "shadow": "方框阴影",
-    "gradient": "渐变"
+    "gradient": "渐变",
+    "radius": "Border Radius",
+    "flex": "Flex",
+    "grid": "Grid"
   },
   "shadow": {
     "offsetX": "偏移 X",
@@ -24,6 +27,47 @@
     "toBottomRight": "向右下",
     "toTopRight": "向右上"
   },
+  "radius": {
+    "topLeft": "左上圆角",
+    "topRight": "右上圆角",
+    "bottomRight": "右下圆角",
+    "bottomLeft": "左下圆角"
+  },
+  "flex": {
+    "direction": "方向",
+    "wrapMode": "换行",
+    "justifyContent": "主轴对齐",
+    "alignItems": "交叉轴对齐",
+    "gap": "间距",
+    "row": "横向",
+    "rowReverse": "横向反转",
+    "column": "纵向",
+    "columnReverse": "纵向反转",
+    "noWrap": "不换行",
+    "wrap": "换行",
+    "justifyStart": "起点",
+    "justifyCenter": "居中",
+    "justifyEnd": "终点",
+    "justifyBetween": "两端对齐",
+    "justifyAround": "环绕均分",
+    "justifyEvenly": "均匀分布",
+    "alignStretch": "拉伸",
+    "alignStart": "起点",
+    "alignCenter": "居中",
+    "alignEnd": "终点",
+    "alignBaseline": "基线"
+  },
+  "grid": {
+    "columns": "列数",
+    "rows": "行数",
+    "justifyItems": "横向对齐",
+    "alignItems": "纵向对齐",
+    "gap": "间距",
+    "stretch": "拉伸",
+    "start": "起点",
+    "center": "居中",
+    "end": "终点"
+  },
   "code": {
     "css": "CSS",
     "tailwind": "Tailwind",
@@ -31,6 +75,6 @@
   },
   "openGraph": {
     "title": "CSS生成器",
-    "description": "免费在线CSS生成器。可视化轻松设计复杂的CSS方框阴影和线性渐变。一键复制生成的代码。支持纯CSS和Tailwind CSS类，提升您的Web开发效率。立即创建并应用您的独特风格。"
+    "description": "免费在线CSS生成器。可视化轻松设计CSS方框阴影、线性渐变、Border Radius、Flex 和 Grid。一键复制生成的代码。支持纯CSS和Tailwind CSS类，提升您的Web开发效率。立即创建并应用您的独特风格。"
   }
 }


### PR DESCRIPTION
## Description
Added a CSS Generator tool.
This tool allows users to visually design Box Shadows and Linear Gradients and copy the generated CSS or Tailwind classes.

## Components
- `src/components/complex/tools/CssGenerator.tsx`: Logic and UI for shadow/gradient generation.
- `src/app/[lng]/tools/css-generator/page.tsx`: Page wrapper.

## Features
- Box Shadow generator with offset, blur, spread, color, opacity controls.
- Linear Gradient generator with direction and 2-color stop controls.
- Real-time preview.
- Copy-to-clipboard for CSS and Tailwind code.