### PR TITLE
feat: add ladder game tool

### DIFF
--- a/src/app/[lng]/(mobile)/ladder-game/components/LadderGame.tsx
+++ b/src/app/[lng]/(mobile)/ladder-game/components/LadderGame.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { Language } from '~/app/i18n/settings';
+import { useTranslation } from '~/app/i18n/client';
+
+interface LadderGameProps {
+  lng: Language;
+}
+
+type LadderRow = {
+  id: string;
+  cells: boolean[];
+};
+
+const parseLines = (value: string) =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const shuffle = <T,>(items: T[]) => {
+  const next = [...items];
+  for (let i = next.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [next[i], next[j]] = [next[j], next[i]];
+  }
+  return next;
+};
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const generateLadderRows = (columns: number, rows: number) => {
+  const ladderRows: LadderRow[] = [];
+
+  for (let r = 0; r < rows; r += 1) {
+    const cells = Array(Math.max(columns - 1, 0)).fill(false);
+    let prevConnected = false;
+
+    for (let c = 0; c < cells.length; c += 1) {
+      if (prevConnected) {
+        prevConnected = false;
+      } else if (Math.random() > 0.55) {
+        cells[c] = true;
+        prevConnected = true;
+      }
+    }
+
+    ladderRows.push({ id: createId(), cells });
+  }
+
+  return ladderRows;
+};
+
+const resolveLadderMapping = (columns: number, ladderRows: LadderRow[]) => {
+  const mapping: number[] = [];
+
+  for (let start = 0; start < columns; start += 1) {
+    let position = start;
+
+    ladderRows.forEach((row) => {
+      if (row.cells[position]) {
+        position += 1;
+      } else if (position > 0 && row.cells[position - 1]) {
+        position -= 1;
+      }
+    });
+
+    mapping[start] = position;
+  }
+
+  return mapping;
+};
+
+function LadderPreview({
+  participants,
+  outcomes,
+  ladderRows,
+  title,
+}: {
+  participants: string[];
+  outcomes: string[];
+  ladderRows: LadderRow[];
+  title: string;
+}) {
+  if (participants.length < 2 || ladderRows.length === 0) return null;
+
+  const participantCounts: Record<string, number> = {};
+  const outcomeCounts: Record<string, number> = {};
+
+  const participantEntries = participants.map((name) => {
+    participantCounts[name] = (participantCounts[name] ?? 0) + 1;
+    return { id: `${name}-${participantCounts[name]}`, name };
+  });
+
+  const outcomeEntries = outcomes.map((name) => {
+    outcomeCounts[name] = (outcomeCounts[name] ?? 0) + 1;
+    return { id: `${name}-${outcomeCounts[name]}`, name };
+  });
+
+  return (
+    <section className={`${SERVICE_PANEL_SOFT} space-y-4 p-4`}>
+      <h3 className="text-left text-base font-semibold text-slate-100">{title}</h3>
+      <div className="overflow-x-auto">
+        <div className="min-w-[320px] space-y-2">
+          <div
+            className="grid gap-2 text-center text-sm font-semibold text-slate-100"
+            style={{ gridTemplateColumns: `repeat(${participants.length}, minmax(72px, 1fr))` }}
+          >
+            {participantEntries.map((entry) => (
+              <div key={entry.id} className="rounded-md bg-slate-900/60 px-2 py-1">
+                {entry.name}
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-1">
+            {ladderRows.map((row) => (
+              <div
+                key={row.id}
+                className="grid items-center"
+                style={{ gridTemplateColumns: `repeat(${participants.length}, minmax(72px, 1fr))` }}
+              >
+                {participantEntries.map((entry, colIndex) => {
+                  const hasRight = row.cells[colIndex];
+                  return (
+                    <div key={entry.id} className="relative h-6">
+                      <div className="absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-slate-500" />
+                      {hasRight && (
+                        <div className="absolute left-1/2 top-1/2 h-px w-full -translate-y-1/2 bg-slate-400" />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+
+          <div
+            className="grid gap-2 text-center text-sm font-semibold text-point-2"
+            style={{ gridTemplateColumns: `repeat(${participants.length}, minmax(72px, 1fr))` }}
+          >
+            {outcomeEntries.map((entry) => (
+              <div key={entry.id} className="rounded-md bg-point-2/20 px-2 py-1">
+                {entry.name}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function LadderGame({ lng }: LadderGameProps) {
+  const { t } = useTranslation(lng, 'ladder-game');
+
+  const sampleParticipants = useMemo(() => {
+    const sample = t('sampleParticipants', { returnObjects: true }) as string[];
+    return Array.isArray(sample) ? sample : ['A', 'B', 'C', 'D'];
+  }, [t]);
+
+  const sampleOutcomes = useMemo(() => {
+    const sample = t('sampleOutcomes', { returnObjects: true }) as string[];
+    return Array.isArray(sample) ? sample : ['1', '2', '3', '4'];
+  }, [t]);
+
+  const [participantsText, setParticipantsText] = useState(sampleParticipants.join('\n'));
+  const [outcomesText, setOutcomesText] = useState(sampleOutcomes.join('\n'));
+  const participantsId = 'ladder-participants';
+  const outcomesId = 'ladder-outcomes';
+  const [rungCount, setRungCount] = useState(8);
+  const [ladderRows, setLadderRows] = useState<LadderRow[]>([]);
+  const [results, setResults] = useState<{ participant: string; outcome: string }[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const participants = useMemo(() => parseLines(participantsText), [participantsText]);
+  const outcomesRaw = useMemo(() => parseLines(outcomesText), [outcomesText]);
+
+  const normalizedOutcomes = useMemo(() => {
+    if (participants.length === 0) return [];
+    if (outcomesRaw.length >= participants.length) return outcomesRaw.slice(0, participants.length);
+
+    const filled = [...outcomesRaw];
+    for (let i = outcomesRaw.length; i < participants.length; i += 1) {
+      filled.push(t('autoOutcome', { index: i + 1 }));
+    }
+    return filled;
+  }, [participants.length, outcomesRaw, t]);
+
+  useEffect(() => {
+    setResults([]);
+    setLadderRows([]);
+    setError(null);
+  }, [participantsText, outcomesText, rungCount]);
+
+  const handleDraw = () => {
+    if (participants.length < 2) {
+      setError(t('needsParticipants'));
+      return;
+    }
+
+    setError(null);
+    const rows = generateLadderRows(participants.length, rungCount);
+    const mapping = resolveLadderMapping(participants.length, rows);
+
+    const nextResults = participants.map((participant, index) => ({
+      participant,
+      outcome: normalizedOutcomes[mapping[index]] ?? '',
+    }));
+
+    setLadderRows(rows);
+    setResults(nextResults);
+  };
+
+  const handleShuffle = () => {
+    setParticipantsText(shuffle(participants).join('\n'));
+    setOutcomesText(shuffle(outcomesRaw).join('\n'));
+  };
+
+  const handleReset = () => {
+    setParticipantsText(sampleParticipants.join('\n'));
+    setOutcomesText(sampleOutcomes.join('\n'));
+    setRungCount(8);
+  };
+
+  const mismatchNotice =
+    participants.length > 0 && outcomesRaw.length > 0 && participants.length !== outcomesRaw.length;
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge="Daily Helper" />
+
+      <section className={`${SERVICE_PANEL_SOFT} space-y-4 p-4`}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm text-slate-100" htmlFor={participantsId}>
+            <span className="font-semibold">{t('participantsLabel')}</span>
+            <textarea
+              id={participantsId}
+              className="min-h-[160px] w-full rounded-lg border border-white/10 bg-slate-950/40 p-3 text-sm text-slate-100"
+              placeholder={t('participantsPlaceholder')}
+              value={participantsText}
+              onChange={(event) => setParticipantsText(event.target.value)}
+            />
+          </label>
+
+          <label className="space-y-2 text-sm text-slate-100" htmlFor={outcomesId}>
+            <span className="font-semibold">{t('outcomesLabel')}</span>
+            <textarea
+              id={outcomesId}
+              className="min-h-[160px] w-full rounded-lg border border-white/10 bg-slate-950/40 p-3 text-sm text-slate-100"
+              placeholder={t('outcomesPlaceholder')}
+              value={outcomesText}
+              onChange={(event) => setOutcomesText(event.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-[1fr_auto]">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm text-slate-100">
+              <span className="font-semibold">{t('rungCountLabel')}</span>
+              <span className="text-xs text-slate-400">{rungCount}</span>
+            </div>
+            <input
+              className="w-full"
+              type="range"
+              min={3}
+              max={16}
+              value={rungCount}
+              onChange={(event) => setRungCount(Number(event.target.value))}
+            />
+            <p className="text-xs text-slate-400">{t('rungCountHint')}</p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button type="button" className="button px-4" onClick={handleDraw}>
+              {t('drawButton')}
+            </button>
+            <button type="button" className="button-secondary px-4" onClick={handleShuffle}>
+              {t('shuffleButton')}
+            </button>
+            <button type="button" className="button-ghost px-4" onClick={handleReset}>
+              {t('resetButton')}
+            </button>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-rose-300">{error}</p>}
+
+        {mismatchNotice && (
+          <p className="rounded-lg bg-slate-900/60 px-3 py-2 text-xs text-slate-300">
+            {t('mismatchNotice', {
+              participants: participants.length,
+              outcomes: outcomesRaw.length,
+            })}
+          </p>
+        )}
+      </section>
+
+      {results.length > 0 && (
+        <section className={`${SERVICE_PANEL_SOFT} space-y-3 p-4`}>
+          <div className="flex items-center justify-between">
+            <h3 className="text-base font-semibold text-slate-100">{t('resultTitle')}</h3>
+            <span className="text-xs text-slate-400">
+              {t('resultCount', { count: results.length })}
+            </span>
+          </div>
+          <ul className="space-y-2">
+            {results.map((item) => (
+              <li
+                key={`${item.participant}-${item.outcome}`}
+                className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2 text-sm"
+              >
+                <span className="text-slate-100">{item.participant}</span>
+                <span className="font-semibold text-point-2">{item.outcome}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <LadderPreview
+        participants={participants}
+        outcomes={normalizedOutcomes}
+        ladderRows={ladderRows}
+        title={t('previewTitle')}
+      />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/ladder-game/page.tsx
+++ b/src/app/[lng]/(mobile)/ladder-game/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import LadderGame from './components/LadderGame';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'ladder-game' });
+
+export default async function LadderGamePage({ params }: LanguageParams) {
+  const { lng } = await params;
+
+  return <LadderGame lng={lng as Language} />;
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -22,6 +22,7 @@ import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 import cronGenerator from 'assets/locales/ko/cron-generator.json';
 import cssGenerator from 'assets/locales/ko/css-generator.json';
 import slugGenerator from 'assets/locales/ko/slug-generator.json';
+import ladderGame from 'assets/locales/ko/ladder-game.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -50,6 +51,7 @@ declare module 'i18next' {
       'cron-generator': typeof cronGenerator;
       'css-generator': typeof cssGenerator;
       'slug-generator': typeof slugGenerator;
+      'ladder-game': typeof ladderGame;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -14,6 +14,7 @@ import {
   Palette,
   QrCode,
   Server,
+  Shuffle,
   Smile,
   Sparkles,
   TextCursorInput,
@@ -145,6 +146,16 @@ const menus: Menus = {
       },
       icon: <Server />,
       link: '/server-clock',
+    },
+    {
+      title: {
+        ko: '사다리타기',
+        en: 'Ladder Game',
+        ja: 'あみだくじ',
+        zh: '梯子抽签',
+      },
+      icon: <Shuffle />,
+      link: '/ladder-game',
     },
     {
       title: {

--- a/src/assets/locales/en/ladder-game.json
+++ b/src/assets/locales/en/ladder-game.json
@@ -1,0 +1,26 @@
+{
+  "openGraph": {
+    "title": "Ladder Game",
+    "ogTitle": "Ladder Game random draw tool",
+    "description": "Enter participants and outcomes to generate a random ladder draw result."
+  },
+  "title": "Ladder Game",
+  "description": "Add participants and outcomes, then draw a ladder to reveal random matches.",
+  "participantsLabel": "Participants",
+  "participantsPlaceholder": "Enter one name per line",
+  "outcomesLabel": "Outcomes",
+  "outcomesPlaceholder": "Enter one outcome per line",
+  "rungCountLabel": "Number of rungs",
+  "rungCountHint": "Adjust the number to change the ladder complexity.",
+  "drawButton": "Draw ladder",
+  "shuffleButton": "Shuffle inputs",
+  "resetButton": "Reset",
+  "resultTitle": "Draw results",
+  "resultCount": "{{count}} results",
+  "previewTitle": "Ladder preview",
+  "mismatchNotice": "Participants ({{participants}}) and outcomes ({{outcomes}}) do not match. Missing outcomes are auto-filled.",
+  "needsParticipants": "Add at least 2 participants.",
+  "autoOutcome": "Outcome {{index}}",
+  "sampleParticipants": ["Alex", "Sam", "Riley", "Jamie"],
+  "sampleOutcomes": ["Coffee duty", "Lunch treat", "Free pass", "Snack"]
+}

--- a/src/assets/locales/ja/ladder-game.json
+++ b/src/assets/locales/ja/ladder-game.json
@@ -1,0 +1,26 @@
+{
+  "openGraph": {
+    "title": "あみだくじ",
+    "ogTitle": "あみだくじ抽選ツール",
+    "description": "参加者と結果を入力して、ランダムなあみだくじ結果を作成します。"
+  },
+  "title": "あみだくじ",
+  "description": "参加者と結果を入力して、あみだくじでランダムな割り当てを確認しましょう。",
+  "participantsLabel": "参加者",
+  "participantsPlaceholder": "1行に1名ずつ入力してください",
+  "outcomesLabel": "結果",
+  "outcomesPlaceholder": "1行に1つずつ入力してください",
+  "rungCountLabel": "横線の数",
+  "rungCountHint": "数を調整すると難易度が変わります。",
+  "drawButton": "くじを引く",
+  "shuffleButton": "入力をシャッフル",
+  "resetButton": "リセット",
+  "resultTitle": "抽選結果",
+  "resultCount": "{{count}}件の結果",
+  "previewTitle": "あみだくじプレビュー",
+  "mismatchNotice": "参加者（{{participants}}）と結果（{{outcomes}}）の数が一致しません。不足分は自動で補完されます。",
+  "needsParticipants": "参加者は2名以上必要です。",
+  "autoOutcome": "結果 {{index}}",
+  "sampleParticipants": ["さくら", "ゆうき", "はる", "けん"],
+  "sampleOutcomes": ["コーヒー係", "ランチおごり", "免除", "おやつ"]
+}

--- a/src/assets/locales/ko/ladder-game.json
+++ b/src/assets/locales/ko/ladder-game.json
@@ -1,0 +1,26 @@
+{
+  "openGraph": {
+    "title": "사다리타기",
+    "ogTitle": "사다리타기 결과 추첨 도구",
+    "description": "참가자와 결과를 입력하면 랜덤 사다리타기 결과를 만들어 줍니다."
+  },
+  "title": "사다리타기",
+  "description": "참가자와 결과를 입력하고 사다리를 그려 랜덤 매칭을 확인하세요.",
+  "participantsLabel": "참가자",
+  "participantsPlaceholder": "한 줄에 한 명씩 입력하세요",
+  "outcomesLabel": "결과",
+  "outcomesPlaceholder": "한 줄에 한 결과씩 입력하세요",
+  "rungCountLabel": "가로줄 개수",
+  "rungCountHint": "숫자를 조절하면 사다리의 난이도가 바뀝니다.",
+  "drawButton": "사다리 돌리기",
+  "shuffleButton": "입력 섞기",
+  "resetButton": "초기화",
+  "resultTitle": "추첨 결과",
+  "resultCount": "{{count}}명 결과",
+  "previewTitle": "사다리 미리보기",
+  "mismatchNotice": "참가자 {{participants}}명과 결과 {{outcomes}}개가 달라요. 부족한 결과는 자동으로 채워집니다.",
+  "needsParticipants": "참가자는 2명 이상 필요해요.",
+  "autoOutcome": "{{index}}번 결과",
+  "sampleParticipants": ["민지", "서준", "유나", "도현"],
+  "sampleOutcomes": ["커피 당첨", "점심 쏘기", "면제", "간식"]
+}

--- a/src/assets/locales/zh/ladder-game.json
+++ b/src/assets/locales/zh/ladder-game.json
@@ -1,0 +1,26 @@
+{
+  "openGraph": {
+    "title": "梯子抽签",
+    "ogTitle": "梯子抽签随机分配工具",
+    "description": "输入参与者和结果，即可生成随机梯子抽签结果。"
+  },
+  "title": "梯子抽签",
+  "description": "输入参与者与结果，通过梯子随机匹配查看分配情况。",
+  "participantsLabel": "参与者",
+  "participantsPlaceholder": "每行输入一位参与者",
+  "outcomesLabel": "结果",
+  "outcomesPlaceholder": "每行输入一个结果",
+  "rungCountLabel": "横线数量",
+  "rungCountHint": "调整数量可以改变梯子的复杂度。",
+  "drawButton": "开始抽签",
+  "shuffleButton": "打乱输入",
+  "resetButton": "重置",
+  "resultTitle": "抽签结果",
+  "resultCount": "共 {{count}} 项结果",
+  "previewTitle": "梯子预览",
+  "mismatchNotice": "参与者（{{participants}}）与结果（{{outcomes}}）数量不一致，缺少的结果会自动补齐。",
+  "needsParticipants": "请至少输入 2 位参与者。",
+  "autoOutcome": "结果 {{index}}",
+  "sampleParticipants": ["小安", "小李", "小雅", "小杰"],
+  "sampleOutcomes": ["请咖啡", "请午餐", "免除", "零食"]
+}


### PR DESCRIPTION
## Summary
- add ladder game mobile tool with ladder preview and random draw
- add ladder game translations and menu entry
- wire new route metadata

## Testing
- yarn lint
- yarn test (via husky, failed: localStorage.clear is not a function in localStorage.test.ts)