### PR TITLE
feat(tool): add Playback Speed Calculator

### DIFF
--- a/src/app/[lng]/(mobile)/playback-speed/components/PlaybackSpeedCalculator.tsx
+++ b/src/app/[lng]/(mobile)/playback-speed/components/PlaybackSpeedCalculator.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Button } from '@components/basic/Button';
+import { Input } from '@components/basic/Input';
+import { Text } from '@components/basic/Text';
+import { H2, H3 } from '@components/basic/Text/Headers';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import { TimeParts, formatTime, sanitizeNumberInput, toSeconds } from '../utils/time';
+
+const defaultTime: TimeParts = {
+  hours: '',
+  minutes: '',
+  seconds: '',
+};
+
+const speedPresets = ['1', '1.25', '1.5', '2'];
+
+type PlaybackSpeedCalculatorProps = {
+  lng: Language;
+};
+
+function PlaybackSpeedCalculator({ lng }: PlaybackSpeedCalculatorProps) {
+  const { t } = useTranslation(lng, 'playback-speed');
+  const [originalTime, setOriginalTime] = useState<TimeParts>(defaultTime);
+  const [targetTime, setTargetTime] = useState<TimeParts>(defaultTime);
+  const [speed, setSpeed] = useState('1');
+
+  const originalSeconds = useMemo(() => toSeconds(originalTime), [originalTime]);
+  const targetSeconds = useMemo(() => toSeconds(targetTime), [targetTime]);
+
+  const speedValue = useMemo(() => Number(speed), [speed]);
+  const adjustedSeconds = useMemo(() => {
+    if (!originalSeconds || !speedValue || speedValue <= 0) return null;
+    return originalSeconds / speedValue;
+  }, [originalSeconds, speedValue]);
+
+  const requiredSpeed = useMemo(() => {
+    if (!originalSeconds || !targetSeconds) return null;
+    return originalSeconds / targetSeconds;
+  }, [originalSeconds, targetSeconds]);
+
+  const handleTimeChange = (
+    updater: React.Dispatch<React.SetStateAction<TimeParts>>,
+    field: keyof TimeParts,
+    max?: number,
+  ) => {
+    return (event: React.ChangeEvent<HTMLInputElement>) => {
+      updater((prev) => ({
+        ...prev,
+        [field]: sanitizeNumberInput(event.target.value, max),
+      }));
+    };
+  };
+
+  const handleSpeedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.replace(/[^0-9.]/g, '');
+    const normalized = value.startsWith('.') ? `0${value}` : value;
+    const parts = normalized.split('.');
+    const safe = parts.length > 2 ? `${parts[0]}.${parts.slice(1).join('')}` : normalized;
+    setSpeed(safe);
+  };
+
+  const copyText = async (value: string) => {
+    if (!value) return;
+    await navigator.clipboard.writeText(value);
+  };
+
+  const resetAll = () => {
+    setOriginalTime(defaultTime);
+    setTargetTime(defaultTime);
+    setSpeed('1');
+  };
+
+  const displayAdjusted = adjustedSeconds ? formatTime(adjustedSeconds) : '-';
+  const displayRequiredSpeed = requiredSpeed ? `${requiredSpeed.toFixed(2)}x` : '-';
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="space-y-2">
+          <H2>{t('section.adjusted')}</H2>
+          <Text variant="d2" color="basic-4">
+            {t('section.adjustedDescription')}
+          </Text>
+        </div>
+        <div className="mt-4 grid gap-4">
+          <div>
+            <H3 className="mb-2">{t('label.originalDuration')}</H3>
+            <div className="grid grid-cols-3 gap-2">
+              <Input
+                inputMode="numeric"
+                placeholder={t('unit.hours')}
+                value={originalTime.hours}
+                onChange={handleTimeChange(setOriginalTime, 'hours')}
+              />
+              <Input
+                inputMode="numeric"
+                placeholder={t('unit.minutes')}
+                value={originalTime.minutes}
+                onChange={handleTimeChange(setOriginalTime, 'minutes', 59)}
+              />
+              <Input
+                inputMode="numeric"
+                placeholder={t('unit.seconds')}
+                value={originalTime.seconds}
+                onChange={handleTimeChange(setOriginalTime, 'seconds', 59)}
+              />
+            </div>
+          </div>
+          <div>
+            <H3 className="mb-2">{t('label.speed')}</H3>
+            <div className="flex flex-wrap items-center gap-2">
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={speed}
+                onChange={handleSpeedChange}
+                placeholder="1"
+                className="max-w-[140px]"
+              />
+              <div className="flex flex-wrap gap-2">
+                {speedPresets.map((preset) => (
+                  <Button
+                    key={preset}
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setSpeed(preset)}
+                    className={cn(
+                      'h-8 rounded-full px-3 text-sm',
+                      speed === preset && 'border border-point-1',
+                    )}
+                  >
+                    {preset}x
+                  </Button>
+                ))}
+              </div>
+            </div>
+            <Text variant="c1" color="basic-5" className="mt-2">
+              {t('helper.speedRange')}
+            </Text>
+          </div>
+          <div className="rounded-xl bg-gray-50 p-3 dark:bg-gray-800">
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <Text variant="d2" color="basic-4">
+                  {t('label.adjustedResult')}
+                </Text>
+                <Text variant="t3" className="block">
+                  {displayAdjusted}
+                </Text>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => copyText(displayAdjusted)}
+                disabled={displayAdjusted === '-'}
+              >
+                {t('button.copyTime')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="space-y-2">
+          <H2>{t('section.required')}</H2>
+          <Text variant="d2" color="basic-4">
+            {t('section.requiredDescription')}
+          </Text>
+        </div>
+        <div className="mt-4 grid gap-4">
+          <div>
+            <H3 className="mb-2">{t('label.targetDuration')}</H3>
+            <div className="grid grid-cols-3 gap-2">
+              <Input
+                inputMode="numeric"
+                placeholder={t('unit.hours')}
+                value={targetTime.hours}
+                onChange={handleTimeChange(setTargetTime, 'hours')}
+              />
+              <Input
+                inputMode="numeric"
+                placeholder={t('unit.minutes')}
+                value={targetTime.minutes}
+                onChange={handleTimeChange(setTargetTime, 'minutes', 59)}
+              />
+              <Input
+                inputMode="numeric"
+                placeholder={t('unit.seconds')}
+                value={targetTime.seconds}
+                onChange={handleTimeChange(setTargetTime, 'seconds', 59)}
+              />
+            </div>
+            <Text variant="c1" color="basic-5" className="mt-2">
+              {t('helper.requiredSpeed')}
+            </Text>
+          </div>
+          <div className="rounded-xl bg-gray-50 p-3 dark:bg-gray-800">
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <Text variant="d2" color="basic-4">
+                  {t('label.requiredSpeed')}
+                </Text>
+                <Text variant="t3" className="block">
+                  {displayRequiredSpeed}
+                </Text>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => copyText(displayRequiredSpeed)}
+                disabled={displayRequiredSpeed === '-'}
+              >
+                {t('button.copySpeed')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="button" variant="secondary" onClick={resetAll}>
+          {t('button.reset')}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            setOriginalTime({ hours: '1', minutes: '30', seconds: '0' });
+            setTargetTime({ hours: '1', minutes: '0', seconds: '0' });
+            setSpeed('1.5');
+          }}
+        >
+          {t('button.example')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default PlaybackSpeedCalculator;

--- a/src/app/[lng]/(mobile)/playback-speed/page.tsx
+++ b/src/app/[lng]/(mobile)/playback-speed/page.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import PlaybackSpeedCalculator from '~/app/[lng]/(mobile)/playback-speed/components/PlaybackSpeedCalculator';
+import { H1 } from '@components/basic/Text/Headers';
+import { Text } from '@components/basic/Text';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'playback-speed' });
+
+export default async function PlaybackSpeedPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'playback-speed');
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <H1>{t('title')}</H1>
+        <Text variant="d2" color="basic-4">
+          {t('description')}
+        </Text>
+      </header>
+      <PlaybackSpeedCalculator lng={language} />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/playback-speed/utils/time.ts
+++ b/src/app/[lng]/(mobile)/playback-speed/utils/time.ts
@@ -1,0 +1,45 @@
+export type TimeParts = {
+  hours: string;
+  minutes: string;
+  seconds: string;
+};
+
+export const sanitizeNumberInput = (value: string, max?: number) => {
+  if (!value) return '';
+  const sanitized = value.replace(/\D/g, '');
+  if (!sanitized) return '';
+  const parsed = Number(sanitized);
+  if (Number.isNaN(parsed)) return '';
+  if (typeof max === 'number') {
+    return String(Math.min(parsed, max));
+  }
+  return String(parsed);
+};
+
+export const toSeconds = (time: TimeParts) => {
+  const hours = Number(time.hours || 0);
+  const minutes = Number(time.minutes || 0);
+  const seconds = Number(time.seconds || 0);
+
+  const safeHours = Number.isNaN(hours) ? 0 : Math.max(hours, 0);
+  const safeMinutes = Number.isNaN(minutes) ? 0 : Math.max(Math.min(minutes, 59), 0);
+  const safeSeconds = Number.isNaN(seconds) ? 0 : Math.max(Math.min(seconds, 59), 0);
+
+  return safeHours * 3600 + safeMinutes * 60 + safeSeconds;
+};
+
+export const formatTime = (totalSeconds: number) => {
+  const safeSeconds = Math.max(Math.round(totalSeconds), 0);
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const seconds = safeSeconds % 60;
+
+  const paddedMinutes = String(minutes).padStart(2, '0');
+  const paddedSeconds = String(seconds).padStart(2, '0');
+
+  if (hours > 0) {
+    return `${hours}:${paddedMinutes}:${paddedSeconds}`;
+  }
+
+  return `${paddedMinutes}:${paddedSeconds}`;
+};

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -5,11 +5,13 @@ import {
   CalendarClock,
   Code,
   CreditCard,
+  Gauge,
   Github,
   Hash,
   Key,
   Linkedin,
   List,
+  ListChecks,
   MonitorPlay,
   Palette,
   QrCode,
@@ -98,6 +100,16 @@ const menus: Menus = {
     },
     {
       title: {
+        ko: '배속 시간 계산기',
+        en: 'Playback Speed Calculator',
+        ja: '再生速度計算機',
+        zh: '播放速度计算器',
+      },
+      icon: <Gauge />,
+      link: '/playback-speed',
+    },
+    {
+      title: {
         ko: '할일',
         en: 'Todo',
         ja: 'やること',
@@ -105,6 +117,16 @@ const menus: Menus = {
       },
       icon: <List />,
       link: '/todo',
+    },
+    {
+      title: {
+        ko: '리스트 포맷터',
+        en: 'List Formatter',
+        ja: 'リストフォーマッター',
+        zh: '列表格式化',
+      },
+      icon: <ListChecks />,
+      link: '/list-formatter',
     },
     {
       title: {

--- a/src/assets/locales/en/playback-speed.json
+++ b/src/assets/locales/en/playback-speed.json
@@ -1,0 +1,36 @@
+{
+  "title": "Playback Speed Calculator",
+  "description": "Calculate how long a video or audio will take at any speed and find the speed you need to finish by a target time.",
+  "section": {
+    "adjusted": "Adjusted watch time",
+    "adjustedDescription": "Enter the original duration and a playback speed.",
+    "required": "Required speed",
+    "requiredDescription": "Set a target duration to see the speed you need."
+  },
+  "label": {
+    "originalDuration": "Original duration",
+    "speed": "Playback speed",
+    "adjustedResult": "Adjusted duration",
+    "targetDuration": "Target duration",
+    "requiredSpeed": "Required speed"
+  },
+  "unit": {
+    "hours": "Hours",
+    "minutes": "Minutes",
+    "seconds": "Seconds"
+  },
+  "helper": {
+    "speedRange": "Tip: common speeds are 1.25x, 1.5x, and 2x.",
+    "requiredSpeed": "Enter a target duration to calculate the speed."
+  },
+  "button": {
+    "copyTime": "Copy time",
+    "copySpeed": "Copy speed",
+    "reset": "Reset",
+    "example": "Use example"
+  },
+  "openGraph": {
+    "title": "Playback Speed Calculator",
+    "description": "Free playback speed calculator. Convert video duration by speed and find the exact speed needed to finish within a target time."
+  }
+}

--- a/src/assets/locales/ja/playback-speed.json
+++ b/src/assets/locales/ja/playback-speed.json
@@ -1,0 +1,36 @@
+{
+  "title": "再生速度計算機",
+  "description": "再生速度を変えたときの視聴時間を計算し、目標時間に合わせるための速度も確認できます。",
+  "section": {
+    "adjusted": "再生時間の変換",
+    "adjustedDescription": "元の長さと再生速度を入力してください。",
+    "required": "必要な再生速度",
+    "requiredDescription": "目標時間を設定すると必要な速度を表示します。"
+  },
+  "label": {
+    "originalDuration": "元の長さ",
+    "speed": "再生速度",
+    "adjustedResult": "変換後の時間",
+    "targetDuration": "目標時間",
+    "requiredSpeed": "必要な速度"
+  },
+  "unit": {
+    "hours": "時間",
+    "minutes": "分",
+    "seconds": "秒"
+  },
+  "helper": {
+    "speedRange": "よく使われる速度: 1.25x、1.5x、2x",
+    "requiredSpeed": "目標時間を入力すると必要な速度が計算されます。"
+  },
+  "button": {
+    "copyTime": "時間をコピー",
+    "copySpeed": "速度をコピー",
+    "reset": "リセット",
+    "example": "例を入力"
+  },
+  "openGraph": {
+    "title": "再生速度計算機",
+    "description": "無料の再生速度計算機。再生速度ごとの視聴時間と、目標時間に必要な速度をすぐに計算できます。"
+  }
+}

--- a/src/assets/locales/ko/playback-speed.json
+++ b/src/assets/locales/ko/playback-speed.json
@@ -1,0 +1,36 @@
+{
+  "title": "배속 시간 계산기",
+  "description": "영상/오디오를 배속으로 재생할 때 걸리는 시간을 계산하고, 목표 시간에 맞추기 위한 배속을 확인하세요.",
+  "section": {
+    "adjusted": "배속 적용 시간",
+    "adjustedDescription": "원본 길이와 배속을 입력하면 새로운 재생 시간을 계산합니다.",
+    "required": "필요 배속",
+    "requiredDescription": "목표 시간을 입력하면 필요한 배속을 계산합니다."
+  },
+  "label": {
+    "originalDuration": "원본 길이",
+    "speed": "재생 배속",
+    "adjustedResult": "배속 적용 결과",
+    "targetDuration": "목표 시간",
+    "requiredSpeed": "필요 배속"
+  },
+  "unit": {
+    "hours": "시간",
+    "minutes": "분",
+    "seconds": "초"
+  },
+  "helper": {
+    "speedRange": "자주 쓰는 배속: 1.25x, 1.5x, 2x",
+    "requiredSpeed": "목표 시간을 입력하면 필요한 배속이 계산됩니다."
+  },
+  "button": {
+    "copyTime": "시간 복사",
+    "copySpeed": "배속 복사",
+    "reset": "초기화",
+    "example": "예시 입력"
+  },
+  "openGraph": {
+    "title": "배속 시간 계산기",
+    "description": "무료 배속 시간 계산기. 배속에 따른 재생 시간을 계산하고 목표 시간에 맞는 배속을 확인하세요."
+  }
+}

--- a/src/assets/locales/zh/playback-speed.json
+++ b/src/assets/locales/zh/playback-speed.json
@@ -1,0 +1,36 @@
+{
+  "title": "播放速度计算器",
+  "description": "计算不同播放速度下的观看时间，并找出在目标时间内完成所需的速度。",
+  "section": {
+    "adjusted": "速度换算时间",
+    "adjustedDescription": "输入原始时长和播放速度即可计算新时长。",
+    "required": "所需速度",
+    "requiredDescription": "设置目标时长后即可得到所需速度。"
+  },
+  "label": {
+    "originalDuration": "原始时长",
+    "speed": "播放速度",
+    "adjustedResult": "换算后的时长",
+    "targetDuration": "目标时长",
+    "requiredSpeed": "所需速度"
+  },
+  "unit": {
+    "hours": "小时",
+    "minutes": "分钟",
+    "seconds": "秒"
+  },
+  "helper": {
+    "speedRange": "常用速度：1.25x、1.5x、2x",
+    "requiredSpeed": "输入目标时长即可计算所需速度。"
+  },
+  "button": {
+    "copyTime": "复制时间",
+    "copySpeed": "复制速度",
+    "reset": "重置",
+    "example": "填入示例"
+  },
+  "openGraph": {
+    "title": "播放速度计算器",
+    "description": "免费的播放速度计算器。快速计算不同速度下的观看时间，并找出目标时长所需的速度。"
+  }
+}


### PR DESCRIPTION
## Summary\n- add playback speed calculator tool for watch-time conversions\n- compute adjusted duration from speed and required speed for target time\n- include presets, copy actions, and example reset\n- add i18n namespace: playback-speed (ko/en/ja/zh)\n\n## Testing\n- 
/home/openclaw/.openclaw/workspace/okdohyuk-front/src/app/[lng]/(mobile)/list-formatter/page.tsx
  7:33  error  Missing file extension for "~/app/[lng]/(mobile)/list-formatter/components/ListFormatterClient"  import/extensions

/home/openclaw/.openclaw/workspace/okdohyuk-front/src/app/api/monitoring/route.ts
  32:5  warning  Unexpected console statement  no-console

✖ 2 problems (1 error, 1 warning) **failed** (existing lint errors in list-formatter tool and prettier formatting)\n-  **failed** (localStorage.clear is not a function in src/utils/__tests__/localStorage.test.ts)\n