### PR TITLE
feat(tool): add Lotto Number Generator

### DIFF
--- a/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
+++ b/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Button } from '@components/basic/Button';
+import { Input } from '@components/basic/Input';
+import { Text } from '@components/basic/Text';
+import { cn } from '@utils/cn';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+
+interface LottoGeneratorStrings {
+  settingsTitle: string;
+  resultsTitle: string;
+  helper: string;
+  labels: {
+    minNumber: string;
+    maxNumber: string;
+    picksPerTicket: string;
+    ticketCount: string;
+    includeBonus: string;
+  };
+  placeholders: {
+    minNumber: string;
+    maxNumber: string;
+    picksPerTicket: string;
+    ticketCount: string;
+  };
+  buttons: {
+    generate: string;
+    clear: string;
+    copy: string;
+    reset: string;
+  };
+  status: {
+    copied: string;
+    empty: string;
+  };
+  validation: {
+    range: string;
+    picks: string;
+    tickets: string;
+  };
+}
+
+interface LottoResult {
+  id: string;
+  numbers: number[];
+  bonus?: number;
+}
+
+interface LottoGeneratorProps {
+  strings: LottoGeneratorStrings;
+}
+
+const DEFAULT_SETTINGS = {
+  minNumber: 1,
+  maxNumber: 45,
+  picksPerTicket: 6,
+  ticketCount: 5,
+  includeBonus: false,
+};
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random()}`;
+};
+
+const generateTicket = (
+  minNumber: number,
+  maxNumber: number,
+  picksPerTicket: number,
+  includeBonus: boolean,
+): LottoResult => {
+  const pool = Array.from({ length: maxNumber - minNumber + 1 }, (_, index) => index + minNumber);
+
+  for (let i = pool.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+
+  const numbers = pool.slice(0, picksPerTicket).sort((a, b) => a - b);
+  let bonus: number | undefined;
+
+  if (includeBonus) {
+    bonus = pool[picksPerTicket];
+  }
+
+  return { id: createId(), numbers, bonus };
+};
+
+export default function LottoGenerator({ strings }: LottoGeneratorProps) {
+  const [minNumber, setMinNumber] = useState(DEFAULT_SETTINGS.minNumber);
+  const [maxNumber, setMaxNumber] = useState(DEFAULT_SETTINGS.maxNumber);
+  const [picksPerTicket, setPicksPerTicket] = useState(DEFAULT_SETTINGS.picksPerTicket);
+  const [ticketCount, setTicketCount] = useState(DEFAULT_SETTINGS.ticketCount);
+  const [includeBonus, setIncludeBonus] = useState(DEFAULT_SETTINGS.includeBonus);
+
+  const [results, setResults] = useState<LottoResult[]>([]);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const resultsText = useMemo(() => {
+    if (results.length === 0) return '';
+
+    return results
+      .map((result, index) => {
+        const main = result.numbers.join(', ');
+        const bonus = result.bonus !== undefined ? ` (+ ${result.bonus})` : '';
+        return `${index + 1}. ${main}${bonus}`;
+      })
+      .join('\n');
+  }, [results]);
+
+  const handleGenerate = () => {
+    setError('');
+    setCopied(false);
+
+    if (minNumber >= maxNumber) {
+      setError(strings.validation.range);
+      return;
+    }
+
+    const rangeSize = maxNumber - minNumber + 1;
+    const totalNeeded = includeBonus ? picksPerTicket + 1 : picksPerTicket;
+
+    if (totalNeeded > rangeSize) {
+      setError(strings.validation.picks);
+      return;
+    }
+
+    if (ticketCount < 1 || ticketCount > 20) {
+      setError(strings.validation.tickets);
+      return;
+    }
+
+    const nextResults = Array.from({ length: ticketCount }, () =>
+      generateTicket(minNumber, maxNumber, picksPerTicket, includeBonus),
+    );
+
+    setResults(nextResults);
+  };
+
+  const handleClear = () => {
+    setResults([]);
+    setError('');
+    setCopied(false);
+  };
+
+  const handleReset = () => {
+    setMinNumber(DEFAULT_SETTINGS.minNumber);
+    setMaxNumber(DEFAULT_SETTINGS.maxNumber);
+    setPicksPerTicket(DEFAULT_SETTINGS.picksPerTicket);
+    setTicketCount(DEFAULT_SETTINGS.ticketCount);
+    setIncludeBonus(DEFAULT_SETTINGS.includeBonus);
+    handleClear();
+  };
+
+  const handleCopy = async () => {
+    if (!resultsText) return;
+
+    try {
+      await navigator.clipboard.writeText(resultsText);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch (copyError) {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className={cn(SERVICE_PANEL, 'space-y-4 p-4')}>
+        <div className="space-y-1">
+          <Text className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            {strings.settingsTitle}
+          </Text>
+          <Text className="text-xs text-zinc-500 dark:text-zinc-400">{strings.helper}</Text>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <label
+              htmlFor="lotto-min-number"
+              className="text-xs font-medium text-zinc-600 dark:text-zinc-300"
+            >
+              {strings.labels.minNumber}
+            </label>
+            <Input
+              id="lotto-min-number"
+              type="number"
+              min={1}
+              value={minNumber}
+              onChange={(event) => setMinNumber(Number(event.target.value))}
+              placeholder={strings.placeholders.minNumber}
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor="lotto-max-number"
+              className="text-xs font-medium text-zinc-600 dark:text-zinc-300"
+            >
+              {strings.labels.maxNumber}
+            </label>
+            <Input
+              id="lotto-max-number"
+              type="number"
+              min={1}
+              value={maxNumber}
+              onChange={(event) => setMaxNumber(Number(event.target.value))}
+              placeholder={strings.placeholders.maxNumber}
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor="lotto-picks"
+              className="text-xs font-medium text-zinc-600 dark:text-zinc-300"
+            >
+              {strings.labels.picksPerTicket}
+            </label>
+            <Input
+              id="lotto-picks"
+              type="number"
+              min={1}
+              value={picksPerTicket}
+              onChange={(event) => setPicksPerTicket(Number(event.target.value))}
+              placeholder={strings.placeholders.picksPerTicket}
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor="lotto-ticket-count"
+              className="text-xs font-medium text-zinc-600 dark:text-zinc-300"
+            >
+              {strings.labels.ticketCount}
+            </label>
+            <Input
+              id="lotto-ticket-count"
+              type="number"
+              min={1}
+              max={20}
+              value={ticketCount}
+              onChange={(event) => setTicketCount(Number(event.target.value))}
+              placeholder={strings.placeholders.ticketCount}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            id="lotto-include-bonus"
+            type="checkbox"
+            checked={includeBonus}
+            onChange={() => setIncludeBonus((prev) => !prev)}
+            className="h-4 w-4 rounded border-gray-300 bg-gray-100 text-point-1 focus:ring-2 focus:ring-point-1 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800"
+          />
+          <label htmlFor="lotto-include-bonus" className="text-xs text-zinc-600 dark:text-zinc-300">
+            {strings.labels.includeBonus}
+          </label>
+        </div>
+
+        {error && <Text className="text-xs text-red-500">{error}</Text>}
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" className="px-4 text-sm" onClick={handleGenerate}>
+            {strings.buttons.generate}
+          </Button>
+          <button
+            type="button"
+            className="rounded-md border border-zinc-200 px-3 py-1 text-xs font-medium text-zinc-600 transition hover:border-point-2/70 hover:text-point-2 dark:border-zinc-700 dark:text-zinc-300"
+            onClick={handleClear}
+          >
+            {strings.buttons.clear}
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-zinc-200 px-3 py-1 text-xs font-medium text-zinc-600 transition hover:border-point-2/70 hover:text-point-2 dark:border-zinc-700 dark:text-zinc-300"
+            onClick={handleReset}
+          >
+            {strings.buttons.reset}
+          </button>
+        </div>
+      </section>
+
+      <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-4 p-4')}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <Text className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            {strings.resultsTitle}
+          </Text>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-zinc-200 px-3 py-1 text-xs font-medium text-zinc-600 transition hover:border-point-2/70 hover:text-point-2 dark:border-zinc-700 dark:text-zinc-300 disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={handleCopy}
+              disabled={!resultsText}
+            >
+              {copied ? strings.status.copied : strings.buttons.copy}
+            </button>
+          </div>
+        </div>
+
+        {results.length === 0 ? (
+          <Text className="text-sm text-zinc-500 dark:text-zinc-400">{strings.status.empty}</Text>
+        ) : (
+          <div className="space-y-3">
+            {results.map((result, index) => (
+              <div
+                key={result.id}
+                className="flex flex-wrap items-center gap-2 rounded-2xl border border-zinc-200/70 bg-white/80 p-3 text-sm text-zinc-700 shadow-sm dark:border-zinc-700/70 dark:bg-zinc-900/70 dark:text-zinc-100"
+              >
+                <Text className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+                  #{index + 1}
+                </Text>
+                <div className="flex flex-wrap items-center gap-2">
+                  {result.numbers.map((number) => (
+                    <span
+                      key={number}
+                      className="rounded-full bg-point-1/10 px-3 py-1 text-xs font-semibold text-point-1"
+                    >
+                      {number}
+                    </span>
+                  ))}
+                  {result.bonus !== undefined && (
+                    <span className="rounded-full bg-point-2/10 px-3 py-1 text-xs font-semibold text-point-2">
+                      + {result.bonus}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/lotto-generator/page.tsx
+++ b/src/app/[lng]/(mobile)/lotto-generator/page.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { getTranslations } from '~/app/i18n';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import { H1, Text } from '@components/basic/Text';
+import LottoGenerator from '~/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'lotto-generator' });
+
+export default async function LottoGeneratorPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'lotto-generator');
+
+  const strings = {
+    settingsTitle: t('settingsTitle'),
+    resultsTitle: t('resultsTitle'),
+    helper: t('helper'),
+    labels: {
+      minNumber: t('labels.minNumber'),
+      maxNumber: t('labels.maxNumber'),
+      picksPerTicket: t('labels.picksPerTicket'),
+      ticketCount: t('labels.ticketCount'),
+      includeBonus: t('labels.includeBonus'),
+    },
+    placeholders: {
+      minNumber: t('placeholders.minNumber'),
+      maxNumber: t('placeholders.maxNumber'),
+      picksPerTicket: t('placeholders.picksPerTicket'),
+      ticketCount: t('placeholders.ticketCount'),
+    },
+    buttons: {
+      generate: t('buttons.generate'),
+      clear: t('buttons.clear'),
+      copy: t('buttons.copy'),
+      reset: t('buttons.reset'),
+    },
+    status: {
+      copied: t('status.copied'),
+      empty: t('status.empty'),
+    },
+    validation: {
+      range: t('validation.range'),
+      picks: t('validation.picks'),
+      tickets: t('validation.tickets'),
+    },
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <H1 className="text-balance text-zinc-900 dark:text-zinc-100">{t('title')}</H1>
+        <Text className="text-sm text-zinc-600 dark:text-zinc-300">{t('description')}</Text>
+      </header>
+      <LottoGenerator strings={strings} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -45,6 +45,7 @@ import dataSizeConverter from 'assets/locales/ko/data-size-converter.json';
 import commuteCost from 'assets/locales/ko/commute-cost.json';
 import salaryConverter from 'assets/locales/ko/salary-converter.json';
 import anniversaryCounter from 'assets/locales/ko/anniversary-counter.json';
+import lottoGenerator from 'assets/locales/ko/lotto-generator.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -96,6 +97,7 @@ declare module 'i18next' {
       'commute-cost': typeof commuteCost;
       'salary-converter': typeof salaryConverter;
       'anniversary-counter': typeof anniversaryCounter;
+      'lotto-generator': typeof lottoGenerator;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -14,6 +14,7 @@ import {
   Eye,
   FileText,
   Fingerprint,
+  Dices,
   Github,
   Hash,
   HeartPulse,
@@ -65,6 +66,16 @@ const menus: Menus = {
       },
       icon: <QrCode />,
       link: '/qr-generator',
+    },
+    {
+      title: {
+        ko: '로또 번호 생성기',
+        en: 'Lotto Number Generator',
+        ja: 'ロト番号ジェネレーター',
+        zh: '乐透号码生成器',
+      },
+      icon: <Dices />,
+      link: '/lotto-generator',
     },
     {
       title: {

--- a/src/assets/locales/en/lotto-generator.json
+++ b/src/assets/locales/en/lotto-generator.json
@@ -1,0 +1,39 @@
+{
+  "title": "Lotto Number Generator",
+  "description": "Generate random lotto numbers within your chosen range. Create multiple tickets at once and copy the results to share.",
+  "settingsTitle": "Draw Settings",
+  "resultsTitle": "Generated Numbers",
+  "helper": "Set the range and ticket count, then tap Generate.",
+  "labels": {
+    "minNumber": "Minimum number",
+    "maxNumber": "Maximum number",
+    "picksPerTicket": "Numbers per ticket",
+    "ticketCount": "Ticket count",
+    "includeBonus": "Include bonus number"
+  },
+  "placeholders": {
+    "minNumber": "1",
+    "maxNumber": "45",
+    "picksPerTicket": "6",
+    "ticketCount": "5"
+  },
+  "buttons": {
+    "generate": "Generate",
+    "clear": "Clear results",
+    "copy": "Copy results",
+    "reset": "Reset defaults"
+  },
+  "status": {
+    "copied": "Copied",
+    "empty": "No numbers yet."
+  },
+  "validation": {
+    "range": "Minimum number must be smaller than maximum.",
+    "picks": "You are picking more numbers than the available range.",
+    "tickets": "Ticket count must be between 1 and 20."
+  },
+  "openGraph": {
+    "title": "Lotto Number Generator",
+    "description": "Free online lotto number generator for quick random picks. Set the minimum and maximum number, numbers per ticket, total ticket count, and optional bonus number to generate multiple tickets at once, then copy the full result in one tap."
+  }
+}

--- a/src/assets/locales/ja/lotto-generator.json
+++ b/src/assets/locales/ja/lotto-generator.json
@@ -1,0 +1,39 @@
+{
+  "title": "ロト番号ジェネレーター",
+  "description": "指定した範囲でロト番号を自動生成します。複数のチケットをまとめて作成し、結果をコピーできます。",
+  "settingsTitle": "抽選設定",
+  "resultsTitle": "生成結果",
+  "helper": "範囲とチケット数を設定して生成ボタンを押してください。",
+  "labels": {
+    "minNumber": "最小番号",
+    "maxNumber": "最大番号",
+    "picksPerTicket": "1枚あたりの数字",
+    "ticketCount": "チケット数",
+    "includeBonus": "ボーナス番号を含める"
+  },
+  "placeholders": {
+    "minNumber": "1",
+    "maxNumber": "45",
+    "picksPerTicket": "6",
+    "ticketCount": "5"
+  },
+  "buttons": {
+    "generate": "生成する",
+    "clear": "結果をクリア",
+    "copy": "結果をコピー",
+    "reset": "初期値に戻す"
+  },
+  "status": {
+    "copied": "コピーしました",
+    "empty": "まだ番号がありません。"
+  },
+  "validation": {
+    "range": "最小番号は最大番号より小さくしてください。",
+    "picks": "選ぶ数が範囲を超えています。",
+    "tickets": "チケット数は1〜20の間で入力してください。"
+  },
+  "openGraph": {
+    "title": "ロト番号ジェネレーター",
+    "description": "無料で使えるロト番号ジェネレーターです。最小番号、最大番号、1枚あたりの数字数、チケット数を設定し、必要に応じてボーナス番号も含めて複数のランダム番号を一度に生成し、そのままコピーして共有できます。"
+  }
+}

--- a/src/assets/locales/ko/lotto-generator.json
+++ b/src/assets/locales/ko/lotto-generator.json
@@ -1,0 +1,39 @@
+{
+  "title": "로또 번호 생성기",
+  "description": "원하는 범위에서 로또 번호를 자동으로 뽑아줍니다. 여러 장을 한 번에 생성하고 결과를 복사해 공유하세요.",
+  "settingsTitle": "추첨 설정",
+  "resultsTitle": "추첨 결과",
+  "helper": "범위와 티켓 수를 설정한 뒤 생성 버튼을 누르세요.",
+  "labels": {
+    "minNumber": "시작 번호",
+    "maxNumber": "끝 번호",
+    "picksPerTicket": "한 장당 숫자 개수",
+    "ticketCount": "티켓 수",
+    "includeBonus": "보너스 번호 포함"
+  },
+  "placeholders": {
+    "minNumber": "1",
+    "maxNumber": "45",
+    "picksPerTicket": "6",
+    "ticketCount": "5"
+  },
+  "buttons": {
+    "generate": "번호 생성",
+    "clear": "결과 지우기",
+    "copy": "결과 복사",
+    "reset": "기본값으로"
+  },
+  "status": {
+    "copied": "복사됨",
+    "empty": "아직 생성된 번호가 없어요."
+  },
+  "validation": {
+    "range": "시작 번호는 끝 번호보다 작아야 해요.",
+    "picks": "뽑는 숫자 수가 범위보다 많아요.",
+    "tickets": "티켓 수는 1~20 사이로 입력해 주세요."
+  },
+  "openGraph": {
+    "title": "로또 번호 생성기",
+    "description": "무료 온라인 로또 번호 생성기입니다. 시작 번호, 끝 번호, 한 장당 숫자 개수, 티켓 수를 직접 설정해 여러 장의 랜덤 번호를 한 번에 생성하고, 보너스 번호까지 포함해 결과를 바로 복사하고 공유할 수 있습니다."
+  }
+}

--- a/src/assets/locales/zh/lotto-generator.json
+++ b/src/assets/locales/zh/lotto-generator.json
@@ -1,0 +1,39 @@
+{
+  "title": "乐透号码生成器",
+  "description": "在指定范围内自动生成乐透号码，可一次创建多张并复制分享结果。",
+  "settingsTitle": "抽奖设置",
+  "resultsTitle": "生成结果",
+  "helper": "设置范围和张数后点击生成即可。",
+  "labels": {
+    "minNumber": "最小号码",
+    "maxNumber": "最大号码",
+    "picksPerTicket": "每张号码数量",
+    "ticketCount": "生成张数",
+    "includeBonus": "包含特别号"
+  },
+  "placeholders": {
+    "minNumber": "1",
+    "maxNumber": "45",
+    "picksPerTicket": "6",
+    "ticketCount": "5"
+  },
+  "buttons": {
+    "generate": "生成号码",
+    "clear": "清空结果",
+    "copy": "复制结果",
+    "reset": "恢复默认"
+  },
+  "status": {
+    "copied": "已复制",
+    "empty": "还没有生成号码。"
+  },
+  "validation": {
+    "range": "最小号码必须小于最大号码。",
+    "picks": "选取数量超过范围。",
+    "tickets": "张数需在1到20之间。"
+  },
+  "openGraph": {
+    "title": "乐透号码生成器",
+    "description": "免费在线乐透号码生成器。可自定义最小号、最大号、每张号码数量、生成张数，并支持包含特别号，一次生成多组随机号码后可直接复制结果用于分享或保存。"
+  }
+}


### PR DESCRIPTION
## Summary\n- Adds a mobile Lotto Number Generator with configurable range, ticket count, picks, and bonus ball toggle.\n- Includes copy/reset controls and validation for common constraints.\n- Adds menu entry + i18n namespace for ko/en/ja/zh.\n\n## Screenshots\n- N/A\n\n## I18n\n- lotto-generator (ko/en/ja/zh)\n\n## Tests\n- yarn lint (pass; warning in src/app/api/monitoring/route.ts: no-console)\n- husky pre-commit vitest failed: localStorage.clear is not a function (src/utils/__tests__/localStorage.test.ts)\n\n## Follow-ups\n- Investigate localStorage test failures in the current test environment.