### PR TITLE
feat(mobile): add text counter tool

### DIFF
--- a/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { Textarea } from '@components/basic/Textarea';
+import { Button } from '@components/basic/Button';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+
+interface TextCounterClientProps {
+  lng: Language;
+}
+
+const countWords = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+};
+
+const countLines = (value: string) => {
+  if (!value) return 0;
+  return value.split(/\r\n|\r|\n/).length;
+};
+
+export default function TextCounterClient({ lng }: TextCounterClientProps) {
+  const { t } = useTranslation(lng, 'text-counter');
+  const [value, setValue] = useState('');
+
+  const stats = useMemo(() => {
+    const characters = value.length;
+    const charactersNoSpace = value.replace(/\s/g, '').length;
+    const words = countWords(value);
+    const lines = countLines(value);
+    const bytes = typeof TextEncoder !== 'undefined' ? new TextEncoder().encode(value).length : 0;
+
+    return [
+      { key: 'stats.characters', value: characters },
+      { key: 'stats.charactersNoSpace', value: charactersNoSpace },
+      { key: 'stats.words', value: words },
+      { key: 'stats.lines', value: lines },
+      { key: 'stats.bytes', value: bytes },
+    ] as const;
+  }, [value]);
+
+  const handleClear = () => setValue('');
+
+  return (
+    <div className="w-full space-y-6">
+      <div className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor="text-counter-input"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {t('label.input')}
+          </label>
+          <Button
+            type="button"
+            onClick={handleClear}
+            disabled={!value}
+            className="flex items-center gap-2 px-3 py-1 text-xs"
+          >
+            <RotateCcw size={14} />
+            {t('button.clear')}
+          </Button>
+        </div>
+        <Textarea
+          id="text-counter-input"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder={t('placeholder')}
+          rows={8}
+          className="resize-none"
+        />
+        <p className="text-xs text-gray-500 dark:text-gray-400">{t('helper')}</p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {stats.map((stat) => (
+          <div
+            key={stat.key}
+            className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-1 p-4')}
+          >
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t(stat.key)}
+            </p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {stat.value.toLocaleString()}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/text-counter/page.tsx
+++ b/src/app/[lng]/(mobile)/text-counter/page.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import TextCounterClient from '~/app/[lng]/(mobile)/text-counter/components/TextCounterClient';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { getTranslations } from '~/app/i18n';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'text-counter' });
+
+export default async function TextCounterPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'text-counter');
+
+  return (
+    <div className="space-y-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge="Text Utility" />
+      <TextCounterClient lng={language} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -22,6 +22,7 @@ import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 import cronGenerator from 'assets/locales/ko/cron-generator.json';
 import cssGenerator from 'assets/locales/ko/css-generator.json';
 import slugGenerator from 'assets/locales/ko/slug-generator.json';
+import textCounter from 'assets/locales/ko/text-counter.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -50,6 +51,7 @@ declare module 'i18next' {
       'cron-generator': typeof cronGenerator;
       'css-generator': typeof cssGenerator;
       'slug-generator': typeof slugGenerator;
+      'text-counter': typeof textCounter;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -5,6 +5,7 @@ import {
   CalendarClock,
   Code,
   CreditCard,
+  FileText,
   Github,
   Hash,
   Key,
@@ -85,6 +86,16 @@ const menus: Menus = {
       },
       icon: <Hash />,
       link: '/slug-generator',
+    },
+    {
+      title: {
+        ko: '텍스트 카운터',
+        en: 'Text Counter',
+        ja: 'テキストカウンター',
+        zh: '文本统计',
+      },
+      icon: <FileText />,
+      link: '/text-counter',
     },
     {
       title: {

--- a/src/assets/locales/en/text-counter.json
+++ b/src/assets/locales/en/text-counter.json
@@ -1,0 +1,23 @@
+{
+  "title": "Text Counter",
+  "description": "Count characters, words, lines, and bytes in your text.",
+  "label": {
+    "input": "Text input"
+  },
+  "placeholder": "Paste or type your text here.",
+  "helper": "Counts update instantly as you type.",
+  "button": {
+    "clear": "Clear"
+  },
+  "stats": {
+    "characters": "Characters (with spaces)",
+    "charactersNoSpace": "Characters (no spaces)",
+    "words": "Words",
+    "lines": "Lines",
+    "bytes": "Bytes"
+  },
+  "openGraph": {
+    "title": "Text Counter",
+    "description": "Count characters, words, lines, and bytes in your text."
+  }
+}

--- a/src/assets/locales/ja/text-counter.json
+++ b/src/assets/locales/ja/text-counter.json
@@ -1,0 +1,23 @@
+{
+  "title": "テキストカウンター",
+  "description": "文字数・単語数・行数・バイト数をすばやく確認できます。",
+  "label": {
+    "input": "テキスト入力"
+  },
+  "placeholder": "ここにテキストを入力または貼り付けてください。",
+  "helper": "入力と同時にリアルタイムで更新されます。",
+  "button": {
+    "clear": "クリア"
+  },
+  "stats": {
+    "characters": "文字数（空白含む）",
+    "charactersNoSpace": "文字数（空白除く）",
+    "words": "単語数",
+    "lines": "行数",
+    "bytes": "バイト数"
+  },
+  "openGraph": {
+    "title": "テキストカウンター",
+    "description": "文字数・単語数・行数・バイト数を簡単に数えられます。"
+  }
+}

--- a/src/assets/locales/ko/text-counter.json
+++ b/src/assets/locales/ko/text-counter.json
@@ -1,0 +1,23 @@
+{
+  "title": "텍스트 카운터",
+  "description": "문자, 단어, 줄, 바이트 수를 빠르게 확인하세요.",
+  "label": {
+    "input": "텍스트 입력"
+  },
+  "placeholder": "여기에 텍스트를 입력하거나 붙여넣으세요.",
+  "helper": "입력과 동시에 실시간으로 집계됩니다.",
+  "button": {
+    "clear": "비우기"
+  },
+  "stats": {
+    "characters": "공백 포함 문자",
+    "charactersNoSpace": "공백 제외 문자",
+    "words": "단어",
+    "lines": "줄",
+    "bytes": "바이트"
+  },
+  "openGraph": {
+    "title": "텍스트 카운터",
+    "description": "문자, 단어, 줄, 바이트 수를 간편하게 계산하세요."
+  }
+}

--- a/src/assets/locales/zh/text-counter.json
+++ b/src/assets/locales/zh/text-counter.json
@@ -1,0 +1,23 @@
+{
+  "title": "文本统计",
+  "description": "快速统计字符、单词、行数与字节数。",
+  "label": {
+    "input": "文本输入"
+  },
+  "placeholder": "在此输入或粘贴文本。",
+  "helper": "输入后实时更新统计结果。",
+  "button": {
+    "clear": "清空"
+  },
+  "stats": {
+    "characters": "字符数（含空格）",
+    "charactersNoSpace": "字符数（不含空格）",
+    "words": "单词数",
+    "lines": "行数",
+    "bytes": "字节数"
+  },
+  "openGraph": {
+    "title": "文本统计",
+    "description": "轻松统计字符、单词、行数与字节数。"
+  }
+}


### PR DESCRIPTION
## Summary\n- add a text counter mobile tool page\n- add menu entry and i18n strings for new tool\n- register text-counter namespace in i18n types\n\n## Testing\n- yarn lint (warns: existing console in src/app/api/monitoring/route.ts)\n- yarn test (fails: localStorage.clear is not a function in src/utils/__tests__/localStorage.test.ts)\n- yarn build (fails: prerender error on /en/auth/login, Invalid URL)