### PR TITLE
feat(tool): add markdown previewer

### DIFF
--- a/src/app/[lng]/(mobile)/markdown-previewer/components/MarkdownPreviewer.tsx
+++ b/src/app/[lng]/(mobile)/markdown-previewer/components/MarkdownPreviewer.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import MarkdownTransJSX from 'markdown-to-jsx';
+import { Button } from '@components/basic/Button';
+import { Textarea } from '@components/basic/Textarea';
+import Link from '@components/basic/Link';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import { cn } from '@utils/cn';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+
+interface MarkdownPreviewerProps {
+  lng: Language;
+}
+
+export default function MarkdownPreviewer({ lng }: MarkdownPreviewerProps) {
+  const { t } = useTranslation(lng, 'markdown-previewer');
+  const [content, setContent] = useState('');
+
+  const stats = useMemo(() => {
+    const trimmed = content.trim();
+    const words = trimmed ? trimmed.split(/\s+/).length : 0;
+    const characters = content.length;
+    const charactersNoSpaces = content.replace(/\s/g, '').length;
+    const lines = content ? content.split(/\n/).length : 0;
+
+    return {
+      words,
+      characters,
+      charactersNoSpaces,
+      lines,
+    };
+  }, [content]);
+
+  const handleSample = () => {
+    setContent(t('sample'));
+  };
+
+  const handleClear = () => {
+    setContent('');
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
+        <label
+          htmlFor="markdown-input"
+          className="text-sm font-semibold text-zinc-700 dark:text-zinc-200"
+        >
+          {t('label.input')}
+        </label>
+        <Textarea
+          id="markdown-input"
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          placeholder={t('placeholder')}
+          className="min-h-[180px] font-mono text-sm"
+        />
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">{t('helper')}</p>
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={handleSample} className="px-4 py-2 text-sm">
+            {t('button.sample')}
+          </Button>
+          <Button
+            onClick={handleClear}
+            className="px-4 py-2 text-sm bg-zinc-200 text-zinc-900 hover:bg-zinc-300 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:bg-zinc-700"
+          >
+            {t('button.clear')}
+          </Button>
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs text-zinc-600 dark:text-zinc-300 sm:grid-cols-4">
+          <div className="rounded-lg bg-white/70 p-2 text-center font-semibold shadow-sm dark:bg-zinc-900/60">
+            <div className="text-[10px] uppercase text-zinc-400">{t('stats.words')}</div>
+            <div>{stats.words}</div>
+          </div>
+          <div className="rounded-lg bg-white/70 p-2 text-center font-semibold shadow-sm dark:bg-zinc-900/60">
+            <div className="text-[10px] uppercase text-zinc-400">{t('stats.characters')}</div>
+            <div>{stats.characters}</div>
+          </div>
+          <div className="rounded-lg bg-white/70 p-2 text-center font-semibold shadow-sm dark:bg-zinc-900/60">
+            <div className="text-[10px] uppercase text-zinc-400">{t('stats.noSpaces')}</div>
+            <div>{stats.charactersNoSpaces}</div>
+          </div>
+          <div className="rounded-lg bg-white/70 p-2 text-center font-semibold shadow-sm dark:bg-zinc-900/60">
+            <div className="text-[10px] uppercase text-zinc-400">{t('stats.lines')}</div>
+            <div>{stats.lines}</div>
+          </div>
+        </div>
+      </section>
+
+      <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'p-4')}>
+        <h3 className="mb-3 text-sm font-semibold text-zinc-800 dark:text-zinc-100">
+          {t('label.preview')}
+        </h3>
+        {content ? (
+          <MarkdownTransJSX
+            className="prose prose-zinc dark:prose-invert max-w-none"
+            options={{
+              forceBlock: true,
+              overrides: {
+                a: {
+                  component: Link,
+                  props: {
+                    hasTargetBlank: true,
+                  },
+                },
+              },
+            }}
+          >
+            {content}
+          </MarkdownTransJSX>
+        ) : (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">{t('empty')}</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/markdown-previewer/page.tsx
+++ b/src/app/[lng]/(mobile)/markdown-previewer/page.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language } from '~/app/i18n/settings';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+import MarkdownPreviewer from '~/app/[lng]/(mobile)/markdown-previewer/components/MarkdownPreviewer';
+
+export const generateMetadata: GenerateMetadata = async ({ params }) => {
+  return translationsMetadata({
+    params,
+    ns: 'markdown-previewer',
+  });
+};
+
+export default async function MarkdownPreviewerPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'markdown-previewer');
+
+  return (
+    <div className="space-y-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge={t('badge')} />
+      <MarkdownPreviewer lng={language} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -22,6 +22,7 @@ import jwtDecoder from 'assets/locales/ko/jwt-decoder.json';
 import cronGenerator from 'assets/locales/ko/cron-generator.json';
 import cssGenerator from 'assets/locales/ko/css-generator.json';
 import slugGenerator from 'assets/locales/ko/slug-generator.json';
+import markdownPreviewer from 'assets/locales/ko/markdown-previewer.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -50,6 +51,7 @@ declare module 'i18next' {
       'cron-generator': typeof cronGenerator;
       'css-generator': typeof cssGenerator;
       'slug-generator': typeof slugGenerator;
+      'markdown-previewer': typeof markdownPreviewer;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -5,6 +5,7 @@ import {
   CalendarClock,
   Code,
   CreditCard,
+  FileText,
   Github,
   Hash,
   Key,
@@ -75,6 +76,16 @@ const menus: Menus = {
       },
       icon: <Palette />,
       link: '/css-generator',
+    },
+    {
+      title: {
+        ko: '마크다운 미리보기',
+        en: 'Markdown Previewer',
+        ja: 'Markdownプレビュー',
+        zh: 'Markdown 预览器',
+      },
+      icon: <FileText />,
+      link: '/markdown-previewer',
     },
     {
       title: {

--- a/src/assets/locales/en/markdown-previewer.json
+++ b/src/assets/locales/en/markdown-previewer.json
@@ -1,0 +1,27 @@
+{
+  "title": "Markdown Previewer",
+  "description": "Preview Markdown as you type with quick stats.",
+  "badge": "Markdown Utility",
+  "label": {
+    "input": "Markdown input",
+    "preview": "Live preview"
+  },
+  "placeholder": "Type Markdown here...",
+  "helper": "Paste your Markdown and see the rendered result instantly.",
+  "button": {
+    "sample": "Load sample",
+    "clear": "Clear"
+  },
+  "stats": {
+    "words": "Words",
+    "characters": "Chars",
+    "noSpaces": "Chars (no spaces)",
+    "lines": "Lines"
+  },
+  "empty": "Enter Markdown to see the preview.",
+  "sample": "# Markdown Preview\n\n**Quick tips**\n- Use # for headings\n- Use **bold** for emphasis\n- Add [links](https://okdohyuk.dev)\n\n```js\nconsole.log('Hello, Markdown!');\n```",
+  "openGraph": {
+    "title": "Markdown Previewer",
+    "description": "Live preview your Markdown with instant stats."
+  }
+}

--- a/src/assets/locales/ja/markdown-previewer.json
+++ b/src/assets/locales/ja/markdown-previewer.json
@@ -1,0 +1,27 @@
+{
+  "title": "Markdownプレビュー",
+  "description": "Markdownを入力すると即座にプレビューできます。",
+  "badge": "Markdown ツール",
+  "label": {
+    "input": "Markdown入力",
+    "preview": "ライブプレビュー"
+  },
+  "placeholder": "Markdownを入力してください...",
+  "helper": "Markdownを貼り付けるとすぐにレンダリング結果が表示されます。",
+  "button": {
+    "sample": "サンプルを読み込む",
+    "clear": "クリア"
+  },
+  "stats": {
+    "words": "単語",
+    "characters": "文字",
+    "noSpaces": "空白除外",
+    "lines": "行"
+  },
+  "empty": "Markdownを入力するとプレビューが表示されます。",
+  "sample": "# Markdownプレビュー\n\n**クイックヒント**\n- # で見出しを作成\n- **太字**で強調\n- [リンク](https://okdohyuk.dev)を追加\n\n```js\nconsole.log('こんにちは、Markdown!');\n```",
+  "openGraph": {
+    "title": "Markdownプレビュー",
+    "description": "Markdownを入力してすぐにプレビュー。"
+  }
+}

--- a/src/assets/locales/ko/markdown-previewer.json
+++ b/src/assets/locales/ko/markdown-previewer.json
@@ -1,0 +1,27 @@
+{
+  "title": "마크다운 미리보기",
+  "description": "마크다운을 입력하면 즉시 렌더링 결과를 확인할 수 있습니다.",
+  "badge": "Markdown 도구",
+  "label": {
+    "input": "마크다운 입력",
+    "preview": "실시간 미리보기"
+  },
+  "placeholder": "여기에 마크다운을 입력하세요...",
+  "helper": "마크다운을 붙여 넣으면 바로 렌더링 결과를 보여줍니다.",
+  "button": {
+    "sample": "샘플 불러오기",
+    "clear": "지우기"
+  },
+  "stats": {
+    "words": "단어",
+    "characters": "문자",
+    "noSpaces": "공백 제외",
+    "lines": "줄"
+  },
+  "empty": "마크다운을 입력하면 미리보기가 표시됩니다.",
+  "sample": "# 마크다운 미리보기\n\n**빠른 팁**\n- #으로 제목을 만들어요\n- **굵게**로 강조할 수 있어요\n- [링크](https://okdohyuk.dev)를 추가해 보세요\n\n```js\nconsole.log('안녕하세요, Markdown!');\n```",
+  "openGraph": {
+    "title": "마크다운 미리보기",
+    "description": "마크다운을 입력하면 즉시 미리볼 수 있습니다."
+  }
+}

--- a/src/assets/locales/zh/markdown-previewer.json
+++ b/src/assets/locales/zh/markdown-previewer.json
@@ -1,0 +1,27 @@
+{
+  "title": "Markdown 预览器",
+  "description": "输入 Markdown 即可实时预览并查看统计。",
+  "badge": "Markdown 工具",
+  "label": {
+    "input": "Markdown 输入",
+    "preview": "实时预览"
+  },
+  "placeholder": "在这里输入 Markdown...",
+  "helper": "粘贴 Markdown 后即可立即看到渲染结果。",
+  "button": {
+    "sample": "加载示例",
+    "clear": "清空"
+  },
+  "stats": {
+    "words": "单词",
+    "characters": "字符",
+    "noSpaces": "不含空格",
+    "lines": "行"
+  },
+  "empty": "输入 Markdown 即可显示预览。",
+  "sample": "# Markdown 预览\n\n**快速提示**\n- 使用 # 创建标题\n- 用 **粗体** 强调\n- 添加 [链接](https://okdohyuk.dev)\n\n```js\nconsole.log('你好，Markdown!');\n```",
+  "openGraph": {
+    "title": "Markdown 预览器",
+    "description": "实时预览 Markdown，并查看统计。"
+  }
+}


### PR DESCRIPTION
## Summary
- add markdown previewer mobile tool page with live stats and preview
- add menu entry for markdown previewer
- add i18n strings and namespace typings

## Testing
- yarn lint
- yarn test (fails: localStorage.clear is not a function)
- yarn build (fails: prerender /ko/auth/login invalid URL)
