### PR TITLE
feat: add text toolkit mobile page

### DIFF
--- a/src/app/[lng]/(mobile)/text-toolkit/components/CaseConverterPanel.tsx
+++ b/src/app/[lng]/(mobile)/text-toolkit/components/CaseConverterPanel.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Clipboard, ClipboardCheck } from 'lucide-react';
+import { TFunction } from 'i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/basic/Select/Select';
+import { Textarea } from '@components/basic/Textarea';
+import { Button } from '@components/basic/Button';
+
+interface CaseConverterPanelProps {
+  t: TFunction<'text-toolkit', undefined>;
+}
+
+type CaseMode = 'upper' | 'lower' | 'title' | 'sentence' | 'camel';
+
+const toTitleCase = (input: string) =>
+  input.toLowerCase().replace(/\b([a-z\p{L}])/giu, (match) => match.toUpperCase());
+
+const toSentenceCase = (input: string) => {
+  const lower = input.toLowerCase();
+  return lower.replace(/(^\s*[\p{L}])|([.!?]\s+[\p{L}])/gu, (match) => match.toUpperCase());
+};
+
+const toCamelCase = (input: string) => {
+  const parts = input
+    .trim()
+    .split(/[^\p{L}\p{N}]+/gu)
+    .filter(Boolean);
+  if (!parts.length) return '';
+  return (
+    parts[0].toLowerCase() +
+    parts
+      .slice(1)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+      .join('')
+  );
+};
+
+export default function CaseConverterPanel({ t }: CaseConverterPanelProps) {
+  const [value, setValue] = useState('');
+  const [mode, setMode] = useState<CaseMode>('upper');
+  const [copied, setCopied] = useState(false);
+
+  const output = useMemo(() => {
+    if (!value) return '';
+    switch (mode) {
+      case 'lower':
+        return value.toLowerCase();
+      case 'title':
+        return toTitleCase(value);
+      case 'sentence':
+        return toSentenceCase(value);
+      case 'camel':
+        return toCamelCase(value);
+      case 'upper':
+      default:
+        return value.toUpperCase();
+    }
+  }, [mode, value]);
+
+  const handleCopy = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to copy converted text:', error);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          {t('case.title')}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{t('case.description')}</p>
+      </div>
+      <div className="space-y-2">
+        <label
+          htmlFor="text-toolkit-case-input"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t('case.label.input')}
+        </label>
+        <Textarea
+          id="text-toolkit-case-input"
+          className="min-h-[120px]"
+          placeholder={t('case.placeholder')}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <label
+          htmlFor="text-toolkit-case-mode"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t('case.label.mode')}
+        </label>
+        <Select value={mode} onValueChange={(nextValue) => setMode(nextValue as CaseMode)}>
+          <SelectTrigger id="text-toolkit-case-mode" aria-label={t('case.label.mode')}>
+            <SelectValue placeholder={t('case.placeholderMode')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="upper">{t('case.mode.upper')}</SelectItem>
+            <SelectItem value="lower">{t('case.mode.lower')}</SelectItem>
+            <SelectItem value="title">{t('case.mode.title')}</SelectItem>
+            <SelectItem value="sentence">{t('case.mode.sentence')}</SelectItem>
+            <SelectItem value="camel">{t('case.mode.camel')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor="text-toolkit-case-output"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {t('case.label.output')}
+          </label>
+          <Button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center gap-2 px-3 py-2 text-xs"
+            disabled={!output}
+          >
+            {copied ? <ClipboardCheck size={16} /> : <Clipboard size={16} />}
+            {copied ? t('case.button.copied') : t('case.button.copy')}
+          </Button>
+        </div>
+        <Textarea
+          id="text-toolkit-case-output"
+          className="min-h-[120px] font-mono"
+          value={output}
+          readOnly
+          placeholder={t('case.empty')}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/text-toolkit/components/LineOrganizerPanel.tsx
+++ b/src/app/[lng]/(mobile)/text-toolkit/components/LineOrganizerPanel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Clipboard, ClipboardCheck } from 'lucide-react';
+import { TFunction } from 'i18next';
+import { Textarea } from '@components/basic/Textarea';
+import { Button } from '@components/basic/Button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/basic/Select/Select';
+
+interface LineOrganizerPanelProps {
+  t: TFunction<'text-toolkit', undefined>;
+}
+
+type SortOrder = 'keep' | 'asc' | 'desc';
+
+export default function LineOrganizerPanel({ t }: LineOrganizerPanelProps) {
+  const [value, setValue] = useState('');
+  const [trimLines, setTrimLines] = useState(true);
+  const [removeEmpty, setRemoveEmpty] = useState(true);
+  const [uniqueLines, setUniqueLines] = useState(false);
+  const [sortOrder, setSortOrder] = useState<SortOrder>('keep');
+  const [copied, setCopied] = useState(false);
+
+  const output = useMemo(() => {
+    const rawLines = value.split(/\r?\n/);
+    let lines = rawLines.map((line) => (trimLines ? line.trim() : line));
+
+    if (removeEmpty) {
+      lines = lines.filter((line) => line.length > 0);
+    }
+
+    if (uniqueLines) {
+      const seen = new Set<string>();
+      lines = lines.filter((line) => {
+        if (seen.has(line)) return false;
+        seen.add(line);
+        return true;
+      });
+    }
+
+    if (sortOrder !== 'keep') {
+      lines = [...lines].sort((a, b) => a.localeCompare(b));
+      if (sortOrder === 'desc') {
+        lines = lines.reverse();
+      }
+    }
+
+    return lines.join('\n');
+  }, [removeEmpty, sortOrder, trimLines, uniqueLines, value]);
+
+  const handleCopy = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to copy line output:', error);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          {t('lines.title')}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{t('lines.description')}</p>
+      </div>
+      <div className="space-y-2">
+        <label
+          htmlFor="text-toolkit-lines-input"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t('lines.label.input')}
+        </label>
+        <Textarea
+          id="text-toolkit-lines-input"
+          className="min-h-[120px]"
+          placeholder={t('lines.placeholder')}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-2">
+          <label
+            htmlFor="text-toolkit-lines-sort"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {t('lines.label.sort')}
+          </label>
+          <Select
+            value={sortOrder}
+            onValueChange={(nextValue) => setSortOrder(nextValue as SortOrder)}
+          >
+            <SelectTrigger id="text-toolkit-lines-sort" aria-label={t('lines.label.sort')}>
+              <SelectValue placeholder={t('lines.sort.keep')} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="keep">{t('lines.sort.keep')}</SelectItem>
+              <SelectItem value="asc">{t('lines.sort.asc')}</SelectItem>
+              <SelectItem value="desc">{t('lines.sort.desc')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-3">
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {t('lines.label.options')}
+          </p>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+              <input
+                id="text-toolkit-option-trim"
+                type="checkbox"
+                checked={trimLines}
+                onChange={() => setTrimLines((prev) => !prev)}
+                className="h-4 w-4 rounded border-gray-300 bg-gray-100 text-point-1 focus:ring-2 focus:ring-point-1 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800"
+              />
+              <label htmlFor="text-toolkit-option-trim">{t('lines.option.trim')}</label>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+              <input
+                id="text-toolkit-option-remove-empty"
+                type="checkbox"
+                checked={removeEmpty}
+                onChange={() => setRemoveEmpty((prev) => !prev)}
+                className="h-4 w-4 rounded border-gray-300 bg-gray-100 text-point-1 focus:ring-2 focus:ring-point-1 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800"
+              />
+              <label htmlFor="text-toolkit-option-remove-empty">
+                {t('lines.option.removeEmpty')}
+              </label>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+              <input
+                id="text-toolkit-option-unique"
+                type="checkbox"
+                checked={uniqueLines}
+                onChange={() => setUniqueLines((prev) => !prev)}
+                className="h-4 w-4 rounded border-gray-300 bg-gray-100 text-point-1 focus:ring-2 focus:ring-point-1 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800"
+              />
+              <label htmlFor="text-toolkit-option-unique">{t('lines.option.unique')}</label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor="text-toolkit-lines-output"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {t('lines.label.output')}
+          </label>
+          <Button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center gap-2 px-3 py-2 text-xs"
+            disabled={!output}
+          >
+            {copied ? <ClipboardCheck size={16} /> : <Clipboard size={16} />}
+            {copied ? t('lines.button.copied') : t('lines.button.copy')}
+          </Button>
+        </div>
+        <Textarea
+          id="text-toolkit-lines-output"
+          className="min-h-[120px] font-mono"
+          value={output}
+          readOnly
+          placeholder={t('lines.empty')}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/text-toolkit/components/TextStatsPanel.tsx
+++ b/src/app/[lng]/(mobile)/text-toolkit/components/TextStatsPanel.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { TFunction } from 'i18next';
+import { Textarea } from '@components/basic/Textarea';
+import { cn } from '@utils/cn';
+
+interface TextStatsPanelProps {
+  t: TFunction<'text-toolkit', undefined>;
+}
+
+export default function TextStatsPanel({ t }: TextStatsPanelProps) {
+  const [value, setValue] = useState('');
+
+  const stats = useMemo(() => {
+    const trimmed = value.trim();
+    const characters = value.length;
+    const charactersNoSpace = value.replace(/\s/g, '').length;
+    const words = trimmed ? trimmed.split(/\s+/).length : 0;
+    const lines = value ? value.split(/\r?\n/).length : 0;
+
+    return {
+      characters,
+      charactersNoSpace,
+      words,
+      lines,
+    };
+  }, [value]);
+
+  const statItems = [
+    { label: t('stats.label.characters'), value: stats.characters },
+    { label: t('stats.label.charactersNoSpace'), value: stats.charactersNoSpace },
+    { label: t('stats.label.words'), value: stats.words },
+    { label: t('stats.label.lines'), value: stats.lines },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          {t('stats.title')}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{t('stats.description')}</p>
+      </div>
+      <div className="space-y-2">
+        <label
+          htmlFor="text-toolkit-stats"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t('stats.label.input')}
+        </label>
+        <Textarea
+          id="text-toolkit-stats"
+          className="min-h-[140px]"
+          placeholder={t('stats.placeholder')}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {statItems.map((item) => (
+          <div
+            key={item.label}
+            className={cn(
+              'rounded-xl border border-gray-200/70 bg-white/70 px-4 py-3 text-sm shadow-sm',
+              'dark:border-gray-700/70 dark:bg-gray-900/60',
+            )}
+          >
+            <p className="text-xs text-gray-500 dark:text-gray-400">{item.label}</p>
+            <p className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {item.value}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/text-toolkit/components/TextToolkitClient.tsx
+++ b/src/app/[lng]/(mobile)/text-toolkit/components/TextToolkitClient.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import { cn } from '@utils/cn';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+import TextStatsPanel from './TextStatsPanel';
+import CaseConverterPanel from './CaseConverterPanel';
+import LineOrganizerPanel from './LineOrganizerPanel';
+
+interface TextToolkitClientProps {
+  lng: Language;
+}
+
+export default function TextToolkitClient({ lng }: TextToolkitClientProps) {
+  const { t } = useTranslation(lng, 'text-toolkit');
+
+  return (
+    <div className="w-full space-y-6">
+      <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'p-4')}>
+        <TextStatsPanel t={t} />
+      </section>
+      <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'p-4')}>
+        <CaseConverterPanel t={t} />
+      </section>
+      <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'p-4')}>
+        <LineOrganizerPanel t={t} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/text-toolkit/page.tsx
+++ b/src/app/[lng]/(mobile)/text-toolkit/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import TextToolkitClient from '~/app/[lng]/(mobile)/text-toolkit/components/TextToolkitClient';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'text-toolkit' });
+
+export default async function TextToolkitPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+
+  const { t } = await getTranslations(language, 'text-toolkit');
+
+  return (
+    <div className="space-y-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge={t('badge')} />
+      <TextToolkitClient lng={language} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -22,6 +22,7 @@ import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 import cronGenerator from 'assets/locales/ko/cron-generator.json';
 import cssGenerator from 'assets/locales/ko/css-generator.json';
 import slugGenerator from 'assets/locales/ko/slug-generator.json';
+import textToolkit from 'assets/locales/ko/text-toolkit.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -50,6 +51,7 @@ declare module 'i18next' {
       'cron-generator': typeof cronGenerator;
       'css-generator': typeof cssGenerator;
       'slug-generator': typeof slugGenerator;
+      'text-toolkit': typeof textToolkit;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -18,6 +18,7 @@ import {
   Sparkles,
   TextCursorInput,
   Tv,
+  Type,
   Youtube,
 } from 'lucide-react';
 import { Language } from '~/app/i18n/settings';
@@ -85,6 +86,16 @@ const menus: Menus = {
       },
       icon: <Hash />,
       link: '/slug-generator',
+    },
+    {
+      title: {
+        ko: '텍스트 툴킷',
+        en: 'Text Toolkit',
+        ja: 'テキストツールキット',
+        zh: '文本工具包',
+      },
+      icon: <Type />,
+      link: '/text-toolkit',
     },
     {
       title: {

--- a/src/assets/locales/en/text-toolkit.json
+++ b/src/assets/locales/en/text-toolkit.json
@@ -1,0 +1,70 @@
+{
+  "title": "Text Toolkit",
+  "description": "Run quick text utilities—stats, case conversions, and line cleanup—in one place.",
+  "badge": "Multi Tool",
+  "stats": {
+    "title": "Text stats",
+    "description": "Count characters, words, and lines instantly.",
+    "label": {
+      "input": "Text input",
+      "characters": "Characters",
+      "charactersNoSpace": "Characters (no spaces)",
+      "words": "Words",
+      "lines": "Lines"
+    },
+    "placeholder": "Paste text to measure"
+  },
+  "case": {
+    "title": "Case converter",
+    "description": "Switch between upper, lower, title, sentence, and camel case.",
+    "label": {
+      "input": "Text to convert",
+      "mode": "Conversion mode",
+      "output": "Converted result"
+    },
+    "placeholder": "Type or paste text",
+    "placeholderMode": "Choose a mode",
+    "mode": {
+      "upper": "UPPERCASE",
+      "lower": "lowercase",
+      "title": "Title Case",
+      "sentence": "Sentence case",
+      "camel": "camelCase"
+    },
+    "button": {
+      "copy": "Copy",
+      "copied": "Copied"
+    },
+    "empty": "Converted text appears here."
+  },
+  "lines": {
+    "title": "Line organizer",
+    "description": "Clean and organize lists with sorting and filters.",
+    "label": {
+      "input": "Lines input",
+      "sort": "Sort order",
+      "options": "Options",
+      "output": "Organized lines"
+    },
+    "placeholder": "Enter one item per line",
+    "sort": {
+      "keep": "Keep order",
+      "asc": "A → Z",
+      "desc": "Z → A"
+    },
+    "option": {
+      "trim": "Trim whitespace",
+      "removeEmpty": "Remove empty lines",
+      "unique": "Remove duplicates"
+    },
+    "button": {
+      "copy": "Copy",
+      "copied": "Copied"
+    },
+    "empty": "Organized lines will show here."
+  },
+  "openGraph": {
+    "title": "Text Toolkit",
+    "description": "Analyze text, convert case, and clean up lists quickly."
+  }
+}

--- a/src/assets/locales/ja/text-toolkit.json
+++ b/src/assets/locales/ja/text-toolkit.json
@@ -1,0 +1,70 @@
+{
+  "title": "テキストツールキット",
+  "description": "文字数カウント、ケース変換、行整理を一箇所でまとめて実行します。",
+  "badge": "マルチツール",
+  "stats": {
+    "title": "テキスト統計",
+    "description": "文字数・単語数・行数をすばやく確認できます。",
+    "label": {
+      "input": "テキスト入力",
+      "characters": "文字数",
+      "charactersNoSpace": "空白除外の文字数",
+      "words": "単語数",
+      "lines": "行数"
+    },
+    "placeholder": "計測したいテキストを貼り付けてください"
+  },
+  "case": {
+    "title": "ケース変換",
+    "description": "大文字・小文字・タイトルケースなどに即変換します。",
+    "label": {
+      "input": "変換するテキスト",
+      "mode": "変換モード",
+      "output": "変換結果"
+    },
+    "placeholder": "テキストを入力または貼り付けてください",
+    "placeholderMode": "モードを選択してください",
+    "mode": {
+      "upper": "大文字",
+      "lower": "小文字",
+      "title": "タイトルケース",
+      "sentence": "文頭大文字",
+      "camel": "キャメルケース"
+    },
+    "button": {
+      "copy": "コピー",
+      "copied": "コピー済み"
+    },
+    "empty": "変換されたテキストがここに表示されます。"
+  },
+  "lines": {
+    "title": "行整理",
+    "description": "並び替えとフィルターでリストを整えます。",
+    "label": {
+      "input": "行入力",
+      "sort": "並び替え",
+      "options": "オプション",
+      "output": "整理された結果"
+    },
+    "placeholder": "1行に1項目ずつ入力してください",
+    "sort": {
+      "keep": "元の順序",
+      "asc": "昇順",
+      "desc": "降順"
+    },
+    "option": {
+      "trim": "空白を削除",
+      "removeEmpty": "空行を削除",
+      "unique": "重複を削除"
+    },
+    "button": {
+      "copy": "コピー",
+      "copied": "コピー済み"
+    },
+    "empty": "整理された結果がここに表示されます。"
+  },
+  "openGraph": {
+    "title": "テキストツールキット",
+    "description": "テキスト分析、ケース変換、リスト整理をすばやく行います。"
+  }
+}

--- a/src/assets/locales/ko/text-toolkit.json
+++ b/src/assets/locales/ko/text-toolkit.json
@@ -1,0 +1,70 @@
+{
+  "title": "텍스트 툴킷",
+  "description": "문자 통계, 케이스 변환, 줄 정리까지 한 번에 처리하세요.",
+  "badge": "멀티 툴",
+  "stats": {
+    "title": "텍스트 통계",
+    "description": "문자 수, 단어 수, 줄 수를 빠르게 확인합니다.",
+    "label": {
+      "input": "텍스트 입력",
+      "characters": "문자 수",
+      "charactersNoSpace": "공백 제외 문자 수",
+      "words": "단어 수",
+      "lines": "줄 수"
+    },
+    "placeholder": "측정할 텍스트를 붙여 넣으세요"
+  },
+  "case": {
+    "title": "케이스 변환",
+    "description": "대문자, 소문자, 타이틀 케이스 등을 즉시 변환합니다.",
+    "label": {
+      "input": "변환할 텍스트",
+      "mode": "변환 모드",
+      "output": "변환 결과"
+    },
+    "placeholder": "텍스트를 입력하거나 붙여 넣으세요",
+    "placeholderMode": "모드를 선택하세요",
+    "mode": {
+      "upper": "대문자",
+      "lower": "소문자",
+      "title": "타이틀 케이스",
+      "sentence": "문장 케이스",
+      "camel": "카멜 케이스"
+    },
+    "button": {
+      "copy": "복사",
+      "copied": "복사됨"
+    },
+    "empty": "변환된 텍스트가 여기에 표시됩니다."
+  },
+  "lines": {
+    "title": "줄 정리",
+    "description": "정렬과 필터로 리스트를 깔끔하게 정리하세요.",
+    "label": {
+      "input": "줄 입력",
+      "sort": "정렬 방식",
+      "options": "옵션",
+      "output": "정리된 결과"
+    },
+    "placeholder": "한 줄에 하나씩 입력하세요",
+    "sort": {
+      "keep": "원래 순서",
+      "asc": "오름차순",
+      "desc": "내림차순"
+    },
+    "option": {
+      "trim": "공백 제거",
+      "removeEmpty": "빈 줄 제거",
+      "unique": "중복 제거"
+    },
+    "button": {
+      "copy": "복사",
+      "copied": "복사됨"
+    },
+    "empty": "정리된 결과가 여기에 표시됩니다."
+  },
+  "openGraph": {
+    "title": "텍스트 툴킷",
+    "description": "텍스트 분석, 케이스 변환, 리스트 정리를 빠르게 처리하세요."
+  }
+}

--- a/src/assets/locales/zh/text-toolkit.json
+++ b/src/assets/locales/zh/text-toolkit.json
@@ -1,0 +1,70 @@
+{
+  "title": "文本工具包",
+  "description": "一次完成字符统计、大小写转换和行整理。",
+  "badge": "多功能",
+  "stats": {
+    "title": "文本统计",
+    "description": "快速查看字符数、单词数与行数。",
+    "label": {
+      "input": "文本输入",
+      "characters": "字符数",
+      "charactersNoSpace": "不含空格字符数",
+      "words": "单词数",
+      "lines": "行数"
+    },
+    "placeholder": "粘贴要统计的文本"
+  },
+  "case": {
+    "title": "大小写转换",
+    "description": "在大写、小写、标题格式等之间切换。",
+    "label": {
+      "input": "待转换文本",
+      "mode": "转换模式",
+      "output": "转换结果"
+    },
+    "placeholder": "输入或粘贴文本",
+    "placeholderMode": "请选择模式",
+    "mode": {
+      "upper": "大写",
+      "lower": "小写",
+      "title": "标题格式",
+      "sentence": "句首大写",
+      "camel": "驼峰"
+    },
+    "button": {
+      "copy": "复制",
+      "copied": "已复制"
+    },
+    "empty": "转换后的文本将显示在此处。"
+  },
+  "lines": {
+    "title": "行整理",
+    "description": "通过排序与筛选整理列表。",
+    "label": {
+      "input": "行输入",
+      "sort": "排序方式",
+      "options": "选项",
+      "output": "整理结果"
+    },
+    "placeholder": "每行输入一个项目",
+    "sort": {
+      "keep": "保持顺序",
+      "asc": "升序",
+      "desc": "降序"
+    },
+    "option": {
+      "trim": "去除空白",
+      "removeEmpty": "移除空行",
+      "unique": "去重"
+    },
+    "button": {
+      "copy": "复制",
+      "copied": "已复制"
+    },
+    "empty": "整理后的内容会显示在这里。"
+  },
+  "openGraph": {
+    "title": "文本工具包",
+    "description": "快速完成文本分析、大小写转换与列表整理。"
+  }
+}


### PR DESCRIPTION
## Summary
- add text toolkit mobile page with stats, case conversion, and line organizer panels
- add text-toolkit translations (ko/en/ja/zh) and register namespace
- update mobile service menu with new text toolkit entry

## Testing
- yarn lint (warning: src/app/api/monitoring/route.ts no-console)
- yarn test (fails: src/utils/__tests__/localStorage.test.ts localStorage.clear is not a function)
- yarn build (fails: /ko/auth/login prerender Invalid URL)
