### PR TITLE
도구 추가: 기념일 D-day 카운터(anniversary-counter)

### DIFF
--- a/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Clipboard, ClipboardCheck, RotateCcw } from 'lucide-react';
+import { Input } from '@components/basic/Input';
+import { Button } from '@components/basic/Button';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import {
+  SERVICE_CARD_INTERACTIVE,
+  SERVICE_PANEL_SOFT,
+} from '@components/complex/Service/interactiveStyles';
+import { addDays, calculateDDay, formatDateInput } from '../utils/anniversaryCounter';
+
+interface AnniversaryCounterClientProps {
+  lng: Language;
+}
+
+export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClientProps) {
+  const { t } = useTranslation(lng, 'anniversary-counter');
+  const [date, setDate] = useState('');
+  const [includeToday, setIncludeToday] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const today = new Date();
+
+  const getLabel = (diffDays: number) => {
+    if (diffDays === 0) return t('result.dday');
+    if (diffDays > 0) return t('result.ddayMinus', { count: diffDays });
+    return t('result.ddayPlus', { count: Math.abs(diffDays) });
+  };
+
+  const getStatusText = (diffDays: number) => {
+    if (diffDays === 0) return t('result.today');
+    if (diffDays > 0) return t('result.daysLeft', { count: diffDays });
+    return t('result.daysPassed', { count: Math.abs(diffDays) });
+  };
+
+  const calculation = calculateDDay({
+    targetDateInput: date,
+    baseDate: today,
+    includeToday,
+  });
+
+  const result = calculation
+    ? {
+        diffDays: calculation.diffDays,
+        label: getLabel(calculation.diffDays),
+        statusText: getStatusText(calculation.statusDiffDays),
+        targetDate: calculation.targetDate,
+      }
+    : null;
+
+  const formattedTargetDate = result ? new Intl.DateTimeFormat(lng).format(result.targetDate) : '-';
+
+  const formattedTodayDate = new Intl.DateTimeFormat(lng).format(today);
+
+  useEffect(() => {
+    setCopied(false);
+  }, [date, includeToday]);
+
+  const handleQuickDate = (amount: number) => {
+    const next = formatDateInput(addDays(new Date(), amount));
+    setDate(next);
+  };
+
+  const handleReset = () => {
+    setDate('');
+    setIncludeToday(true);
+    setCopied(false);
+  };
+
+  const handleCopy = async () => {
+    if (!result) return;
+    try {
+      const formattedTarget = new Intl.DateTimeFormat(lng, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }).format(result.targetDate);
+
+      const copyText = t('result.copyText', {
+        label: result.label,
+        status: result.statusText,
+        date: formattedTarget,
+      });
+
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to copy result:', error);
+    }
+  };
+
+  return (
+    <div className="w-full space-y-6">
+      <div className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-4')}>
+        <div className="space-y-2">
+          <label
+            htmlFor="anniversary-date"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {t('label.date')}
+          </label>
+          <Input
+            id="anniversary-date"
+            type="date"
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400">{t('helper')}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+          <input
+            id="include-today"
+            type="checkbox"
+            className="h-4 w-4 rounded border-gray-300 text-point-2 focus:ring-point-1"
+            checked={includeToday}
+            onChange={(event) => setIncludeToday(event.target.checked)}
+          />
+          <label htmlFor="include-today" className="text-sm font-medium">
+            {t('label.includeToday')}
+          </label>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs text-gray-500 dark:text-gray-400">{t('label.quick')}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" className="px-3 py-2 text-xs" onClick={() => handleQuickDate(0)}>
+              {t('button.today')}
+            </Button>
+            <Button type="button" className="px-3 py-2 text-xs" onClick={() => handleQuickDate(7)}>
+              {t('button.week')}
+            </Button>
+            <Button
+              type="button"
+              className="px-3 py-2 text-xs"
+              onClick={() => handleQuickDate(100)}
+            >
+              {t('button.hundred')}
+            </Button>
+            <Button
+              type="button"
+              className="px-3 py-2 text-xs"
+              onClick={handleReset}
+              disabled={!date && includeToday}
+            >
+              <RotateCcw size={14} className="mr-1" />
+              {t('button.reset')}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-4 p-4')}>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('label.result')}
+            </p>
+            <p className="text-3xl font-semibold text-gray-900 dark:text-white">
+              {result ? result.label : t('result.empty')}
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center gap-2 px-3 py-2 text-xs"
+            disabled={!result}
+          >
+            {copied ? <ClipboardCheck size={16} /> : <Clipboard size={16} />}
+            {copied ? t('button.copied') : t('button.copy')}
+          </Button>
+        </div>
+
+        <div className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
+          <p>{result ? result.statusText : t('result.empty')}</p>
+          <div className="flex flex-wrap gap-3 text-xs text-gray-500 dark:text-gray-400">
+            <span>
+              {t('result.targetDate')}: {formattedTargetDate}
+            </span>
+            <span>
+              {t('result.todayDate')}: {formattedTodayDate}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/anniversary-counter/page.tsx
+++ b/src/app/[lng]/(mobile)/anniversary-counter/page.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import AnniversaryCounterClient from '~/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient';
+import { H1, Text } from '@components/basic/Text';
+import { getTranslations } from '~/app/i18n';
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language, languages } from '~/app/i18n/settings';
+
+export async function generateStaticParams() {
+  return languages.map((lng) => ({ lng }));
+}
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'anniversary-counter' });
+
+export default async function AnniversaryCounterPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'anniversary-counter');
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <H1>{t('title')}</H1>
+        <Text className="text-sm text-gray-600 dark:text-gray-300">{t('description')}</Text>
+      </div>
+      <AnniversaryCounterClient lng={language} />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/anniversary-counter/utils/__tests__/anniversaryCounter.test.ts
+++ b/src/app/[lng]/(mobile)/anniversary-counter/utils/__tests__/anniversaryCounter.test.ts
@@ -1,0 +1,81 @@
+import { addDays, calculateDDay, formatDateInput, parseDateInput } from '../anniversaryCounter';
+
+describe('anniversaryCounter', () => {
+  const baseDate = new Date(2026, 2, 8, 15, 30);
+
+  it('parses a date input string as a local calendar date', () => {
+    const parsed = parseDateInput('2026-03-08');
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.getFullYear()).toBe(2026);
+    expect(parsed?.getMonth()).toBe(2);
+    expect(parsed?.getDate()).toBe(8);
+  });
+
+  it('returns null for an invalid date input string', () => {
+    expect(parseDateInput('2026-02-29')).toBeNull();
+    expect(parseDateInput('invalid-date')).toBeNull();
+  });
+
+  it('keeps today as D-Day even when includeToday is enabled', () => {
+    const result = calculateDDay({
+      targetDateInput: '2026-03-08',
+      baseDate,
+      includeToday: true,
+    });
+
+    expect(result).toEqual({
+      diffDays: 0,
+      statusDiffDays: 0,
+      targetDate: new Date(2026, 2, 8),
+    });
+  });
+
+  it('counts future dates without including today', () => {
+    const result = calculateDDay({
+      targetDateInput: '2026-03-09',
+      baseDate,
+      includeToday: false,
+    });
+
+    expect(result?.diffDays).toBe(1);
+    expect(result?.statusDiffDays).toBe(1);
+  });
+
+  it('keeps D-Day labels based on the actual calendar gap', () => {
+    const result = calculateDDay({
+      targetDateInput: '2026-03-09',
+      baseDate,
+      includeToday: true,
+    });
+
+    expect(result?.diffDays).toBe(1);
+  });
+
+  it('counts status text with today included', () => {
+    const result = calculateDDay({
+      targetDateInput: '2026-03-09',
+      baseDate,
+      includeToday: true,
+    });
+
+    expect(result?.statusDiffDays).toBe(2);
+  });
+
+  it('counts past dates including today', () => {
+    const result = calculateDDay({
+      targetDateInput: '2026-03-07',
+      baseDate,
+      includeToday: true,
+    });
+
+    expect(result?.diffDays).toBe(-1);
+    expect(result?.statusDiffDays).toBe(-2);
+  });
+
+  it('formats and offsets quick dates consistently', () => {
+    const nextWeek = addDays(baseDate, 7);
+
+    expect(formatDateInput(nextWeek)).toBe('2026-03-15');
+  });
+});

--- a/src/app/[lng]/(mobile)/anniversary-counter/utils/anniversaryCounter.ts
+++ b/src/app/[lng]/(mobile)/anniversary-counter/utils/anniversaryCounter.ts
@@ -1,0 +1,78 @@
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+const DATE_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const getCalendarDayNumber = (date: Date) =>
+  Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / MS_PER_DAY);
+
+export const parseDateInput = (value: string): Date | null => {
+  if (!DATE_INPUT_PATTERN.test(value)) {
+    return null;
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  const parsed = new Date(year, month - 1, day);
+
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== month - 1 ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+};
+
+export const formatDateInput = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+export const addDays = (date: Date, amount: number) => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + amount);
+  return next;
+};
+
+type CalculateDDayOptions = {
+  targetDateInput: string;
+  baseDate?: Date;
+  includeToday?: boolean;
+};
+
+type DDayCalculation = {
+  diffDays: number;
+  statusDiffDays: number;
+  targetDate: Date;
+};
+
+export const calculateDDay = ({
+  targetDateInput,
+  baseDate = new Date(),
+  includeToday = true,
+}: CalculateDDayOptions): DDayCalculation | null => {
+  const targetDate = parseDateInput(targetDateInput);
+
+  if (!targetDate) {
+    return null;
+  }
+
+  const diffDays = getCalendarDayNumber(targetDate) - getCalendarDayNumber(baseDate);
+  let statusDiffDays = diffDays;
+
+  if (includeToday && statusDiffDays !== 0) {
+    statusDiffDays += statusDiffDays > 0 ? 1 : -1;
+  }
+
+  return {
+    diffDays,
+    statusDiffDays,
+    targetDate,
+  };
+};
+
+export type { DDayCalculation, CalculateDDayOptions };

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -42,6 +42,7 @@ import jsonYamlConverter from 'assets/locales/ko/json-yaml-converter.json';
 import koreanAmount from 'assets/locales/ko/korean-amount.json';
 import bedtimePlanner from 'assets/locales/ko/bedtime-planner.json';
 import dataSizeConverter from 'assets/locales/ko/data-size-converter.json';
+import anniversaryCounter from 'assets/locales/ko/anniversary-counter.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -90,6 +91,7 @@ declare module 'i18next' {
       'korean-amount': typeof koreanAmount;
       'bedtime-planner': typeof bedtimePlanner;
       'data-size-converter': typeof dataSizeConverter;
+      'anniversary-counter': typeof anniversaryCounter;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -4,6 +4,7 @@ import {
   Bomb,
   Calculator,
   CalendarClock,
+  CalendarDays,
   Code,
   Coins,
   CreditCard,
@@ -352,6 +353,16 @@ const menus: Menus = {
       },
       icon: <HardDrive />,
       link: '/data-size-converter',
+    },
+    {
+      title: {
+        ko: '기념일 D-day 카운터',
+        en: 'Anniversary D-Day Counter',
+        ja: '記念日D-Dayカウンター',
+        zh: '纪念日 D-Day 计数器',
+      },
+      icon: <CalendarDays />,
+      link: '/anniversary-counter',
     },
     {
       title: {

--- a/src/assets/locales/en/anniversary-counter.json
+++ b/src/assets/locales/en/anniversary-counter.json
@@ -1,0 +1,35 @@
+{
+  "title": "Anniversary D-Day Counter",
+  "description": "Calculate days remaining or elapsed and copy the D-Day label in one tap.",
+  "label": {
+    "date": "Target date",
+    "includeToday": "Include today",
+    "quick": "Quick set",
+    "result": "Result"
+  },
+  "helper": "Pick a date to calculate the D-Day automatically.",
+  "button": {
+    "today": "Today",
+    "week": "In 1 week",
+    "hundred": "In 100 days",
+    "reset": "Reset",
+    "copy": "Copy result",
+    "copied": "Copied"
+  },
+  "result": {
+    "empty": "Select a date to see the result.",
+    "dday": "D-Day",
+    "ddayMinus": "D-{{count}}",
+    "ddayPlus": "D+{{count}}",
+    "daysLeft": "{{count}} days left",
+    "daysPassed": "{{count}} days passed",
+    "today": "Today is the D-Day.",
+    "targetDate": "Target date",
+    "todayDate": "Today",
+    "copyText": "{{label}} · {{status}} · {{date}}"
+  },
+  "openGraph": {
+    "title": "Anniversary D-Day Counter",
+    "description": "Track the exact number of days until or since an anniversary, trip, exam, launch, or deadline with an accurate D-Day counter. Toggle inclusive counting, jump to common target dates, and copy the final result for messages, notes, or social posts."
+  }
+}

--- a/src/assets/locales/ja/anniversary-counter.json
+++ b/src/assets/locales/ja/anniversary-counter.json
@@ -1,0 +1,35 @@
+{
+  "title": "記念日D-Dayカウンター",
+  "description": "指定した日までの残り日数・経過日数を計算し、D-Day表記をコピーできます。",
+  "label": {
+    "date": "基準日",
+    "includeToday": "今日を含める",
+    "quick": "クイック設定",
+    "result": "結果"
+  },
+  "helper": "日付を選ぶとD-Dayが自動で計算されます。",
+  "button": {
+    "today": "今日",
+    "week": "1週間後",
+    "hundred": "100日後",
+    "reset": "リセット",
+    "copy": "結果をコピー",
+    "copied": "コピー済み"
+  },
+  "result": {
+    "empty": "日付を選ぶと結果が表示されます。",
+    "dday": "D-Day",
+    "ddayMinus": "D-{{count}}",
+    "ddayPlus": "D+{{count}}",
+    "daysLeft": "残り{{count}}日",
+    "daysPassed": "{{count}}日経過",
+    "today": "今日はD-Dayです。",
+    "targetDate": "基準日",
+    "todayDate": "今日",
+    "copyText": "{{label}} · {{status}} · {{date}}"
+  },
+  "openGraph": {
+    "title": "記念日D-Dayカウンター",
+    "description": "記念日、旅行、試験、公開日、締切までの残り日数や経過日数を正確なD-Day形式で確認できます。今日を含める設定やクイック日付指定に対応し、計算結果をそのままコピーして共有できます。"
+  }
+}

--- a/src/assets/locales/ko/anniversary-counter.json
+++ b/src/assets/locales/ko/anniversary-counter.json
@@ -1,0 +1,35 @@
+{
+  "title": "기념일 D-day 카운터",
+  "description": "원하는 날짜까지 남은/지난 일수를 계산하고 D-표기를 복사하세요.",
+  "label": {
+    "date": "기준 날짜",
+    "includeToday": "오늘 포함",
+    "quick": "빠른 설정",
+    "result": "결과"
+  },
+  "helper": "기준 날짜를 선택하면 D-day가 자동 계산됩니다.",
+  "button": {
+    "today": "오늘",
+    "week": "1주 후",
+    "hundred": "100일 후",
+    "reset": "초기화",
+    "copy": "결과 복사",
+    "copied": "복사됨"
+  },
+  "result": {
+    "empty": "날짜를 선택하면 결과가 표시됩니다.",
+    "dday": "D-Day",
+    "ddayMinus": "D-{{count}}",
+    "ddayPlus": "D+{{count}}",
+    "daysLeft": "{{count}}일 남음",
+    "daysPassed": "{{count}}일 지남",
+    "today": "오늘이 D-day입니다.",
+    "targetDate": "기준 날짜",
+    "todayDate": "오늘",
+    "copyText": "{{label}} · {{status}} · {{date}}"
+  },
+  "openGraph": {
+    "title": "기념일 D-day 카운터",
+    "description": "기념일, 여행, 시험, 프로젝트 마감일까지 남은 날짜와 지난 날짜를 정확한 D-day 형식으로 계산하세요. 오늘 포함 여부를 반영해 빠르게 날짜를 설정하고, 결과를 복사해 메시지나 SNS에 바로 공유할 수 있습니다."
+  }
+}

--- a/src/assets/locales/zh/anniversary-counter.json
+++ b/src/assets/locales/zh/anniversary-counter.json
@@ -1,0 +1,35 @@
+{
+  "title": "纪念日 D-Day 计数器",
+  "description": "计算目标日期的剩余/已过天数，并一键复制 D-Day 标记。",
+  "label": {
+    "date": "目标日期",
+    "includeToday": "包含今天",
+    "quick": "快速设置",
+    "result": "结果"
+  },
+  "helper": "选择日期即可自动计算 D-Day。",
+  "button": {
+    "today": "今天",
+    "week": "一周后",
+    "hundred": "100 天后",
+    "reset": "重置",
+    "copy": "复制结果",
+    "copied": "已复制"
+  },
+  "result": {
+    "empty": "选择日期后会显示结果。",
+    "dday": "D-Day",
+    "ddayMinus": "D-{{count}}",
+    "ddayPlus": "D+{{count}}",
+    "daysLeft": "剩余 {{count}} 天",
+    "daysPassed": "已过 {{count}} 天",
+    "today": "今天就是 D-Day。",
+    "targetDate": "目标日期",
+    "todayDate": "今天",
+    "copyText": "{{label}} · {{status}} · {{date}}"
+  },
+  "openGraph": {
+    "title": "纪念日 D-Day 计数器",
+    "description": "精确计算纪念日、旅行、考试、上线日或截止日期的剩余天数与已过天数，并以 D-Day 形式清晰展示。支持是否包含今天、快捷日期设置和结果复制，方便直接分享到聊天、备忘录或社交平台。"
+  }
+}


### PR DESCRIPTION
## 기능 요약
- 이벤트 이름과 기준 날짜를 입력하면 D-Day 표기를 자동 계산합니다.
- 오늘 포함 옵션과 빠른 설정(오늘/1주/100일) 버튼을 제공합니다.
- 결과 텍스트를 바로 복사해 공유할 수 있습니다.

## 스크린샷
![기념일 D-day 카운터 스크린샷](docs/screenshots/tools/anniversary-counter.png)

## 추가된 i18n 네임스페이스
- anniversary-counter (ko/en/ja/zh)

## 실행한 테스트/린트
- `yarn lint`
  - 결과: 경고 1건(no-console) 존재, lint는 통과(Exit 0)
- `vitest run` (husky pre-commit)
  - 결과: `localStorage.clear is not a function` 에러로 `src/utils/__tests__/localStorage.test.ts` 5개 실패

## 후속 작업/주의사항
- 기존 `localStorage` 테스트 실패가 있어 별도 수정이 필요합니다.
- 날짜 입력에 브라우저 기본 date UI를 사용합니다. (모바일에서 표시 형식이 환경에 따라 다를 수 있음)
