### PR TITLE
feat: add global Cmd/Ctrl+K sitemap search palette

### DIFF
--- a/src/assets/locales/en/menu.json
+++ b/src/assets/locales/en/menu.json
@@ -58,5 +58,12 @@
     "description": "Go to Login!",
     "logout": "Logout",
     "logoutAll": "Logout All"
+  },
+  "commandPalette": {
+    "title": "Quick Page Navigation",
+    "description": "Press Ctrl + K / Cmd + K to search sitemap pages and navigate instantly.",
+    "placeholder": "Search by page title or path",
+    "loading": "Loading sitemap...",
+    "empty": "No matching pages found."
   }
 }

--- a/src/assets/locales/ja/menu.json
+++ b/src/assets/locales/ja/menu.json
@@ -58,5 +58,12 @@
     "description": "ログインする",
     "logout": "ログアウト",
     "logoutAll": "すべてのデバイスからログアウト"
+  },
+  "commandPalette": {
+    "title": "クイックページ移動",
+    "description": "Ctrl + K / Cmd + K でサイトマップからページを検索して移動します。",
+    "placeholder": "ページタイトルまたはパスで検索",
+    "loading": "サイトマップを読み込み中...",
+    "empty": "一致するページがありません。"
   }
 }

--- a/src/assets/locales/ko/menu.json
+++ b/src/assets/locales/ko/menu.json
@@ -58,5 +58,12 @@
     "description": "로그인하러가기!",
     "logout": "로그아웃",
     "logoutAll": "모두 로그아웃"
+  },
+  "commandPalette": {
+    "title": "빠른 페이지 이동",
+    "description": "Ctrl + K / Cmd + K로 사이트맵 기반 페이지를 검색하고 이동하세요.",
+    "placeholder": "페이지 제목 또는 경로 검색",
+    "loading": "사이트맵을 불러오는 중...",
+    "empty": "검색 결과가 없습니다."
   }
 }

--- a/src/assets/locales/zh/menu.json
+++ b/src/assets/locales/zh/menu.json
@@ -58,5 +58,12 @@
     "description": "去登录！",
     "logout": "退出登录",
     "logoutAll": "退出所有设备"
+  },
+  "commandPalette": {
+    "title": "快速页面跳转",
+    "description": "按 Ctrl + K / Cmd + K 可基于站点地图搜索并跳转页面。",
+    "placeholder": "按页面标题或路径搜索",
+    "loading": "正在加载站点地图...",
+    "empty": "没有匹配的页面。"
   }
 }

--- a/src/components/complex/Layout/CommonLayout.tsx
+++ b/src/components/complex/Layout/CommonLayout.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePathname } from 'next/navigation';
 import LocalesNav from '@components/complex/Nav/LocalesNav';
 import Nav from '@components/complex/Nav';
+import GlobalCommandPalette from '@components/complex/Layout/GlobalCommandPalette';
 
 type CommonLayoutProps = {
   children: React.ReactNode;
@@ -43,6 +44,7 @@ function CommonLayout({ children }: CommonLayoutProps) {
     <div ref={wrapperRef} className="w-full min-h-screen flex flex-col dark:bg-black">
       <QueryClientProvider client={queryClient}>
         {children}
+        <GlobalCommandPalette />
         {showNav && (
           <>
             <LocalesNav />

--- a/src/components/complex/Layout/GlobalCommandPalette.tsx
+++ b/src/components/complex/Layout/GlobalCommandPalette.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { observer } from 'mobx-react';
+import { Command, Search } from 'lucide-react';
+import { menus } from '@assets/datas/menus';
+import { Input } from '@components/basic/Input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@components/ui/dialog';
+import useStore from '@hooks/useStore';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language, languages } from '~/app/i18n/settings';
+
+type SearchPageItem = {
+  path: string;
+  title: string;
+  subtitle: string;
+};
+
+const ADMIN_ONLY_PREFIXES = ['/admin'];
+
+let sitemapPathCache: string[] | null = null;
+
+const normalizePath = (rawPath: string) => {
+  const withoutQuery = rawPath.split('?')[0].split('#')[0].trim();
+  if (!withoutQuery) return '/';
+  if (withoutQuery === '/') return '/';
+  return withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+};
+
+const removeLocalePrefix = (path: string) => path.replace(/^\/(ko|en|ja|zh)(?=\/|$)/, '') || '/';
+
+const titleByPath = new Map(
+  menus.service.map((menu) => [
+    menu.link,
+    {
+      ko: menu.title.ko,
+      en: menu.title.en,
+      ja: menu.title.ja,
+      zh: menu.title.zh,
+    },
+  ]),
+);
+
+const toAbsoluteUrl = (path: string) => {
+  if (path.startsWith('http')) {
+    return path;
+  }
+
+  if (typeof window !== 'undefined') {
+    return new URL(path, window.location.origin).toString();
+  }
+
+  return path;
+};
+
+const extractSitemapLocs = (xmlText: string) => {
+  const xmlDoc = new DOMParser().parseFromString(xmlText, 'application/xml');
+  const locNodes = Array.from(xmlDoc.getElementsByTagName('loc'));
+  return locNodes
+    .map((node) => node.textContent?.trim())
+    .filter((value): value is string => Boolean(value));
+};
+
+const collectSitemapPaths = async (): Promise<string[]> => {
+  if (sitemapPathCache) {
+    return sitemapPathCache;
+  }
+
+  const indexResponse = await fetch('/sitemap.xml');
+  if (!indexResponse.ok) {
+    throw new Error('Failed to load sitemap.xml');
+  }
+
+  const indexXml = await indexResponse.text();
+  const sitemapLocs = extractSitemapLocs(indexXml);
+
+  const nestedXmlUrls = sitemapLocs.filter((loc) => /sitemap.*\.xml|server-sitemap\.xml/.test(loc));
+
+  const urlCandidates = nestedXmlUrls.length > 0 ? nestedXmlUrls : ['/sitemap.xml'];
+
+  const allPageLocs: string[] = [];
+
+  await Promise.all(
+    urlCandidates.map(async (urlCandidate) => {
+      const response = await fetch(toAbsoluteUrl(urlCandidate));
+      if (!response.ok) {
+        return;
+      }
+      const xml = await response.text();
+      const locs = extractSitemapLocs(xml);
+      allPageLocs.push(...locs);
+    }),
+  );
+
+  const paths = allPageLocs
+    .map((loc) => {
+      try {
+        return normalizePath(new URL(loc).pathname);
+      } catch {
+        return normalizePath(loc);
+      }
+    })
+    .filter((path) => !path.includes('sitemap.xml'))
+    .filter((path) => !path.startsWith('/server-sitemap.xml'))
+    .filter((path) => path !== '/404')
+    .filter((path) => path !== '/500');
+
+  sitemapPathCache = Array.from(new Set(paths)).sort((a, b) => a.localeCompare(b));
+  return sitemapPathCache;
+};
+
+const isAccessiblePath = (path: string, role?: string) => {
+  const localizedPath = removeLocalePrefix(path);
+
+  if (
+    ADMIN_ONLY_PREFIXES.some(
+      (prefix) => localizedPath === prefix || localizedPath.startsWith(`${prefix}/`),
+    )
+  ) {
+    return role === 'ADMIN' || role === 'Admin';
+  }
+
+  return true;
+};
+
+const fallbackTitleFromPath = (path: string) => {
+  const normalized = removeLocalePrefix(path);
+  if (normalized === '/') {
+    return 'Home';
+  }
+
+  const lastSegment = normalized.split('/').filter(Boolean).pop();
+  if (!lastSegment) {
+    return 'Page';
+  }
+
+  return decodeURIComponent(lastSegment)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+function GlobalCommandPalette() {
+  const pathname = usePathname();
+  const { push } = useRouter();
+  const { user } = useStore('userStore');
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [paths, setPaths] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const language = useMemo<Language>(() => {
+    const locale = pathname?.split('/')[1];
+    return (languages.includes(locale as Language) ? locale : 'ko') as Language;
+  }, [pathname]);
+
+  const { t } = useTranslation(language, 'menu');
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const isCommandK = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+
+      if (!isCommandK) {
+        return;
+      }
+
+      event.preventDefault();
+      setOpen((prev) => !prev);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (!open || paths.length > 0 || loading) {
+      return;
+    }
+
+    setLoading(true);
+    collectSitemapPaths()
+      .then(setPaths)
+      .finally(() => setLoading(false));
+  }, [loading, open, paths.length]);
+
+  const items = useMemo<SearchPageItem[]>(() => {
+    const keyword = query.trim().toLowerCase();
+
+    return paths
+      .filter((path) => isAccessiblePath(path, user?.role))
+      .map((path) => {
+        const localPath = removeLocalePrefix(path);
+        const localizedPath = localPath === '/' ? `/${language}` : `/${language}${localPath}`;
+        const translatedTitle = titleByPath.get(localPath)?.[language];
+        const title = translatedTitle ?? fallbackTitleFromPath(path);
+
+        return {
+          path: localizedPath,
+          title,
+          subtitle: localPath,
+        };
+      })
+      .filter((item) => {
+        if (!keyword) {
+          return true;
+        }
+
+        const haystack = [item.title, item.subtitle].join(' ').toLowerCase();
+        return haystack.includes(keyword);
+      })
+      .slice(0, 20);
+  }, [language, paths, query, user?.role]);
+
+  const moveToPath = (path: string) => {
+    setOpen(false);
+    setQuery('');
+    push(path);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="border-zinc-200 bg-white p-0 sm:max-w-2xl dark:border-zinc-700 dark:bg-zinc-900">
+        <DialogHeader className="border-b border-zinc-200 px-5 pb-4 pt-5 dark:border-zinc-700">
+          <DialogTitle className="flex items-center gap-2 text-zinc-900 dark:text-zinc-100">
+            <Command className="h-4 w-4" />
+            {t('commandPalette.title')}
+          </DialogTitle>
+          <DialogDescription>{t('commandPalette.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 px-5 pb-5 pt-4">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+            <Input
+              autoFocus
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t('commandPalette.placeholder')}
+              className="min-h-11 rounded-2xl pl-10"
+            />
+          </div>
+
+          <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
+            {loading ? (
+              <p className="px-2 py-4 text-sm text-zinc-500 dark:text-zinc-400">
+                {t('commandPalette.loading')}
+              </p>
+            ) : null}
+
+            {!loading && items.length === 0 ? (
+              <p className="px-2 py-4 text-sm text-zinc-500 dark:text-zinc-400">
+                {t('commandPalette.empty')}
+              </p>
+            ) : null}
+
+            {items.map((item) => (
+              <button
+                key={item.path}
+                type="button"
+                onClick={() => moveToPath(item.path)}
+                className={cn(
+                  'w-full rounded-xl border border-zinc-200 bg-white/80 px-3 py-2 text-left transition-colors hover:border-point-2 hover:bg-point-4/40 dark:border-zinc-700 dark:bg-zinc-800/80 dark:hover:border-point-1/60 dark:hover:bg-point-1/10',
+                  pathname === item.path &&
+                    'border-point-2/80 bg-point-4/60 dark:border-point-1/70 dark:bg-point-1/20',
+                )}
+              >
+                <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  {item.title}
+                </p>
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">{item.subtitle}</p>
+              </button>
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default observer(GlobalCommandPalette);


### PR DESCRIPTION
### Motivation
- Provide a global quick-navigation (Cmd/Ctrl+K) so users can jump to any page from anywhere on the site.
- Include pages that are generated at build time by indexing the runtime `sitemap.xml` (and nested sitemaps) so they become searchable.
- Respect route-level access (e.g. `/admin`) so non-admin users do not see restricted links.

### Description
- Added a new `GlobalCommandPalette` component that opens with `Ctrl+K` / `Cmd+K`, shows a searchable list of pages and navigates on selection (`src/components/complex/Layout/GlobalCommandPalette.tsx`).
- Implemented runtime sitemap fetching, XML parsing and caching to collect searchable routes, and a title-fallback that uses `menus` localized titles or generates a title from the path.
- Added permission-aware filtering for admin-only prefixes (`/admin`) using the current user's role from the store.
- Mounted the palette in the global layout by importing and adding `<GlobalCommandPalette />` to `CommonLayout` so it is available site-wide (`src/components/complex/Layout/CommonLayout.tsx`).
- Added localized copy for the command palette to `menu` locale files for `ko/en/ja/zh` (`src/assets/locales/*/menu.json`).

### Testing
- Ran `npx prettier --write` on the changed files and formatting was applied successfully.
- Ran `yarn eslint src/components/complex/Layout/GlobalCommandPalette.tsx src/components/complex/Layout/CommonLayout.tsx` which passed for the modified files.
- Ran `yarn lint` which reported pre-existing repository lint issues unrelated to the changes (import/extensions, unused variables etc.), so the global lint target did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b2d2ecbc832189f4cdb5129f8d90)