### PR TITLE
feat: add uuid generator tool

### DIFF
--- a/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
@@ -7,6 +7,8 @@ import { Language } from '~/app/i18n/settings';
 import { Button } from '@components/basic/Button';
 import { Input } from '@components/basic/Input';
 import { Textarea } from '@components/basic/Textarea';
+import { Check, Copy, RefreshCw } from 'lucide-react';
+import { cn } from '@utils/cn';
 import {
   Select,
   SelectContent,
@@ -15,6 +17,10 @@ import {
   SelectValue,
 } from '@components/basic/Select';
 import { Text } from '@components/basic/Text';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
 
 const MAX_COUNT = 20;
 const MIN_COUNT = 1;
@@ -75,64 +81,76 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
   };
 
   return (
-    <section className="space-y-4">
-      <div className="grid gap-4 md:grid-cols-[160px_1fr_180px]">
-        <div className="space-y-2">
-          <Text className="t-basic-1" variant="t3">
-            {t('label.count')}
-          </Text>
-          <Input
-            type="number"
-            min={MIN_COUNT}
-            max={MAX_COUNT}
-            value={count}
-            onChange={(event) => setCount(Number(event.target.value))}
-          />
-          <Text className="t-basic-1/60" variant="c1">
-            {t('helper.count', { max: MAX_COUNT })}
-          </Text>
-        </div>
+    <div className="w-full space-y-4">
+      <section className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-4')}>
+        <div className="grid gap-4 md:grid-cols-[160px_1fr_auto]">
+          <div className="space-y-2">
+            <Text className="t-basic-1" variant="t3">
+              {t('label.count')}
+            </Text>
+            <Input
+              type="number"
+              min={MIN_COUNT}
+              max={MAX_COUNT}
+              value={count}
+              onChange={(event) => setCount(Number(event.target.value))}
+            />
+            <Text className="t-basic-1/60" variant="c1">
+              {t('helper.count', { max: MAX_COUNT })}
+            </Text>
+          </div>
 
-        <div className="space-y-2">
-          <Text className="t-basic-1" variant="t3">
-            {t('label.format')}
-          </Text>
-          <Select value={format} onValueChange={(value) => setFormat(value as FormatOption)}>
-            <SelectTrigger>
-              <SelectValue placeholder={t('placeholder.format')} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="standard">{t('format.standard')}</SelectItem>
-              <SelectItem value="noHyphens">{t('format.noHyphens')}</SelectItem>
-              <SelectItem value="uppercase">{t('format.uppercase')}</SelectItem>
-            </SelectContent>
-          </Select>
-          <Text className="t-basic-1/60" variant="c1">
-            {t('helper.format')}
-          </Text>
-        </div>
+          <div className="space-y-2">
+            <Text className="t-basic-1" variant="t3">
+              {t('label.format')}
+            </Text>
+            <Select value={format} onValueChange={(value) => setFormat(value as FormatOption)}>
+              <SelectTrigger>
+                <SelectValue placeholder={t('placeholder.format')} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="standard">{t('format.standard')}</SelectItem>
+                <SelectItem value="noHyphens">{t('format.noHyphens')}</SelectItem>
+                <SelectItem value="uppercase">{t('format.uppercase')}</SelectItem>
+              </SelectContent>
+            </Select>
+            <Text className="t-basic-1/60" variant="c1">
+              {t('helper.format')}
+            </Text>
+          </div>
 
-        <div className="flex flex-col gap-2">
-          <Button type="button" onClick={handleGenerate}>
-            {t('button.generate')}
-          </Button>
-          <Button type="button" variant="outline" onClick={handleCopy}>
-            {copied ? t('button.copied') : t('button.copy')}
-          </Button>
+          <div className="flex items-start gap-2 md:justify-self-end">
+            <Button
+              type="button"
+              onClick={handleGenerate}
+              className="gap-2 px-3 py-1 text-sm whitespace-nowrap mt-[42px]"
+            >
+              <RefreshCw className="h-4 w-4" />
+              {t('button.generate')}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleCopy}
+              className="gap-2 px-3 py-1 text-sm whitespace-nowrap"
+            >
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+              {copied ? t('button.copied') : t('button.copy')}
+            </Button>
+          </div>
         </div>
-      </div>
+      </section>
 
-      <div className="space-y-2">
+      <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-2 p-4')}>
         <Text className="t-basic-1" variant="t3">
           {t('label.output')}
         </Text>
         <Textarea
-          className="min-h-[200px]"
+          className="min-h-[220px] font-mono text-sm"
           readOnly
           value={uuids.join('\n')}
           placeholder={t('placeholder.output')}
         />
-      </div>
-    </section>
+      </section>
+    </div>
   );
 }

--- a/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import { Button } from '@components/basic/Button';
+import { Input } from '@components/basic/Input';
+import { Textarea } from '@components/basic/Textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/basic/Select';
+import { Text } from '@components/basic/Text';
+
+const MAX_COUNT = 20;
+const MIN_COUNT = 1;
+
+const generateUuidV4 = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return uuidv4();
+};
+
+type FormatOption = 'standard' | 'noHyphens' | 'uppercase';
+
+const formatUuid = (uuid: string, format: FormatOption) => {
+  switch (format) {
+    case 'noHyphens':
+      return uuid.replace(/-/g, '');
+    case 'uppercase':
+      return uuid.toUpperCase();
+    default:
+      return uuid;
+  }
+};
+
+const buildUuidList = (count: number, format: FormatOption) => {
+  return Array.from({ length: count }, () => formatUuid(generateUuidV4(), format));
+};
+
+const clampCount = (value: number) => {
+  if (Number.isNaN(value)) return MIN_COUNT;
+  return Math.min(Math.max(value, MIN_COUNT), MAX_COUNT);
+};
+
+export default function UuidGeneratorClient({ lng }: { lng: Language }) {
+  const { t } = useTranslation(lng, 'uuid-generator');
+  const [count, setCount] = React.useState(5);
+  const [format, setFormat] = React.useState<FormatOption>('standard');
+  const [uuids, setUuids] = React.useState<string[]>(() => buildUuidList(5, 'standard'));
+  const [copied, setCopied] = React.useState(false);
+
+  const handleGenerate = () => {
+    const safeCount = clampCount(count);
+    setCount(safeCount);
+    setUuids(buildUuidList(safeCount, format));
+    setCopied(false);
+  };
+
+  const handleCopy = async () => {
+    if (!uuids.length) return;
+    try {
+      await navigator.clipboard.writeText(uuids.join('\n'));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-[160px_1fr_180px]">
+        <div className="space-y-2">
+          <Text className="t-basic-1" variant="t3">
+            {t('label.count')}
+          </Text>
+          <Input
+            type="number"
+            min={MIN_COUNT}
+            max={MAX_COUNT}
+            value={count}
+            onChange={(event) => setCount(Number(event.target.value))}
+          />
+          <Text className="t-basic-1/60" variant="c1">
+            {t('helper.count', { max: MAX_COUNT })}
+          </Text>
+        </div>
+
+        <div className="space-y-2">
+          <Text className="t-basic-1" variant="t3">
+            {t('label.format')}
+          </Text>
+          <Select value={format} onValueChange={(value) => setFormat(value as FormatOption)}>
+            <SelectTrigger>
+              <SelectValue placeholder={t('placeholder.format')} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="standard">{t('format.standard')}</SelectItem>
+              <SelectItem value="noHyphens">{t('format.noHyphens')}</SelectItem>
+              <SelectItem value="uppercase">{t('format.uppercase')}</SelectItem>
+            </SelectContent>
+          </Select>
+          <Text className="t-basic-1/60" variant="c1">
+            {t('helper.format')}
+          </Text>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Button type="button" onClick={handleGenerate}>
+            {t('button.generate')}
+          </Button>
+          <Button type="button" variant="outline" onClick={handleCopy}>
+            {copied ? t('button.copied') : t('button.copy')}
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Text className="t-basic-1" variant="t3">
+          {t('label.output')}
+        </Text>
+        <Textarea
+          className="min-h-[200px]"
+          readOnly
+          value={uuids.join('\n')}
+          placeholder={t('placeholder.output')}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/app/[lng]/(mobile)/uuid-generator/page.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/page.tsx
@@ -3,7 +3,7 @@ import { getTranslations } from '~/app/i18n';
 import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
 import { LanguageParams } from '~/app/[lng]/layout';
 import { Language, languages } from '~/app/i18n/settings';
-import { H1, Text } from '@components/basic/Text';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import UuidGeneratorClient from '~/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient';
 
 export async function generateStaticParams() {
@@ -20,10 +20,9 @@ export default async function UuidGeneratorPage({ params }: LanguageParams) {
   const { t } = await getTranslations(language, 'uuid-generator');
 
   return (
-    <>
-      <H1 className="mb-2 t-basic-1">{t('title')}</H1>
-      <Text className="mb-6 t-basic-1/60">{t('description')}</Text>
+    <div className="space-y-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge="ID Utility" />
       <UuidGeneratorClient lng={language} />
-    </>
+    </div>
   );
 }

--- a/src/app/[lng]/(mobile)/uuid-generator/page.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/page.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import { H1, Text } from '@components/basic/Text';
+import UuidGeneratorClient from '~/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'uuid-generator' });
+
+export default async function UuidGeneratorPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+
+  const { t } = await getTranslations(language, 'uuid-generator');
+
+  return (
+    <>
+      <H1 className="mb-2 t-basic-1">{t('title')}</H1>
+      <Text className="mb-6 t-basic-1/60">{t('description')}</Text>
+      <UuidGeneratorClient lng={language} />
+    </>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -18,6 +18,7 @@ import ppollong from 'assets/locales/ko/ppollong.json'; // ppollong.json 임포�
 import serverClock from 'assets/locales/ko/server-clock.json';
 import choseongMaker from 'assets/locales/ko/choseong-maker.json';
 import qrGenerator from 'assets/locales/ko/qr-generator.json';
+import uuidGenerator from 'assets/locales/ko/uuid-generator.json';
 import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 import cronGenerator from 'assets/locales/ko/cron-generator.json';
 import cssGenerator from 'assets/locales/ko/css-generator.json';
@@ -59,6 +60,7 @@ declare module 'i18next' {
       'server-clock': typeof serverClock;
       'choseong-maker': typeof choseongMaker;
       'qr-generator': typeof qrGenerator;
+      'uuid-generator': typeof uuidGenerator;
       'jwt-decoder': typeof jwtDecoder;
       'cron-generator': typeof cronGenerator;
       'css-generator': typeof cssGenerator;

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -15,6 +15,7 @@ import {
   Key,
   KeyRound,
   Link2,
+  Fingerprint,
   Linkedin,
   List,
   Lock,
@@ -81,13 +82,13 @@ const menus: Menus = {
     },
     {
       title: {
-        ko: '비밀번호 생성기',
-        en: 'Password Generator',
-        ja: 'パスワード生成器',
-        zh: '密码生成器',
+        ko: 'UUID 생성기',
+        en: 'UUID Generator',
+        ja: 'UUID ジェネレーター',
+        zh: 'UUID 生成器',
       },
-      icon: <Lock />,
-      link: '/password-generator',
+      icon: <Fingerprint />,
+      link: '/uuid-generator',
     },
     {
       title: {

--- a/src/assets/locales/en/uuid-generator.json
+++ b/src/assets/locales/en/uuid-generator.json
@@ -1,0 +1,32 @@
+{
+  "openGraph": {
+    "title": "UUID Generator",
+    "description": "Generate UUID v4 values instantly. Create multiple unique identifiers directly in your browser.",
+    "keywords": ["uuid", "uuid v4", "generator", "unique id", "identifier", "tool"]
+  },
+  "title": "UUID Generator",
+  "description": "Generate multiple UUID v4 values instantly. Runs entirely in your browser.",
+  "label": {
+    "count": "Count",
+    "format": "Format",
+    "output": "Generated UUIDs"
+  },
+  "helper": {
+    "count": "Generate up to {{max}} UUIDs at once.",
+    "format": "Choose the output format that fits your workflow."
+  },
+  "format": {
+    "standard": "Standard (lowercase)",
+    "noHyphens": "Compact (no hyphens)",
+    "uppercase": "Uppercase"
+  },
+  "button": {
+    "generate": "Generate",
+    "copy": "Copy",
+    "copied": "Copied!"
+  },
+  "placeholder": {
+    "format": "Select a format",
+    "output": "Generated UUIDs will appear here."
+  }
+}

--- a/src/assets/locales/ja/uuid-generator.json
+++ b/src/assets/locales/ja/uuid-generator.json
@@ -1,0 +1,32 @@
+{
+  "openGraph": {
+    "title": "UUID ジェネレーター",
+    "description": "UUID v4 を即座に生成します。ブラウザ上で複数のユニークIDを作成できます。",
+    "keywords": ["uuid", "uuid v4", "ジェネレーター", "ユニークID", "識別子", "ツール"]
+  },
+  "title": "UUID ジェネレーター",
+  "description": "UUID v4 を即座に生成します。すべてブラウザ内で完結します。",
+  "label": {
+    "count": "件数",
+    "format": "形式",
+    "output": "生成された UUID"
+  },
+  "helper": {
+    "count": "一度に最大 {{max}} 件まで生成できます。",
+    "format": "用途に合わせて出力形式を選択してください。"
+  },
+  "format": {
+    "standard": "標準 (小文字)",
+    "noHyphens": "コンパクト (ハイフンなし)",
+    "uppercase": "大文字"
+  },
+  "button": {
+    "generate": "生成",
+    "copy": "コピー",
+    "copied": "コピーしました！"
+  },
+  "placeholder": {
+    "format": "形式を選択",
+    "output": "生成された UUID がここに表示されます。"
+  }
+}

--- a/src/assets/locales/ko/uuid-generator.json
+++ b/src/assets/locales/ko/uuid-generator.json
@@ -1,0 +1,32 @@
+{
+  "openGraph": {
+    "title": "UUID 생성기",
+    "description": "UUID v4 값을 즉시 생성하세요. 브라우저에서 여러 개의 고유 식별자를 만들 수 있습니다.",
+    "keywords": ["uuid", "uuid v4", "생성기", "고유 아이디", "식별자", "도구"]
+  },
+  "title": "UUID 생성기",
+  "description": "UUID v4 값을 즉시 생성합니다. 모든 작업은 브라우저에서 처리됩니다.",
+  "label": {
+    "count": "개수",
+    "format": "형식",
+    "output": "생성된 UUID"
+  },
+  "helper": {
+    "count": "한 번에 최대 {{max}}개까지 생성할 수 있습니다.",
+    "format": "원하는 출력 형식을 선택하세요."
+  },
+  "format": {
+    "standard": "표준 (소문자)",
+    "noHyphens": "간단형 (하이픈 제거)",
+    "uppercase": "대문자"
+  },
+  "button": {
+    "generate": "생성",
+    "copy": "복사",
+    "copied": "복사됨!"
+  },
+  "placeholder": {
+    "format": "형식을 선택하세요",
+    "output": "생성된 UUID가 여기에 표시됩니다."
+  }
+}

--- a/src/assets/locales/zh/uuid-generator.json
+++ b/src/assets/locales/zh/uuid-generator.json
@@ -1,0 +1,32 @@
+{
+  "openGraph": {
+    "title": "UUID 生成器",
+    "description": "即时生成 UUID v4，可在浏览器中创建多个唯一标识符。",
+    "keywords": ["uuid", "uuid v4", "生成器", "唯一ID", "标识符", "工具"]
+  },
+  "title": "UUID 生成器",
+  "description": "即时生成 UUID v4，全部在浏览器内完成。",
+  "label": {
+    "count": "数量",
+    "format": "格式",
+    "output": "生成的 UUID"
+  },
+  "helper": {
+    "count": "一次最多生成 {{max}} 个。",
+    "format": "选择适合你的输出格式。"
+  },
+  "format": {
+    "standard": "标准（小写）",
+    "noHyphens": "精简（无连字符）",
+    "uppercase": "大写"
+  },
+  "button": {
+    "generate": "生成",
+    "copy": "复制",
+    "copied": "已复制！"
+  },
+  "placeholder": {
+    "format": "选择格式",
+    "output": "生成的 UUID 将显示在这里。"
+  }
+}


### PR DESCRIPTION
## Summary
- add UUID generator tool page and client UI
- add i18n translations for uuid-generator
- add menu entry for UUID generator

## Testing
- yarn lint (warns about existing console in src/app/api/monitoring/route.ts)
- yarn test (fails: localStorage tests due to localStorage.clear not defined)
- yarn build (fails: next command not found)
