### PR TITLE
feat: 블로그 사이드바 Tags UI 개선

### DIFF
--- a/src/components/blog/BlogSearchNav/index.tsx
+++ b/src/components/blog/BlogSearchNav/index.tsx
@@ -5,6 +5,7 @@
 import { observer } from 'mobx-react';
 import React from 'react';
 import FilterDropdown from '@components/complex/FilterDropdown';
+import TagFilterSection from '@components/complex/TagFilterSection';
 import useStore from '@hooks/useStore';
 import { cn } from '@utils/cn';
 import { BLOG_GLASS_PANEL_SOFT } from '@components/blog/interactiveStyles';
@@ -26,7 +27,7 @@ const BlogSearchNav = function BlogSearchNav({ hasMargin = false, lng }: BlogSea
         BLOG_GLASS_PANEL_SOFT,
         'w-full p-0',
         hasMargin
-          ? 'sticky top-20 mt-8 mr-4 ml-auto h-fit w-[280px] overflow-hidden'
+          ? 'sticky top-6 mt-52 mr-4 ml-auto h-fit w-[280px] overflow-hidden'
           : 'h-full overflow-y-auto',
       )}
     >
@@ -35,7 +36,7 @@ const BlogSearchNav = function BlogSearchNav({ hasMargin = false, lng }: BlogSea
         items={category}
         changeType={changeCategoryType}
       />
-      <FilterDropdown title={t('filter.tag')} items={tags} changeType={changeTagType} />
+      <TagFilterSection title={t('filter.tag')} items={tags} changeType={changeTagType} />
     </div>
   );
 };

--- a/src/components/complex/TagFilterSection/index.tsx
+++ b/src/components/complex/TagFilterSection/index.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback } from 'react';
+import Skeleton from '@components/basic/Skeleton';
+import { cn } from '@utils/cn';
+import { FilterDropdownItem, FilterType } from '../FilterDropdown/type';
+
+type TagFilterSectionProps = {
+  title: string;
+  items: FilterDropdownItem[];
+  changeType: (value: string, type: FilterType) => void;
+};
+
+const TagFilterSection: React.FC<TagFilterSectionProps> = function TagFilterSection({
+  title,
+  items,
+  changeType,
+}) {
+  const handleClick = useCallback(
+    (item: FilterDropdownItem) => {
+      if (item.type === 'in') {
+        changeType(item.value, 'notIn');
+      } else if (item.type === 'notIn') {
+        changeType(item.value, 'idle');
+      } else {
+        changeType(item.value, 'in');
+      }
+    },
+    [changeType],
+  );
+
+  return (
+    <div>
+      <div className="border-b border-basic-3/80 bg-basic-2/80 px-3 py-2 text-sm font-bold text-fg-1">
+        {title}
+      </div>
+      <div className="flex flex-wrap gap-1.5 p-2">
+        {items.length === 0
+          ? Array.from({ length: 8 }, (_, i) => (
+              <Skeleton
+                key={`tag-skeleton-${i}`}
+                className={cn(
+                  'h-[26px] rounded-full',
+                  ['w-12', 'w-16', 'w-10', 'w-20', 'w-14', 'w-12', 'w-16', 'w-10'][i],
+                )}
+              />
+            ))
+          : items.map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                onClick={() => handleClick(item)}
+                className={cn(
+                  'inline-flex items-center gap-0.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors',
+                  item.type === 'idle' && 'bg-basic-2 text-fg-3 hover:bg-basic-3 hover:text-fg-2',
+                  item.type === 'in' &&
+                    'bg-point-4/60 text-point-fg dark:bg-point-1/20 dark:text-point-2',
+                  item.type === 'notIn' &&
+                    'bg-danger-4/80 text-danger-2 dark:bg-danger-1/25 dark:text-danger-1',
+                )}
+              >
+                {item.type === 'in' && <span className="font-bold">+</span>}
+                {item.type === 'notIn' && <span className="font-bold">-</span>}
+                {item.name}
+              </button>
+            ))}
+      </div>
+    </div>
+  );
+};
+
+export default TagFilterSection;


### PR DESCRIPTION
## Summary

- `TagFilterSection` 컴포넌트 신규 추가 — flex-wrap 칩 레이아웃으로 태그 자동 줄넘김
- 태그 선택 시 `+` (포함) / `-` (제외) 프리픽스 토글 및 포인트/위험 컬러로 상태 표시
- 사이드바 시작 위치를 검색창 라인 높이에 맞게 조정 (`mt-52`)
- 스크롤 스티키 top offset `top-20` → `top-6` (천장에서 24px 간격)

## Test plan

- [ ] 블로그 목록 페이지 데스크탑에서 사이드바 시작 위치가 검색창과 수평으로 맞는지 확인
- [ ] 태그 클릭 → `+` 프리픽스 + 포인트 컬러, 재클릭 → `-` 프리픽스 + 빨강, 재클릭 → 원래 상태 확인
- [ ] 태그 다수일 때 flex-wrap으로 자동 줄넘김 확인
- [ ] 스크롤 시 사이드바가 상단 24px 간격으로 스티키 동작 확인
- [ ] Category 드롭다운은 기존 스타일 그대로인지 확인
- [ ] 다크모드에서 선택된 태그 색상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)