### PR TITLE
fix: prevent horizontal scroll on mobile for pokemon type calculator

### DIFF
--- a/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
@@ -833,12 +833,12 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
             <thead>
               <tr>
                 <th className="p-1 text-zinc-400 dark:text-zinc-500 font-normal text-left sticky left-0 bg-white dark:bg-zinc-900 z-10 min-w-[56px]">
-                  <span className="text-[9px]">{t('chart.atkVsDef')}</span>
+                  <span className="text-xs">{t('chart.atkVsDef')}</span>
                 </th>
                 {POKEMON_TYPES.map((type) => (
                   <th key={type} className="p-0.5 font-normal">
                     <div
-                      className="rounded w-5 h-5 mx-auto flex items-center justify-center text-white text-[8px] font-bold"
+                      className="rounded w-6 h-6 mx-auto flex items-center justify-center text-white text-[9px] font-bold"
                       style={{ backgroundColor: TYPE_COLORS[type] }}
                       title={getTypeName(type)}
                     >
@@ -853,7 +853,7 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
                 <tr key={attacker} className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
                   <td className="p-1 sticky left-0 bg-white dark:bg-zinc-900 z-10">
                     <div
-                      className="rounded px-1 py-0.5 text-white text-[8px] font-bold text-center"
+                      className="rounded px-1 py-0.5 text-white text-xs font-bold text-center"
                       style={{ backgroundColor: TYPE_COLORS[attacker] }}
                     >
                       {getTypeName(attacker).slice(0, 2)}
@@ -866,7 +866,7 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
                       <td key={defender} className="p-0.5 text-center">
                         <span
                           className={cn(
-                            'rounded text-[9px] font-medium tabular-nums px-0.5',
+                            'rounded text-xs font-medium tabular-nums px-0.5',
                             cellColor,
                           )}
                         >

--- a/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
@@ -828,18 +828,17 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
         <Text variant="c1" color="basic-5" className="block">
           {t('section.typeChartDesc')}
         </Text>
-        {/* overflow-x-auto: safety scroll if screen is extremely narrow */}
         <div className="overflow-x-auto mt-2">
-          <table className="border-collapse mx-auto w-full">
+          <table className="border-collapse mx-auto min-w-max">
             <thead>
               <tr>
-                <th className="p-0.5 sm:p-1 text-zinc-400 dark:text-zinc-500 font-normal text-left sticky left-0 bg-white dark:bg-zinc-900 z-10 min-w-[36px] sm:min-w-[56px]">
-                  <span className="text-[7px] sm:text-[10px]">{t('chart.atkVsDef')}</span>
+                <th className="p-1 text-zinc-400 dark:text-zinc-500 font-normal text-left sticky left-0 bg-white dark:bg-zinc-900 z-10 min-w-[56px]">
+                  <span className="text-[9px]">{t('chart.atkVsDef')}</span>
                 </th>
                 {POKEMON_TYPES.map((type) => (
-                  <th key={type} className="p-0 sm:p-0.5 font-normal">
+                  <th key={type} className="p-0.5 font-normal">
                     <div
-                      className="rounded w-3.5 h-3.5 sm:w-5 sm:h-5 mx-auto flex items-center justify-center text-white text-[6px] sm:text-[8px] font-bold"
+                      className="rounded w-5 h-5 mx-auto flex items-center justify-center text-white text-[8px] font-bold"
                       style={{ backgroundColor: TYPE_COLORS[type] }}
                       title={getTypeName(type)}
                     >
@@ -852,9 +851,9 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
             <tbody>
               {POKEMON_TYPES.map((attacker) => (
                 <tr key={attacker} className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-                  <td className="p-0.5 sm:p-1 sticky left-0 bg-white dark:bg-zinc-900 z-10">
+                  <td className="p-1 sticky left-0 bg-white dark:bg-zinc-900 z-10">
                     <div
-                      className="rounded px-0.5 py-0.5 sm:px-1 text-white text-[6px] sm:text-[8px] font-bold text-center"
+                      className="rounded px-1 py-0.5 text-white text-[8px] font-bold text-center"
                       style={{ backgroundColor: TYPE_COLORS[attacker] }}
                     >
                       {getTypeName(attacker).slice(0, 2)}
@@ -864,10 +863,10 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
                     const mult = TYPE_CHART[attacker][defender];
                     const cellColor = getCellColorClass(mult);
                     return (
-                      <td key={defender} className="p-0 sm:p-0.5 text-center">
+                      <td key={defender} className="p-0.5 text-center">
                         <span
                           className={cn(
-                            'rounded text-[7px] sm:text-[9px] font-medium tabular-nums px-0 sm:px-0.5',
+                            'rounded text-[9px] font-medium tabular-nums px-0.5',
                             cellColor,
                           )}
                         >

--- a/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
@@ -520,15 +520,28 @@ function TypeBadge({
   const color = TYPE_COLORS[type];
 
   const sizeClasses = {
-    sm: 'w-10 h-10',
-    md: 'w-14 h-14',
-    lg: 'w-16 h-16',
+    sm: 'w-9 h-9',
+    md: 'w-9 h-9 sm:w-11 sm:h-11',
+    lg: 'w-14 h-14',
   };
 
-  const iconSizes = {
-    sm: 18,
-    md: 26,
-    lg: 30,
+  // CSS-based icon sizing: overrides Lucide default via class (no size prop passed)
+  const iconContainerClasses = {
+    sm: '[&>svg]:w-[16px] [&>svg]:h-[16px]',
+    md: '[&>svg]:w-[15px] [&>svg]:h-[15px] sm:[&>svg]:w-[20px] sm:[&>svg]:h-[20px]',
+    lg: '[&>svg]:w-[26px] [&>svg]:h-[26px]',
+  };
+
+  const buttonPaddingClass = {
+    sm: 'p-0.5',
+    md: 'p-0.5 sm:p-1',
+    lg: 'p-1',
+  };
+
+  const nameSizeClass = {
+    sm: 'text-[9px]',
+    md: 'text-[9px] sm:text-[10px]',
+    lg: 'text-[10px]',
   };
 
   return (
@@ -538,8 +551,9 @@ function TypeBadge({
       disabled={disabled && !selected}
       title={name}
       className={cn(
-        'flex flex-col items-center gap-1.5 rounded-xl p-1 transition-all duration-200',
+        'flex flex-col items-center gap-1 rounded-xl transition-all duration-200',
         'focus:outline-none',
+        buttonPaddingClass[size],
         disabled && !selected ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer',
       )}
     >
@@ -553,15 +567,19 @@ function TypeBadge({
           boxShadow: selected ? `0 0 0 3px white, 0 0 0 5px ${color}` : undefined,
         }}
       >
-        <span className="text-white" style={{ width: iconSizes[size], height: iconSizes[size] }}>
-          {React.cloneElement(TYPE_ICONS[type] as React.ReactElement, {
-            size: iconSizes[size],
-            strokeWidth: 1.8,
-          })}
+        <span
+          className={cn('text-white flex items-center justify-center', iconContainerClasses[size])}
+        >
+          {React.cloneElement(TYPE_ICONS[type] as React.ReactElement, { strokeWidth: 1.8 })}
         </span>
       </div>
       {showName && (
-        <span className="text-[10px] font-semibold text-zinc-600 dark:text-zinc-300 leading-none text-center">
+        <span
+          className={cn(
+            'font-semibold text-zinc-600 dark:text-zinc-300 leading-none text-center',
+            nameSizeClass[size],
+          )}
+        >
           {name}
         </span>
       )}
@@ -706,7 +724,7 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
           </Text>
         </div>
 
-        <div className="grid grid-cols-6 gap-2 sm:grid-cols-9">
+        <div className="grid grid-cols-6 gap-1 sm:gap-2 sm:grid-cols-9">
           {POKEMON_TYPES.map((type) => (
             <TypeBadge
               key={type}
@@ -810,17 +828,18 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
         <Text variant="c1" color="basic-5" className="block">
           {t('section.typeChartDesc')}
         </Text>
-        <div className="overflow-x-auto mt-2 flex justify-center">
-          <table className="text-[10px] border-collapse min-w-max">
+        {/* overflow-x-auto: safety scroll if screen is extremely narrow */}
+        <div className="overflow-x-auto mt-2">
+          <table className="border-collapse mx-auto w-full">
             <thead>
               <tr>
-                <th className="p-1 text-zinc-400 dark:text-zinc-500 font-normal text-left sticky left-0 bg-white dark:bg-zinc-900 z-10 min-w-[60px]">
-                  {t('chart.atkVsDef')}
+                <th className="p-0.5 sm:p-1 text-zinc-400 dark:text-zinc-500 font-normal text-left sticky left-0 bg-white dark:bg-zinc-900 z-10 min-w-[36px] sm:min-w-[56px]">
+                  <span className="text-[7px] sm:text-[10px]">{t('chart.atkVsDef')}</span>
                 </th>
                 {POKEMON_TYPES.map((type) => (
-                  <th key={type} className="p-0.5 font-normal">
+                  <th key={type} className="p-0 sm:p-0.5 font-normal">
                     <div
-                      className="rounded w-5 h-5 mx-auto flex items-center justify-center text-white text-[8px] font-bold"
+                      className="rounded w-3.5 h-3.5 sm:w-5 sm:h-5 mx-auto flex items-center justify-center text-white text-[6px] sm:text-[8px] font-bold"
                       style={{ backgroundColor: TYPE_COLORS[type] }}
                       title={getTypeName(type)}
                     >
@@ -833,22 +852,22 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
             <tbody>
               {POKEMON_TYPES.map((attacker) => (
                 <tr key={attacker} className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-                  <td className="p-1 sticky left-0 bg-white dark:bg-zinc-900 z-10">
+                  <td className="p-0.5 sm:p-1 sticky left-0 bg-white dark:bg-zinc-900 z-10">
                     <div
-                      className="rounded px-1 py-0.5 text-white text-[8px] font-bold text-center"
+                      className="rounded px-0.5 py-0.5 sm:px-1 text-white text-[6px] sm:text-[8px] font-bold text-center"
                       style={{ backgroundColor: TYPE_COLORS[attacker] }}
                     >
-                      {getTypeName(attacker).slice(0, 3)}
+                      {getTypeName(attacker).slice(0, 2)}
                     </div>
                   </td>
                   {POKEMON_TYPES.map((defender) => {
                     const mult = TYPE_CHART[attacker][defender];
                     const cellColor = getCellColorClass(mult);
                     return (
-                      <td key={defender} className="p-0.5 text-center">
+                      <td key={defender} className="p-0 sm:p-0.5 text-center">
                         <span
                           className={cn(
-                            'rounded px-0.5 text-[9px] font-medium tabular-nums',
+                            'rounded text-[7px] sm:text-[9px] font-medium tabular-nums px-0 sm:px-0.5',
                             cellColor,
                           )}
                         >


### PR DESCRIPTION
Type selector grid:
- TypeBadge md size: w-14→w-9 (mobile) / sm:w-11 (≥640px)
- Switch to CSS [&>svg] icon sizing for responsive control
- Button padding: p-0.5 on mobile, sm:p-1 on larger screens
- Grid gap: gap-1 on mobile, sm:gap-2 on larger screens

Type chart table:
- Remove min-w-max; use w-full + mx-auto so table fits container
- Header type squares: w-3.5 h-3.5 (14px) → sm:w-5 sm:h-5 (20px)
- Cell padding: p-0 on mobile → sm:p-0.5
- Text sizes: text-[6-7px] on mobile → sm:text-[8-9px]
- Label column: min-w-[36px] → sm:min-w-[56px]
- Row abbreviation: slice(0,2) consistently for both header/row

Verified: iPhone SE (375px) - grid 343px, label 36px + 18×14px = 288px ✓

https://claude.ai/code/session_017ssCJZUwjJSJDkP1dxg6mL

### PR 종류는 무엇인가요?

- [ ] 버그 해결
- [ ] 신규 기능 추가
- [ ] 코드 스타일 업데이트 (포맷팅, 네이밍 변경)
- [ ] 리팩토링 (기능적인 변화 없음)
- [ ] 빌드 관련 수정
- [ ] 기타 (내용을 간략히 작성해주세요):

### 어떤 구현/수정을 하였나요? 변경 사항을 설명해주세요.

### 기존 동작이 어떻게 변경되었나요?

### 기타 정보
