### PR TITLE
feat: add global Ctrl/Cmd+K sitemap search palette

### DIFF
--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -47,7 +47,7 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
       <body>
         <StoreProvider>
           <ReactQueryProvider>
-            <CommonLayout>{children}</CommonLayout>
+            <CommonLayout lng={language}>{children}</CommonLayout>
             <Footer lng={language} />
             {enableThirdPartyTracking && (
               <>

--- a/src/assets/locales/en/menu.json
+++ b/src/assets/locales/en/menu.json
@@ -17,6 +17,13 @@
     "emptyTitle": "No matching tools found.",
     "emptyDescription": "Try a different keyword or browse another category."
   },
+  "palette": {
+    "title": "Quick page search",
+    "description": "Search and jump across pages using sitemap data.",
+    "placeholder": "Search by page title or path",
+    "shortcut": "Shortcut: Ctrl + K (Windows/Linux), Cmd + K (Mac)",
+    "empty": "No matching pages found."
+  },
   "group": {
     "planning": {
       "title": "Planning & Time",

--- a/src/assets/locales/ja/menu.json
+++ b/src/assets/locales/ja/menu.json
@@ -17,6 +17,13 @@
     "emptyTitle": "該当するツールが見つかりません。",
     "emptyDescription": "別のキーワードで検索するか、他のカテゴリを確認してください。"
   },
+  "palette": {
+    "title": "クイックページ検索",
+    "description": "サイトマップを基準にページを検索して移動できます。",
+    "placeholder": "ページタイトルまたはパスで検索",
+    "shortcut": "ショートカット: Ctrl + K (Windows/Linux), Cmd + K (Mac)",
+    "empty": "一致するページが見つかりません。"
+  },
   "group": {
     "planning": {
       "title": "日程・時間",

--- a/src/assets/locales/ko/menu.json
+++ b/src/assets/locales/ko/menu.json
@@ -17,6 +17,13 @@
     "emptyTitle": "검색 결과가 없습니다.",
     "emptyDescription": "다른 키워드로 검색하거나 카테고리를 다시 확인해보세요."
   },
+  "palette": {
+    "title": "빠른 페이지 이동",
+    "description": "사이트맵 기반으로 페이지를 검색하고 바로 이동하세요.",
+    "placeholder": "페이지 제목 또는 경로 검색",
+    "shortcut": "단축키: Ctrl + K (Windows/Linux), Cmd + K (Mac)",
+    "empty": "검색 결과가 없습니다."
+  },
   "group": {
     "planning": {
       "title": "일정/시간",

--- a/src/assets/locales/zh/menu.json
+++ b/src/assets/locales/zh/menu.json
@@ -17,6 +17,13 @@
     "emptyTitle": "没有找到匹配的工具。",
     "emptyDescription": "请尝试其他关键词，或查看别的分类。"
   },
+  "palette": {
+    "title": "快速页面搜索",
+    "description": "基于站点地图搜索并跳转页面。",
+    "placeholder": "按页面标题或路径搜索",
+    "shortcut": "快捷键: Ctrl + K (Windows/Linux), Cmd + K (Mac)",
+    "empty": "没有匹配的页面。"
+  },
   "group": {
     "planning": {
       "title": "日程与时间",

--- a/src/components/complex/Layout/CommonLayout.tsx
+++ b/src/components/complex/Layout/CommonLayout.tsx
@@ -5,16 +5,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import LocalesNav from '@components/complex/Nav/LocalesNav';
 import Nav from '@components/complex/Nav';
+import GlobalSearchPalette from '@components/complex/Nav/GlobalSearchPalette';
+import { Language } from '~/app/i18n/settings';
 
 type CommonLayoutProps = {
   children: React.ReactNode;
+  lng: Language;
 };
 
 const queryClient = new QueryClient();
 
 const navDisabledPath = ['/multi-live'];
 
-function CommonLayout({ children }: CommonLayoutProps) {
+function CommonLayout({ children, lng }: CommonLayoutProps) {
   const pathname = usePathname();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -42,6 +45,7 @@ function CommonLayout({ children }: CommonLayoutProps) {
   return (
     <div ref={wrapperRef} className="w-full min-h-screen flex flex-col dark:bg-black">
       <QueryClientProvider client={queryClient}>
+        <GlobalSearchPalette lng={lng} />
         {children}
         {showNav && (
           <>

--- a/src/components/complex/Nav/GlobalSearchPalette.tsx
+++ b/src/components/complex/Nav/GlobalSearchPalette.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Search } from 'lucide-react';
+import Cookies from 'js-cookie';
+import { menus } from '@assets/datas/menus';
+import { Input } from '@components/basic/Input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@components/ui/dialog';
+import { cn } from '@utils/cn';
+import { loadSitemapRoutes } from '@utils/sitemapSearch';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+
+type GlobalSearchPaletteProps = {
+  lng: Language;
+};
+
+type SearchRoute = {
+  href: string;
+  title: string;
+  subtitle: string;
+};
+
+const getPathWithoutLocale = (path: string) => {
+  const segments = path.split('/').filter(Boolean);
+  return `/${segments.slice(1).join('/')}`.replace(/\/$/, '') || '/';
+};
+
+const formatPathAsTitle = (path: string) =>
+  getPathWithoutLocale(path)
+    .split('/')
+    .filter(Boolean)
+    .pop()
+    ?.replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (value) => value.toUpperCase()) || 'Home';
+
+const getRoleFromCookie = () => {
+  try {
+    const userInfo = Cookies.get('user_info');
+    if (!userInfo) return 'GUEST';
+    const parsed = JSON.parse(userInfo) as { role?: string };
+    return parsed.role || 'GUEST';
+  } catch {
+    return 'GUEST';
+  }
+};
+
+const canAccessRoute = (path: string, role: string) => {
+  if (path.includes('/auth')) return false;
+  if (path.includes('/admin')) return role === 'ADMIN';
+  return true;
+};
+
+const LOCALIZED_MENU_MAP = menus.service.reduce<Record<string, Record<Language, string>>>(
+  (acc, menu) => {
+    acc[menu.link] = menu.title;
+    return acc;
+  },
+  {},
+);
+
+export default function GlobalSearchPalette({ lng }: GlobalSearchPaletteProps) {
+  const pathname = usePathname();
+  const { t } = useTranslation(lng, 'menu');
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [routes, setRoutes] = useState<SearchRoute[]>([]);
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, []);
+
+  const hydrateRoutes = useCallback(async () => {
+    const role = getRoleFromCookie();
+    const sitemapRoutes = await loadSitemapRoutes();
+
+    const deduplicated = Array.from(
+      new Set(sitemapRoutes.filter((item) => item.locale === lng).map((item) => item.path)),
+    );
+
+    const nextRoutes = deduplicated
+      .filter((path) => canAccessRoute(path, role))
+      .map((path) => {
+        const relativePath = getPathWithoutLocale(path);
+        const localizedTitle = LOCALIZED_MENU_MAP[relativePath]?.[lng];
+
+        return {
+          href: path,
+          title: localizedTitle || formatPathAsTitle(path),
+          subtitle: relativePath,
+        };
+      });
+
+    setRoutes(nextRoutes);
+  }, [lng]);
+
+  useEffect(() => {
+    if (open) {
+      hydrateRoutes();
+    }
+  }, [hydrateRoutes, open]);
+
+  const filteredRoutes = useMemo(() => {
+    const keyword = query.trim().toLowerCase();
+    if (!keyword) return routes;
+
+    return routes.filter(
+      (route) =>
+        route.title.toLowerCase().includes(keyword) ||
+        route.subtitle.toLowerCase().includes(keyword),
+    );
+  }, [query, routes]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-h-[75vh] max-w-2xl overflow-hidden border-zinc-200 bg-white/95 p-0 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+        <DialogHeader className="px-5 pt-5">
+          <DialogTitle>{t('palette.title')}</DialogTitle>
+          <DialogDescription>{t('palette.description')}</DialogDescription>
+        </DialogHeader>
+        <div className="px-5 pb-4">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+            <Input
+              autoFocus
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t('palette.placeholder')}
+              className="h-11 rounded-xl pl-10"
+            />
+          </div>
+          <p className="mt-2 text-xs text-zinc-500">{t('palette.shortcut')}</p>
+        </div>
+        <div className="max-h-[48vh] overflow-y-auto border-t border-zinc-200 dark:border-zinc-700">
+          {filteredRoutes.map((route) => (
+            <Link
+              key={route.href}
+              href={route.href}
+              onClick={() => setOpen(false)}
+              className={cn(
+                'flex items-center justify-between gap-4 border-b border-zinc-100 px-5 py-3 transition-colors hover:bg-zinc-100/70 dark:border-zinc-800 dark:hover:bg-zinc-800/60',
+                pathname === route.href && 'bg-point-4/50 dark:bg-point-1/20',
+              )}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  {route.title}
+                </p>
+                <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+                  {route.subtitle}
+                </p>
+              </div>
+            </Link>
+          ))}
+          {filteredRoutes.length === 0 ? (
+            <div className="px-5 py-10 text-center text-sm text-zinc-500">{t('palette.empty')}</div>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/utils/sitemapSearch.ts
+++ b/src/utils/sitemapSearch.ts
@@ -1,0 +1,92 @@
+import { Language, languages } from '~/app/i18n/settings';
+
+export type SitemapRoute = {
+  path: string;
+  locale: Language;
+};
+
+const SITEMAP_URLS = ['/sitemap.xml', '/server-sitemap.xml'];
+
+const normalizePathname = (rawPath: string) => {
+  if (!rawPath.startsWith('/')) {
+    return `/${rawPath}`;
+  }
+  return rawPath;
+};
+
+const parseUrlSet = (xmlText: string) => {
+  const parser = new DOMParser();
+  const xml = parser.parseFromString(xmlText, 'application/xml');
+  return Array.from(xml.querySelectorAll('url > loc'))
+    .map((node) => node.textContent?.trim())
+    .filter((value): value is string => Boolean(value));
+};
+
+const parseSitemapIndex = (xmlText: string) => {
+  const parser = new DOMParser();
+  const xml = parser.parseFromString(xmlText, 'application/xml');
+  return Array.from(xml.querySelectorAll('sitemap > loc'))
+    .map((node) => node.textContent?.trim())
+    .filter((value): value is string => Boolean(value));
+};
+
+const toRelativePath = (input: string) => {
+  try {
+    const url = new URL(input);
+    return normalizePathname(url.pathname);
+  } catch {
+    return normalizePathname(input);
+  }
+};
+
+const toLocalizedRoute = (path: string): SitemapRoute | null => {
+  const segments = path.split('/').filter(Boolean);
+  const firstSegment = segments[0];
+
+  if (!firstSegment || !languages.includes(firstSegment as Language)) {
+    return null;
+  }
+
+  return {
+    path,
+    locale: firstSegment as Language,
+  };
+};
+
+async function collectSitemapUrls(path: string, visited: Set<string>): Promise<string[]> {
+  if (visited.has(path)) {
+    return [];
+  }
+
+  visited.add(path);
+
+  const response = await fetch(path, { credentials: 'same-origin' });
+  if (!response.ok) {
+    return [];
+  }
+
+  const xmlText = await response.text();
+  const nestedSitemaps = parseSitemapIndex(xmlText);
+  if (nestedSitemaps.length === 0) {
+    return parseUrlSet(xmlText);
+  }
+
+  const nestedResults = await Promise.all(
+    nestedSitemaps.map((loc) => collectSitemapUrls(toRelativePath(loc), visited)),
+  );
+
+  return nestedResults.flat();
+}
+
+export async function loadSitemapRoutes(): Promise<SitemapRoute[]> {
+  const allUrls = (
+    await Promise.all(
+      SITEMAP_URLS.map((entry) => collectSitemapUrls(entry, new Set<string>()).catch(() => [])),
+    )
+  ).flat();
+
+  const uniquePaths = Array.from(new Set(allUrls.map((value) => toRelativePath(value))));
+  return uniquePaths
+    .map((path) => toLocalizedRoute(path))
+    .filter((entry): entry is SitemapRoute => entry !== null);
+}


### PR DESCRIPTION
### Motivation
- Provide a global, overlay-style quick navigation (Cmd/Ctrl + K) so users can jump to any site page quickly from anywhere. 
- Use sitemap data as the canonical source for searchable pages so pages generated at build-time (including backend-driven pages) are included in search results. 

### Description
- Added a new command-palette component `src/components/complex/Nav/GlobalSearchPalette.tsx` that opens with `Ctrl+K` / `Cmd+K`, displays an overlay dialog, and supports searching by localized title and path subtitle. 
- Implemented sitemap-parsing utility `src/utils/sitemapSearch.ts` that collects URLs from `sitemap.xml` and `server-sitemap.xml` (including sitemap index entries) and produces locale-aware routes. 
- Integrated the palette site-wide by injecting it into `CommonLayout` and passing the current language from `src/app/[lng]/layout.tsx`. 
- Added role-aware filtering (`/admin` visible only for `ADMIN`, `/auth` excluded) and localized title fallback using existing `menus` data, and added i18n copy for the palette in `src/assets/locales/*/menu.json`. 

### Testing
- Ran `yarn eslint` on the modified files and applied `--fix` to resolve formatting issues; linting finished cleanly. 
- No unit tests were changed or added in this PR; only linting was executed as automated validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b2d2ecbc832189f4cdb5129f8d90)