### PR TITLE
feat: add word counter mobile tool

### DIFF
--- a/src/app/[lng]/(mobile)/word-counter/components/WordCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/word-counter/components/WordCounterClient.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Textarea } from '@components/basic/Textarea';
+import { Button } from '@components/basic/Button';
+import { RotateCcw, Sparkles } from 'lucide-react';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+import ServiceInfoNotice from '@components/complex/Service/ServiceInfoNotice';
+
+interface WordCounterClientProps {
+  lng: Language;
+}
+
+export default function WordCounterClient({ lng }: WordCounterClientProps) {
+  const { t } = useTranslation(lng, 'word-counter');
+  const [value, setValue] = useState('');
+
+  const stats = useMemo(() => {
+    if (!value) {
+      return {
+        words: 0,
+        characters: 0,
+        charactersNoSpaces: 0,
+        lines: 0,
+      };
+    }
+
+    const words = value.trim() ? value.trim().split(/\s+/).filter(Boolean).length : 0;
+    const characters = value.length;
+    const charactersNoSpaces = value.replace(/\s/g, '').length;
+    const lines = value.split(/\r\n|\r|\n/).length;
+
+    return {
+      words,
+      characters,
+      charactersNoSpaces,
+      lines,
+    };
+  }, [value]);
+
+  const handleReset = () => {
+    setValue('');
+  };
+
+  const statItems = [
+    { key: 'words', value: stats.words, label: t('stats.words') },
+    { key: 'characters', value: stats.characters, label: t('stats.characters') },
+    {
+      key: 'charactersNoSpaces',
+      value: stats.charactersNoSpaces,
+      label: t('stats.charactersNoSpaces'),
+    },
+    { key: 'lines', value: stats.lines, label: t('stats.lines') },
+  ];
+
+  return (
+    <div className="w-full space-y-6">
+      <div className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor="word-counter-input"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {t('label.input')}
+          </label>
+          <Button
+            type="button"
+            onClick={handleReset}
+            className="flex items-center gap-2 px-3 py-2 text-xs"
+            disabled={!value}
+          >
+            <RotateCcw size={14} />
+            {t('button.reset')}
+          </Button>
+        </div>
+        <Textarea
+          id="word-counter-input"
+          className="min-h-[160px] text-sm"
+          placeholder={t('placeholder')}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+      </div>
+
+      <ServiceInfoNotice icon={<Sparkles className="h-5 w-5" />}>{t('notice')}</ServiceInfoNotice>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {statItems.map((item) => (
+          <div
+            key={item.key}
+            className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'flex flex-col gap-2 p-4')}
+          >
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {item.label}
+            </span>
+            <span className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              {item.value.toLocaleString()}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/word-counter/page.tsx
+++ b/src/app/[lng]/(mobile)/word-counter/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+import WordCounterClient from '~/app/[lng]/(mobile)/word-counter/components/WordCounterClient';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'word-counter' });
+
+export default async function WordCounterPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+
+  const { t } = await getTranslations(language, 'word-counter');
+
+  return (
+    <div className="space-y-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge="Text Meter" />
+      <WordCounterClient lng={language} />
+    </div>
+  );
+}

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Backpack,
   Bomb,
   Calculator,
   CalendarClock,
@@ -18,6 +19,7 @@ import {
   Sparkles,
   TextCursorInput,
   Tv,
+  Type,
   Youtube,
 } from 'lucide-react';
 import { Language } from '~/app/i18n/settings';
@@ -95,6 +97,16 @@ const menus: Menus = {
       },
       icon: <Calculator />,
       link: '/percent',
+    },
+    {
+      title: {
+        ko: '단어 카운터',
+        en: 'Word Counter',
+        ja: 'ワードカウンター',
+        zh: '字数统计',
+      },
+      icon: <Type />,
+      link: '/word-counter',
     },
     {
       title: {

--- a/src/assets/locales/en/word-counter.json
+++ b/src/assets/locales/en/word-counter.json
@@ -1,0 +1,22 @@
+{
+  "title": "Word Counter",
+  "description": "Count words, characters, and lines instantly while you type.",
+  "label": {
+    "input": "Text"
+  },
+  "placeholder": "Paste or type your text here...",
+  "button": {
+    "reset": "Reset"
+  },
+  "notice": "Counts update locally in your browser. No text is stored.",
+  "stats": {
+    "words": "Words",
+    "characters": "Characters",
+    "charactersNoSpaces": "Characters (no spaces)",
+    "lines": "Lines"
+  },
+  "openGraph": {
+    "title": "Word Counter",
+    "description": "Instantly count words, characters, and lines in your text."
+  }
+}

--- a/src/assets/locales/ja/word-counter.json
+++ b/src/assets/locales/ja/word-counter.json
@@ -1,0 +1,22 @@
+{
+  "title": "ワードカウンター",
+  "description": "入力したテキストの単語数・文字数・行数をすぐに計算します。",
+  "label": {
+    "input": "テキスト"
+  },
+  "placeholder": "ここにテキストを入力または貼り付けてください...",
+  "button": {
+    "reset": "リセット"
+  },
+  "notice": "計算はブラウザ内で完結します。テキストは保存されません。",
+  "stats": {
+    "words": "単語数",
+    "characters": "文字数",
+    "charactersNoSpaces": "空白除外文字数",
+    "lines": "行数"
+  },
+  "openGraph": {
+    "title": "ワードカウンター",
+    "description": "テキストの単語数・文字数・行数を瞬時にカウントします。"
+  }
+}

--- a/src/assets/locales/ko/word-counter.json
+++ b/src/assets/locales/ko/word-counter.json
@@ -1,0 +1,22 @@
+{
+  "title": "단어 카운터",
+  "description": "입력한 텍스트의 단어, 문자, 줄 수를 즉시 계산합니다.",
+  "label": {
+    "input": "텍스트"
+  },
+  "placeholder": "여기에 텍스트를 입력하거나 붙여넣으세요...",
+  "button": {
+    "reset": "초기화"
+  },
+  "notice": "모든 계산은 브라우저에서만 진행됩니다. 텍스트는 저장되지 않습니다.",
+  "stats": {
+    "words": "단어 수",
+    "characters": "문자 수",
+    "charactersNoSpaces": "공백 제외 문자 수",
+    "lines": "줄 수"
+  },
+  "openGraph": {
+    "title": "단어 카운터",
+    "description": "텍스트의 단어, 문자, 줄 수를 즉시 계산하세요."
+  }
+}

--- a/src/assets/locales/zh/word-counter.json
+++ b/src/assets/locales/zh/word-counter.json
@@ -1,0 +1,22 @@
+{
+  "title": "字数统计",
+  "description": "即时统计输入文本的单词数、字符数和行数。",
+  "label": {
+    "input": "文本"
+  },
+  "placeholder": "在此输入或粘贴文本...",
+  "button": {
+    "reset": "重置"
+  },
+  "notice": "统计在浏览器内完成，不会保存文本。",
+  "stats": {
+    "words": "单词数",
+    "characters": "字符数",
+    "charactersNoSpaces": "去空格字符数",
+    "lines": "行数"
+  },
+  "openGraph": {
+    "title": "字数统计",
+    "description": "快速统计文本的单词数、字符数和行数。"
+  }
+}


### PR DESCRIPTION
## Summary\n- add a word counter mobile tool with live stats and reset\n- add translations for ko/en/ja/zh\n- register the tool in the mobile menu\n\n## Testing\n- yarn test (fails: src/utils/__tests__/localStorage.test.ts — localStorage.clear is not a function)