### PR TITLE
feat: add ladder draw tool

### DIFF
--- a/src/app/[lng]/(mobile)/ladder-game/components/LadderGameClient.tsx
+++ b/src/app/[lng]/(mobile)/ladder-game/components/LadderGameClient.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { RotateCcw, Shuffle } from 'lucide-react';
+import { Button } from '@components/basic/Button';
+import { Textarea } from '@components/basic/Textarea';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+
+interface LadderGameClientProps {
+  lng: Language;
+}
+
+interface Assignment {
+  name: string;
+  result: string;
+}
+
+const parseList = (raw: string) =>
+  raw
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const shuffleList = (items: string[]) => {
+  const list = [...items];
+  for (let index = list.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [list[index], list[randomIndex]] = [list[randomIndex], list[index]];
+  }
+  return list;
+};
+
+export default function LadderGameClient({ lng }: LadderGameClientProps) {
+  const { t } = useTranslation(lng, 'ladder-game');
+  const [participantsInput, setParticipantsInput] = useState('');
+  const [resultsInput, setResultsInput] = useState('');
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const participants = useMemo(() => parseList(participantsInput), [participantsInput]);
+  const results = useMemo(() => parseList(resultsInput), [resultsInput]);
+
+  const buildAssignments = () => {
+    if (!participants.length) {
+      setErrorMessage(t('error.noParticipants'));
+      setAssignments([]);
+      return;
+    }
+
+    const filledResults = [...results];
+    if (filledResults.length < participants.length) {
+      for (let index = filledResults.length; index < participants.length; index += 1) {
+        filledResults.push(t('autoResult', { index: index + 1 }));
+      }
+    }
+
+    const normalizedResults = filledResults.slice(0, participants.length);
+    const shuffledResults = shuffleList(normalizedResults);
+
+    const nextAssignments = participants.map((name, index) => ({
+      name,
+      result: shuffledResults[index],
+    }));
+
+    setErrorMessage(null);
+    setAssignments(nextAssignments);
+  };
+
+  const handleReset = () => {
+    setParticipantsInput('');
+    setResultsInput('');
+    setAssignments([]);
+    setErrorMessage(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-4')}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label
+              htmlFor="ladder-participants"
+              className="text-sm font-semibold text-zinc-800 dark:text-zinc-100"
+            >
+              {t('participants.label')}
+            </label>
+            <Textarea
+              id="ladder-participants"
+              value={participantsInput}
+              onChange={(event) => setParticipantsInput(event.target.value)}
+              placeholder={t('participants.placeholder')}
+              rows={6}
+              className="text-sm"
+            />
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">{t('participants.helper')}</p>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="ladder-results"
+              className="text-sm font-semibold text-zinc-800 dark:text-zinc-100"
+            >
+              {t('results.label')}
+            </label>
+            <Textarea
+              id="ladder-results"
+              value={resultsInput}
+              onChange={(event) => setResultsInput(event.target.value)}
+              placeholder={t('results.placeholder')}
+              rows={6}
+              className="text-sm"
+            />
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">{t('results.helper')}</p>
+          </div>
+        </div>
+
+        <p className="text-xs text-zinc-500 dark:text-zinc-400">{t('notice')}</p>
+        {errorMessage ? <p className="text-xs font-semibold text-red-500">{errorMessage}</p> : null}
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" onClick={buildAssignments} className="flex items-center gap-2">
+            <Shuffle size={16} />
+            {t('buttons.generate')}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleReset}
+            className="flex items-center gap-2 bg-zinc-200 text-sm text-zinc-700 hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+          >
+            <RotateCcw size={16} />
+            {t('buttons.reset')}
+          </Button>
+        </div>
+      </div>
+
+      <div className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+            {t('resultsTitle')}
+          </h3>
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            {t('resultsCount', { count: assignments.length })}
+          </span>
+        </div>
+
+        {assignments.length ? (
+          <ul className="grid gap-3 md:grid-cols-2">
+            {assignments.map((assignment) => (
+              <li
+                key={`${assignment.name}-${assignment.result}`}
+                className={cn(
+                  SERVICE_PANEL_SOFT,
+                  SERVICE_CARD_INTERACTIVE,
+                  'flex items-center justify-between gap-3 p-3',
+                )}
+              >
+                <span className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+                  {assignment.name}
+                </span>
+                <span className="text-sm font-semibold text-point-1">{assignment.result}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">{t('empty')}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/ladder-game/page.tsx
+++ b/src/app/[lng]/(mobile)/ladder-game/page.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { getTranslations } from '~/app/i18n';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+import LadderGameClient from './components/LadderGameClient';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'ladder-game' });
+
+export default async function LadderGamePage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'ladder-game');
+
+  return (
+    <div className="space-y-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge="Ladder Tool" />
+      <LadderGameClient lng={language} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -22,6 +22,7 @@ import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 import cronGenerator from 'assets/locales/ko/cron-generator.json';
 import cssGenerator from 'assets/locales/ko/css-generator.json';
 import slugGenerator from 'assets/locales/ko/slug-generator.json';
+import ladderGame from 'assets/locales/ko/ladder-game.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -50,6 +51,7 @@ declare module 'i18next' {
       'cron-generator': typeof cronGenerator;
       'css-generator': typeof cssGenerator;
       'slug-generator': typeof slugGenerator;
+      'ladder-game': typeof ladderGame;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -14,6 +14,7 @@ import {
   Palette,
   QrCode,
   Server,
+  Shuffle,
   Smile,
   Sparkles,
   TextCursorInput,
@@ -95,6 +96,16 @@ const menus: Menus = {
       },
       icon: <Calculator />,
       link: '/percent',
+    },
+    {
+      title: {
+        ko: '사다리타기 추첨',
+        en: 'Ladder Draw',
+        ja: 'あみだくじ抽選',
+        zh: '阿弥陀抽签',
+      },
+      icon: <Shuffle />,
+      link: '/ladder-game',
     },
     {
       title: {

--- a/src/assets/locales/en/ladder-game.json
+++ b/src/assets/locales/en/ladder-game.json
@@ -1,0 +1,31 @@
+{
+  "openGraph": {
+    "title": "Ladder Draw",
+    "ogTitle": "Ladder Draw",
+    "description": "A simple ladder draw tool that randomly matches participants with outcomes. Use it for everyday raffles, team assignments, and event picks."
+  },
+  "title": "Ladder Draw",
+  "description": "Enter participants and outcomes to get a random match.",
+  "participants": {
+    "label": "Participants",
+    "placeholder": "Enter names with new lines or commas",
+    "helper": "Example: Alex, Jamie or one name per line"
+  },
+  "results": {
+    "label": "Outcomes",
+    "placeholder": "Enter prizes/roles with new lines or commas",
+    "helper": "Leave empty to auto-generate outcomes."
+  },
+  "notice": "If there are fewer outcomes than participants, we'll fill the rest automatically.",
+  "buttons": {
+    "generate": "Run draw",
+    "reset": "Reset"
+  },
+  "resultsTitle": "Draw results",
+  "resultsCount": "{{count}} entries",
+  "empty": "Enter participants and outcomes, then run the draw.",
+  "autoResult": "Result {{index}}",
+  "error": {
+    "noParticipants": "Please enter at least one participant."
+  }
+}

--- a/src/assets/locales/ja/ladder-game.json
+++ b/src/assets/locales/ja/ladder-game.json
@@ -1,0 +1,31 @@
+{
+  "openGraph": {
+    "title": "あみだくじ抽選",
+    "ogTitle": "あみだくじ抽選",
+    "description": "参加者と結果を入力するとランダムに割り当てられるあみだくじ抽選ツールです。日常の抽選やチーム分けにどうぞ。"
+  },
+  "title": "あみだくじ抽選",
+  "description": "参加者と結果を入力するとランダムにマッチします。",
+  "participants": {
+    "label": "参加者",
+    "placeholder": "名前を改行またはカンマで入力",
+    "helper": "例: 太郎, 花子 または1行ずつ"
+  },
+  "results": {
+    "label": "結果",
+    "placeholder": "景品/役割を改行またはカンマで入力",
+    "helper": "空欄の場合は自動で結果を埋めます。"
+  },
+  "notice": "結果が足りない場合は自動で補完し、人数に合わせます。",
+  "buttons": {
+    "generate": "抽選する",
+    "reset": "リセット"
+  },
+  "resultsTitle": "抽選結果",
+  "resultsCount": "{{count}}件",
+  "empty": "参加者と結果を入力してから実行してください。",
+  "autoResult": "結果 {{index}}",
+  "error": {
+    "noParticipants": "参加者を入力してください。"
+  }
+}

--- a/src/assets/locales/ko/ladder-game.json
+++ b/src/assets/locales/ko/ladder-game.json
@@ -1,0 +1,31 @@
+{
+  "openGraph": {
+    "title": "사다리타기 추첨",
+    "ogTitle": "사다리타기 추첨",
+    "description": "참가자와 결과를 입력하면 랜덤으로 매칭되는 사다리타기 추첨 도구입니다. 모임, 이벤트, 팀 배정 등 일상적인 추첨을 빠르고 공정하게 진행하세요."
+  },
+  "title": "사다리타기 추첨",
+  "description": "참가자와 결과를 입력하면 랜덤으로 매칭합니다.",
+  "participants": {
+    "label": "참가자",
+    "placeholder": "이름을 줄바꿈 또는 쉼표로 입력",
+    "helper": "예: 철수, 영희 또는 줄바꿈으로 입력"
+  },
+  "results": {
+    "label": "결과",
+    "placeholder": "상품/역할을 줄바꿈 또는 쉼표로 입력",
+    "helper": "비워두면 자동 결과가 채워집니다."
+  },
+  "notice": "결과가 부족하면 자동으로 결과를 채워서 동일한 인원 수로 맞춥니다.",
+  "buttons": {
+    "generate": "사다리타기 실행",
+    "reset": "초기화"
+  },
+  "resultsTitle": "추첨 결과",
+  "resultsCount": "총 {{count}}명",
+  "empty": "참가자와 결과를 입력한 뒤 실행해 주세요.",
+  "autoResult": "결과 {{index}}",
+  "error": {
+    "noParticipants": "참가자를 먼저 입력해 주세요."
+  }
+}

--- a/src/assets/locales/zh/ladder-game.json
+++ b/src/assets/locales/zh/ladder-game.json
@@ -1,0 +1,31 @@
+{
+  "openGraph": {
+    "title": "阿弥陀抽签",
+    "ogTitle": "阿弥陀抽签",
+    "description": "输入参与者和结果即可随机匹配的阿弥陀抽签工具，适合日常抽奖、分组与活动选择。"
+  },
+  "title": "阿弥陀抽签",
+  "description": "输入参与者和结果即可随机匹配。",
+  "participants": {
+    "label": "参与者",
+    "placeholder": "用换行或逗号输入名字",
+    "helper": "例如：小明, 小红 或每行一个"
+  },
+  "results": {
+    "label": "结果",
+    "placeholder": "用换行或逗号输入奖品/角色",
+    "helper": "留空将自动生成结果。"
+  },
+  "notice": "结果数量不足时会自动补齐，并与人数一致。",
+  "buttons": {
+    "generate": "开始抽签",
+    "reset": "重置"
+  },
+  "resultsTitle": "抽签结果",
+  "resultsCount": "共 {{count}} 个",
+  "empty": "请输入参与者和结果后再开始。",
+  "autoResult": "结果 {{index}}",
+  "error": {
+    "noParticipants": "请先输入参与者。"
+  }
+}


### PR DESCRIPTION
### PR 종류는 무엇인가요?

- [ ] 버그 해결
- [x] 신규 기능 추가
- [ ] 코드 스타일 업데이트 (포맷팅, 네이밍 변경)
- [ ] 리팩토링 (기능적인 변화 없음)
- [ ] 빌드 관련 수정
- [ ] 기타 (내용을 간략히 작성해주세요):

### 어떤 구현/수정을 하였나요? 변경 사항을 설명해주세요.
- 사다리타기 추첨 도구 페이지/클라이언트 UI 추가
- 메뉴 항목 및 i18n 리소스(ko/en/ja/zh) 추가
- i18next 타입 정의에 ladder-game 네임스페이스 추가

### 기존 동작이 어떻게 변경되었나요?
- 메뉴에 "사다리타기 추첨"이 추가되어 /ladder-game 도구를 사용할 수 있습니다.

### 기타 정보
- Tests: 
 RUN  v2.1.9 /home/openclaw/.openclaw/workspace/okdohyuk-front

 ✓ src/utils/__tests__/blogUtils.test.ts (21 tests) 11ms
 ✓ src/utils/__tests__/filterDropdownUtil.test.ts (21 tests) 13ms
 ✓ src/utils/coderUtils/__tests__/index.test.ts (26 tests) 18ms
 ✓ src/utils/__tests__/markdownUtils.test.ts (12 tests) 11ms
 ✓ src/utils/__tests__/localeUtil.test.ts (8 tests) 13ms
 ✓ src/app/[lng]/(mobile)/server-clock/components/__tests__/TimeDisplay.test.tsx (5 tests) 81ms
 ✓ src/utils/__tests__/dateUtils.test.ts (8 tests) 16ms
 ✓ src/app/[lng]/(mobile)/server-clock/components/__tests__/DisplaySettings.test.tsx (4 tests) 160ms
 ✓ src/utils/__tests__/userTokenUtil.test.ts (10 tests) 18ms
 ❯ src/utils/__tests__/localStorage.test.ts (5 tests | 5 failed) 12ms
   × LocalStorage > setItem > localStorage.setItem을 올바른 키와 값으로 호출해야 합니다 6ms
     → localStorage.clear is not a function
   × LocalStorage > getItem > localStorage.getItem을 올바른 키로 호출하고 값을 반환해야 합니다 1ms
     → localStorage.clear is not a function
   × LocalStorage > getItem > 키가 존재하지 않으면 null을 반환해야 합니다 1ms
     → localStorage.clear is not a function
   × LocalStorage > removeItem > localStorage.removeItem을 올바른 키로 호출해야 합니다 1ms
     → localStorage.clear is not a function
   × LocalStorage > removeItem > 존재하지 않는 키를 삭제하려고 해도 에러가 발생하지 않아야 합니다 1ms
     → localStorage.clear is not a function
 ✓ src/utils/__tests__/jwtUtils.test.ts (5 tests) 8ms
 ✓ src/utils/__tests__/scrollUtils.test.ts (5 tests) 7ms
 ✓ src/app/[lng]/(mobile)/server-clock/hooks/__tests__/useUrgentStyle.test.ts (4 tests) 51ms
 ✓ src/utils/__tests__/stringUtils.test.ts (10 tests) 7ms
 ✓ src/components/complex/Service/__tests__/CursorGlowCard.test.tsx (1 test) 54ms
 ✓ src/components/complex/Service/__tests__/ServiceInfoNotice.test.tsx (2 tests) 175ms
 ✓ src/components/complex/Service/__tests__/ServicePageHeader.test.tsx (2 tests) 147ms
 ✓ src/components/complex/Layout/__tests__/MobileScreenWrapper.test.tsx (2 tests) 53ms
 ✓ src/components/basic/Table/__tests__/Table.test.tsx (1 test) 67ms
 ✓ src/components/basic/Button/__tests__/Button.test.tsx (3 tests) 178ms
 ✓ src/components/basic/Link/__tests__/Link.test.tsx (2 tests) 122ms
 ✓ src/components/basic/Textarea/__tests__/Textarea.test.tsx (2 tests) 121ms
 ✓ src/components/complex/Layout/__tests__/AsideScreenWrapper.test.tsx (1 test) 56ms
 ✓ src/components/basic/Select/__tests__/Select.test.tsx (1 test) 161ms
 ✓ src/components/basic/Input/__tests__/Input.test.tsx (2 tests) 66ms
 ✓ src/components/basic/Icon/__tests__/Icon.test.tsx (1 test) 34ms
 ✓ src/components/basic/Text/__tests__/Text.test.tsx (2 tests) 118ms
 ✓ src/utils/__tests__/choseongUtils.test.ts (2 tests) 5ms
 ✓ src/components/complex/Card/__tests__/MyLinkCard.test.tsx (1 test) 47ms
 ✓ src/components/basic/Tag/__tests__/Tag.test.tsx (1 test) 37ms

 Test Files  1 failed | 29 passed (30)
      Tests  5 failed | 165 passed (170)
   Start at  04:12:42
   Duration  14.94s (transform 779ms, setup 4.20s, collect 5.81s, tests 1.86s, environment 17.58s, prepare 3.78s) (failed: localStorage.clear is not a function in src/utils/__tests__/localStorage.test.ts)
