### PR TITLE
feat: 서비스 페이지 구글 애드센스 광고 추가

### DIFF
--- a/src/app/[lng]/(mobile)/age-calculator/components/AgeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/age-calculator/components/AgeCalculatorClient.tsx
@@ -28,6 +28,7 @@ import {
   SERVICE_PANEL,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface AgeCalculatorClientProps {
   lng: Language;
@@ -226,6 +227,8 @@ export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
           </div>
         )}
       </div>
+
+      {result.data && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       <div className={cn(SERVICE_PANEL_SOFT, 'space-y-2 p-4')}>
         <Text asChild variant="d2" color="basic-4">

--- a/src/app/[lng]/(mobile)/age-calculator/components/AgeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/age-calculator/components/AgeCalculatorClient.tsx
@@ -228,7 +228,7 @@ export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
         )}
       </div>
 
-      {result.data && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result.data && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <div className={cn(SERVICE_PANEL_SOFT, 'space-y-2 p-4')}>
         <Text asChild variant="d2" color="basic-4">

--- a/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
@@ -185,7 +185,7 @@ export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClie
         </div>
       </div>
 
-      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
@@ -11,6 +11,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 import { addDays, calculateDDay, formatDateInput } from '../utils/anniversaryCounter';
 
 interface AnniversaryCounterClientProps {
@@ -183,6 +184,8 @@ export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClie
           </div>
         </div>
       </div>
+
+      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/bedtime-planner/components/BedtimePlannerClient.tsx
+++ b/src/app/[lng]/(mobile)/bedtime-planner/components/BedtimePlannerClient.tsx
@@ -16,6 +16,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface BedtimePlannerClientProps {
   lng: Language;
@@ -143,6 +144,8 @@ export default function BedtimePlannerClient({ lng }: BedtimePlannerClientProps)
           ))}
         </ul>
       </div>
+
+      {results.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/bedtime-planner/components/BedtimePlannerClient.tsx
+++ b/src/app/[lng]/(mobile)/bedtime-planner/components/BedtimePlannerClient.tsx
@@ -145,7 +145,7 @@ export default function BedtimePlannerClient({ lng }: BedtimePlannerClientProps)
         </ul>
       </div>
 
-      {results.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {results.length > 0 && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/bmi-calculator/components/BmiCalculator.tsx
+++ b/src/app/[lng]/(mobile)/bmi-calculator/components/BmiCalculator.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { Copy, RefreshCcw } from 'lucide-react';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface BmiCalculatorProps {
   lng: Language;
@@ -171,6 +172,8 @@ export default function BmiCalculator({ lng }: BmiCalculatorProps) {
           </div>
         )}
       </section>
+
+      {result?.valid && result.bmi && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       <section className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
         <Text variant="d2" className="block font-semibold">

--- a/src/app/[lng]/(mobile)/bmi-calculator/components/BmiCalculator.tsx
+++ b/src/app/[lng]/(mobile)/bmi-calculator/components/BmiCalculator.tsx
@@ -173,7 +173,7 @@ export default function BmiCalculator({ lng }: BmiCalculatorProps) {
         )}
       </section>
 
-      {result?.valid && result.bmi && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result?.valid && result.bmi && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <section className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
         <Text variant="d2" className="block font-semibold">

--- a/src/app/[lng]/(mobile)/bpm-tapper/components/BpmTapperClient.tsx
+++ b/src/app/[lng]/(mobile)/bpm-tapper/components/BpmTapperClient.tsx
@@ -117,7 +117,7 @@ export default function BpmTapperClient({ lng }: BpmTapperClientProps) {
         </div>
       </section>
 
-      {bpm !== null && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {bpm !== null && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/bpm-tapper/components/BpmTapperClient.tsx
+++ b/src/app/[lng]/(mobile)/bpm-tapper/components/BpmTapperClient.tsx
@@ -12,6 +12,7 @@ import {
   SERVICE_PANEL,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface BpmTapperClientProps {
   lng: Language;
@@ -115,6 +116,8 @@ export default function BpmTapperClient({ lng }: BpmTapperClientProps) {
           </Button>
         </div>
       </section>
+
+      {bpm !== null && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/coin-flip/components/CoinFlipClient.tsx
+++ b/src/app/[lng]/(mobile)/coin-flip/components/CoinFlipClient.tsx
@@ -152,7 +152,7 @@ export default function CoinFlipClient({ lng }: CoinFlipClientProps) {
           )}
         </section>
       </div>
-      {results.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {results.length > 0 && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/coin-flip/components/CoinFlipClient.tsx
+++ b/src/app/[lng]/(mobile)/coin-flip/components/CoinFlipClient.tsx
@@ -10,6 +10,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 const MAX_COINS = 20;
 
@@ -70,81 +71,88 @@ export default function CoinFlipClient({ lng }: CoinFlipClientProps) {
   };
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[1.1fr_1fr]">
-      <section className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-4')}>
-        <div className="space-y-2">
-          <label htmlFor="coin-count" className="text-sm font-medium text-fg-3">
-            {t('label.count')}
-          </label>
-          <Input
-            id="coin-count"
-            type="number"
-            min={1}
-            max={MAX_COINS}
-            value={countInput}
-            onChange={(event) => setCountInput(event.target.value)}
-            className="font-mono"
-          />
-          <p className="text-xs text-fg-5">{t('helper')}</p>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Button onClick={handleFlip} className="px-4 py-2 text-sm">
-            {t('button.flip')}
-          </Button>
-          <Button
-            onClick={handleReset}
-            className="px-4 py-2 text-sm bg-basic-2 hover:bg-basic-3 text-fg-1"
-          >
-            {t('button.reset')}
-          </Button>
-        </div>
-
-        <div className={cn(SERVICE_PANEL_SOFT, 'space-y-2 p-3')}>
-          <p className="text-sm font-semibold text-fg-2">{t('summary.title')}</p>
-          <div className="flex flex-wrap gap-2 text-xs font-medium text-fg-4">
-            <span className="rounded-full bg-basic-2 px-2 py-1 dark:bg-basic-3">
-              {t('summary.total', { count: summary.total || safeCount })}
-            </span>
-            <span className="rounded-full bg-basic-2 px-2 py-1 dark:bg-basic-3">
-              {t('summary.heads', { count: summary.heads })}
-            </span>
-            <span className="rounded-full bg-basic-2 px-2 py-1 dark:bg-basic-3">
-              {t('summary.tails', { count: summary.tails })}
-            </span>
+    <div className="space-y-4">
+      <div className="grid gap-6 lg:grid-cols-[1.1fr_1fr]">
+        <section className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-4')}>
+          <div className="space-y-2">
+            <label htmlFor="coin-count" className="text-sm font-medium text-fg-3">
+              {t('label.count')}
+            </label>
+            <Input
+              id="coin-count"
+              type="number"
+              min={1}
+              max={MAX_COINS}
+              value={countInput}
+              onChange={(event) => setCountInput(event.target.value)}
+              className="font-mono"
+            />
+            <p className="text-xs text-fg-5">{t('helper')}</p>
           </div>
-        </div>
-      </section>
 
-      <section
-        className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-3 p-4 min-h-[240px]')}
-      >
-        <h3 className="text-sm font-semibold text-fg-2">{t('result.title')}</h3>
-        {results.length === 0 ? (
-          <p className="text-sm text-fg-5">{t('result.empty')}</p>
-        ) : (
-          <ul className="grid gap-2">
-            {results.map((result, index) => (
-              <li
-                key={result.id}
-                className="flex items-center justify-between rounded-xl border border-basic-3 bg-basic-0/80 px-3 py-2 text-sm text-fg-2 shadow-sm"
-              >
-                <span className="font-medium">{t('result.coinLabel', { index: index + 1 })}</span>
-                <span
-                  className={cn(
-                    'rounded-full px-2 py-0.5 text-xs font-semibold',
-                    result.value === 'heads'
-                      ? 'bg-point-1/15 text-point-fg'
-                      : 'bg-point-4/40 text-fg-3',
-                  )}
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={handleFlip} className="px-4 py-2 text-sm">
+              {t('button.flip')}
+            </Button>
+            <Button
+              onClick={handleReset}
+              className="px-4 py-2 text-sm bg-basic-2 hover:bg-basic-3 text-fg-1"
+            >
+              {t('button.reset')}
+            </Button>
+          </div>
+
+          <div className={cn(SERVICE_PANEL_SOFT, 'space-y-2 p-3')}>
+            <p className="text-sm font-semibold text-fg-2">{t('summary.title')}</p>
+            <div className="flex flex-wrap gap-2 text-xs font-medium text-fg-4">
+              <span className="rounded-full bg-basic-2 px-2 py-1 dark:bg-basic-3">
+                {t('summary.total', { count: summary.total || safeCount })}
+              </span>
+              <span className="rounded-full bg-basic-2 px-2 py-1 dark:bg-basic-3">
+                {t('summary.heads', { count: summary.heads })}
+              </span>
+              <span className="rounded-full bg-basic-2 px-2 py-1 dark:bg-basic-3">
+                {t('summary.tails', { count: summary.tails })}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className={cn(
+            SERVICE_PANEL_SOFT,
+            SERVICE_CARD_INTERACTIVE,
+            'space-y-3 p-4 min-h-[240px]',
+          )}
+        >
+          <h3 className="text-sm font-semibold text-fg-2">{t('result.title')}</h3>
+          {results.length === 0 ? (
+            <p className="text-sm text-fg-5">{t('result.empty')}</p>
+          ) : (
+            <ul className="grid gap-2">
+              {results.map((result, index) => (
+                <li
+                  key={result.id}
+                  className="flex items-center justify-between rounded-xl border border-basic-3 bg-basic-0/80 px-3 py-2 text-sm text-fg-2 shadow-sm"
                 >
-                  {t(`result.${result.value}`)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                  <span className="font-medium">{t('result.coinLabel', { index: index + 1 })}</span>
+                  <span
+                    className={cn(
+                      'rounded-full px-2 py-0.5 text-xs font-semibold',
+                      result.value === 'heads'
+                        ? 'bg-point-1/15 text-point-fg'
+                        : 'bg-point-4/40 text-fg-3',
+                    )}
+                  >
+                    {t(`result.${result.value}`)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+      {results.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/commute-cost/components/CommuteCostClient.tsx
+++ b/src/app/[lng]/(mobile)/commute-cost/components/CommuteCostClient.tsx
@@ -111,7 +111,7 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
         </div>
       </section>
 
-      {roundTrip && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {roundTrip && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <section className={`${SERVICE_PANEL_SOFT} space-y-3 p-4`}>
         <div className="space-y-1">

--- a/src/app/[lng]/(mobile)/commute-cost/components/CommuteCostClient.tsx
+++ b/src/app/[lng]/(mobile)/commute-cost/components/CommuteCostClient.tsx
@@ -6,6 +6,7 @@ import { Language } from '~/app/i18n/settings';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 const DEFAULT_WEEKS = 4.3;
 const DEFAULT_DAYS = 5;
@@ -109,6 +110,8 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
           </Button>
         </div>
       </section>
+
+      {roundTrip && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       <section className={`${SERVICE_PANEL_SOFT} space-y-3 p-4`}>
         <div className="space-y-1">

--- a/src/app/[lng]/(mobile)/contrast-checker/components/ContrastCheckerClient.tsx
+++ b/src/app/[lng]/(mobile)/contrast-checker/components/ContrastCheckerClient.tsx
@@ -285,7 +285,7 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
         </div>
       </div>
 
-      {ratio !== null && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {ratio !== null && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/contrast-checker/components/ContrastCheckerClient.tsx
+++ b/src/app/[lng]/(mobile)/contrast-checker/components/ContrastCheckerClient.tsx
@@ -8,6 +8,7 @@ import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 const DEFAULT_FOREGROUND = '#111827';
 const DEFAULT_BACKGROUND = '#ffffff';
@@ -283,6 +284,8 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
           </Text>
         </div>
       </div>
+
+      {ratio !== null && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/cron-generator/components/CronGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/cron-generator/components/CronGeneratorClient.tsx
@@ -248,7 +248,7 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
 
       <CronResultCard title={t('label.result')} result={humanReadable || '-'} />
 
-      {humanReadable && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {humanReadable && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <CronGuideGrid
         minuteLabel={t('label.minute')}

--- a/src/app/[lng]/(mobile)/cron-generator/components/CronGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/cron-generator/components/CronGeneratorClient.tsx
@@ -7,6 +7,7 @@ import { Text } from '@components/basic/Text';
 import ServiceInfoNotice from '@components/complex/Service/ServiceInfoNotice';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
+import GoogleAd from '@components/google/GoogleAd';
 import CronExpressionInput from './CronExpressionInput';
 import CronFieldBuilder, { CronFieldMode } from './CronFieldBuilder';
 import CronGuideGrid from './CronGuideGrid';
@@ -246,6 +247,9 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
       {error && <p className="animate-pulse text-sm font-medium text-danger-2">{error}</p>}
 
       <CronResultCard title={t('label.result')} result={humanReadable || '-'} />
+
+      {humanReadable && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+
       <CronGuideGrid
         minuteLabel={t('label.minute')}
         hourLabel={t('label.hour')}

--- a/src/app/[lng]/(mobile)/csv-json-converter/components/CsvJsonConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/csv-json-converter/components/CsvJsonConverterClient.tsx
@@ -226,7 +226,7 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
           {t('actions.clear')}
         </Button>
       </div>
-      {jsonInput && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {jsonInput && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/csv-json-converter/components/CsvJsonConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/csv-json-converter/components/CsvJsonConverterClient.tsx
@@ -19,6 +19,7 @@ import {
   stringifyCsv,
   CsvRecord,
 } from '~/app/[lng]/(mobile)/csv-json-converter/utils/csv';
+import GoogleAd from '@components/google/GoogleAd';
 
 const delimiterOptions = [
   { label: ',', value: ',' },
@@ -225,6 +226,7 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
           {t('actions.clear')}
         </Button>
       </div>
+      {jsonInput && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/data-size-converter/components/DataSizeConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/data-size-converter/components/DataSizeConverterClient.tsx
@@ -13,6 +13,7 @@ import {
 } from '@components/basic/Select';
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 const localeMap: Record<Language, string> = {
   ko: 'ko-KR',
@@ -144,6 +145,7 @@ export default function DataSizeConverterClient({ lng }: DataSizeConverterClient
         ) : (
           <p className="text-sm text-fg-5">{t('result.empty')}</p>
         )}
+        {results && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
       </div>
     </div>
   );

--- a/src/app/[lng]/(mobile)/data-size-converter/components/DataSizeConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/data-size-converter/components/DataSizeConverterClient.tsx
@@ -145,7 +145,7 @@ export default function DataSizeConverterClient({ lng }: DataSizeConverterClient
         ) : (
           <p className="text-sm text-fg-5">{t('result.empty')}</p>
         )}
-        {results && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+        {results && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
       </div>
     </div>
   );

--- a/src/app/[lng]/(mobile)/date-diff/components/DateDiffClient.tsx
+++ b/src/app/[lng]/(mobile)/date-diff/components/DateDiffClient.tsx
@@ -4,6 +4,7 @@ import React, { useId, useMemo, useState } from 'react';
 import { Button } from '@components/basic/Button';
 import { Input } from '@components/basic/Input';
 import { Text } from '@components/basic/Text';
+import GoogleAd from '@components/google/GoogleAd';
 import { calculateDateRange, formatDateInput } from '../utils/dateDiff';
 
 type Labels = {
@@ -164,6 +165,7 @@ function DateDiffClient({ labels }: DateDiffClientProps) {
           </div>
         ) : null}
       </div>
+      {result ? <GoogleAd slotId="9185479703" className="w-full mt-4" /> : null}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/date-diff/components/DateDiffClient.tsx
+++ b/src/app/[lng]/(mobile)/date-diff/components/DateDiffClient.tsx
@@ -165,7 +165,7 @@ function DateDiffClient({ labels }: DateDiffClientProps) {
           </div>
         ) : null}
       </div>
-      {result ? <GoogleAd slotId="9185479703" className="w-full mt-4" /> : null}
+      {result ? <GoogleAd slotId="7911066601" className="w-full mt-4" /> : null}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/ip-lookup/components/IpLookupClient.tsx
+++ b/src/app/[lng]/(mobile)/ip-lookup/components/IpLookupClient.tsx
@@ -27,6 +27,7 @@ import {
   SERVICE_PANEL,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 import type { PortInfo } from '~/app/api/ip-lookup/port-scan/route';
 
 interface IpLookupClientProps {
@@ -559,6 +560,8 @@ export default function IpLookupClient({ lng }: IpLookupClientProps) {
               {t('disclaimer')}
             </Text>
           </div>
+
+          <GoogleAd slotId="9185479703" className="w-full mt-4" />
         </>
       )}
     </div>

--- a/src/app/[lng]/(mobile)/ip-lookup/components/IpLookupClient.tsx
+++ b/src/app/[lng]/(mobile)/ip-lookup/components/IpLookupClient.tsx
@@ -561,7 +561,7 @@ export default function IpLookupClient({ lng }: IpLookupClientProps) {
             </Text>
           </div>
 
-          <GoogleAd slotId="9185479703" className="w-full mt-4" />
+          <GoogleAd slotId="7911066601" className="w-full mt-4" />
         </>
       )}
     </div>

--- a/src/app/[lng]/(mobile)/json-yaml-converter/components/JsonYamlConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/json-yaml-converter/components/JsonYamlConverterClient.tsx
@@ -224,7 +224,7 @@ export default function JsonYamlConverterClient({ lng }: JsonYamlConverterClient
             value={output}
           />
         </div>
-        {output && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+        {output && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
       </div>
     </div>
   );

--- a/src/app/[lng]/(mobile)/json-yaml-converter/components/JsonYamlConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/json-yaml-converter/components/JsonYamlConverterClient.tsx
@@ -13,6 +13,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import { parse, stringify } from 'yaml';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface JsonYamlConverterClientProps {
   lng: Language;
@@ -223,6 +224,7 @@ export default function JsonYamlConverterClient({ lng }: JsonYamlConverterClient
             value={output}
           />
         </div>
+        {output && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
       </div>
     </div>
   );

--- a/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 import JwtTokenInput from './JwtTokenInput';
 import JwtDecodedPanel from './JwtDecodedPanel';
 
@@ -71,6 +72,7 @@ function JwtDecoderClient({ lng }: JwtDecoderClientProps) {
           emptyText="// Payload"
         />
       </div>
+      {decoded && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
@@ -72,7 +72,7 @@ function JwtDecoderClient({ lng }: JwtDecoderClientProps) {
           emptyText="// Payload"
         />
       </div>
-      {decoded && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {decoded && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/korean-amount/components/KoreanAmountClient.tsx
+++ b/src/app/[lng]/(mobile)/korean-amount/components/KoreanAmountClient.tsx
@@ -150,7 +150,7 @@ export default function KoreanAmountClient({ lng }: KoreanAmountClientProps) {
           {t('result.tip')}
         </Text>
       </section>
-      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/korean-amount/components/KoreanAmountClient.tsx
+++ b/src/app/[lng]/(mobile)/korean-amount/components/KoreanAmountClient.tsx
@@ -17,6 +17,7 @@ import {
   MAX_KOREAN_AMOUNT_DIGITS,
   MAX_KOREAN_AMOUNT_FORMATTED_LENGTH,
 } from '~/app/[lng]/(mobile)/korean-amount/utils/convertKoreanAmount';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface KoreanAmountClientProps {
   lng: Language;
@@ -149,6 +150,7 @@ export default function KoreanAmountClient({ lng }: KoreanAmountClientProps) {
           {t('result.tip')}
         </Text>
       </section>
+      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/layout.tsx
+++ b/src/app/[lng]/(mobile)/layout.tsx
@@ -30,7 +30,7 @@ export default function MobileLayout({ children }: ChildrenProps) {
           <BackToMenuNav />
           {children}
           <div className="lg:hidden px-4 pb-4">
-            <GoogleAd className="w-full min-h-16" slotId="9185479703" />
+            <GoogleAd className="w-full min-h-16" slotId="6290029027" />
           </div>
         </section>
       </div>

--- a/src/app/[lng]/(mobile)/layout.tsx
+++ b/src/app/[lng]/(mobile)/layout.tsx
@@ -29,6 +29,9 @@ export default function MobileLayout({ children }: ChildrenProps) {
         >
           <BackToMenuNav />
           {children}
+          <div className="lg:hidden px-4 pb-4">
+            <GoogleAd className="w-full min-h-16" slotId="9185479703" />
+          </div>
         </section>
       </div>
     </AsideScreenWrapper>

--- a/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
+++ b/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
@@ -319,7 +319,7 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
           </div>
         )}
       </section>
-      {results.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {results.length > 0 && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
+++ b/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
@@ -10,6 +10,7 @@ import {
   SERVICE_PANEL,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface LottoGeneratorStrings {
   settingsTitle: string;
@@ -318,6 +319,7 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
           </div>
         )}
       </section>
+      {results.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/markdown-table-generator/components/MarkdownTableGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/markdown-table-generator/components/MarkdownTableGeneratorClient.tsx
@@ -19,6 +19,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 const DELIMITERS = [
   { value: 'comma', symbol: ',', labelKey: 'delimiter.comma' },
@@ -283,6 +284,8 @@ export default function MarkdownTableGeneratorClient({ lng }: MarkdownTableGener
         />
         {!rows.length && <p className="text-xs text-fg-5">{t('emptyHelper')}</p>}
       </div>
+
+      {output && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/markdown-table-generator/components/MarkdownTableGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/markdown-table-generator/components/MarkdownTableGeneratorClient.tsx
@@ -285,7 +285,7 @@ export default function MarkdownTableGeneratorClient({ lng }: MarkdownTableGener
         {!rows.length && <p className="text-xs text-fg-5">{t('emptyHelper')}</p>}
       </div>
 
-      {output && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {output && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/network-calculator/components/IpSubnetCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/IpSubnetCalculator.tsx
@@ -264,7 +264,7 @@ export function IpSubnetCalculator({ lng }: IpSubnetCalculatorProps) {
         </div>
       )}
 
-      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/network-calculator/components/IpSubnetCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/IpSubnetCalculator.tsx
@@ -19,6 +19,7 @@ import {
 } from '@components/complex/Service/interactiveStyles';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
+import GoogleAd from '@components/google/GoogleAd';
 import {
   calculateSubnet,
   cidrToSubnetMask,
@@ -262,6 +263,8 @@ export function IpSubnetCalculator({ lng }: IpSubnetCalculatorProps) {
           </div>
         </div>
       )}
+
+      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/network-calculator/components/VlsmCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/VlsmCalculator.tsx
@@ -20,6 +20,7 @@ import {
 } from '@components/complex/Service/interactiveStyles';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
+import GoogleAd from '@components/google/GoogleAd';
 import {
   calculateVlsm,
   cidrToSubnetMask,
@@ -350,6 +351,8 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
           </div>
         )}
       </div>
+
+      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/network-calculator/components/VlsmCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/VlsmCalculator.tsx
@@ -352,7 +352,7 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
         )}
       </div>
 
-      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/network-calculator/components/WildcardCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/WildcardCalculator.tsx
@@ -20,6 +20,7 @@ import {
 } from '@components/complex/Service/interactiveStyles';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
+import GoogleAd from '@components/google/GoogleAd';
 import {
   calculateWildcard,
   cidrToSubnetMask,
@@ -196,6 +197,8 @@ export function WildcardCalculator({ lng }: WildcardCalculatorProps) {
           </div>
         )}
       </div>
+
+      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/network-calculator/components/WildcardCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/WildcardCalculator.tsx
@@ -198,7 +198,7 @@ export function WildcardCalculator({ lng }: WildcardCalculatorProps) {
         )}
       </div>
 
-      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/passphrase-generator/components/PassphraseGenerator.tsx
+++ b/src/app/[lng]/(mobile)/passphrase-generator/components/PassphraseGenerator.tsx
@@ -251,7 +251,7 @@ export default function PassphraseGenerator({ lng }: PassphraseGeneratorProps) {
           {copied ? t('copied') : t('copy')}
         </button>
       </section>
-      {passphrase && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {passphrase && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/passphrase-generator/components/PassphraseGenerator.tsx
+++ b/src/app/[lng]/(mobile)/passphrase-generator/components/PassphraseGenerator.tsx
@@ -11,6 +11,7 @@ import { Textarea } from '@components/basic/Textarea';
 import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import { cn } from '@utils/cn';
 import { Text } from '@components/basic/Text';
+import GoogleAd from '@components/google/GoogleAd';
 
 type PassphraseGeneratorProps = {
   lng: Language;
@@ -250,6 +251,7 @@ export default function PassphraseGenerator({ lng }: PassphraseGeneratorProps) {
           {copied ? t('copied') : t('copy')}
         </button>
       </section>
+      {passphrase && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/percent/components/PercentCalculatorCard.tsx
+++ b/src/app/[lng]/(mobile)/percent/components/PercentCalculatorCard.tsx
@@ -113,7 +113,7 @@ function PercentCalculatorCard({
         </div>
       </div>
       {calculator.primaryNumber && calculator.secondaryNumber && (
-        <GoogleAd slotId="9185479703" className="w-full mt-4" />
+        <GoogleAd slotId="7911066601" className="w-full mt-4" />
       )}
     </div>
   );

--- a/src/app/[lng]/(mobile)/percent/components/PercentCalculatorCard.tsx
+++ b/src/app/[lng]/(mobile)/percent/components/PercentCalculatorCard.tsx
@@ -16,6 +16,7 @@ import {
 } from '@components/basic/Select';
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 type PercentCalculatorCardProps = {
   calculatorName: keyof PercentCalculators;
@@ -111,6 +112,9 @@ function PercentCalculatorCard({
           <span className="t-d-2 t-basic-1">{text[3]}</span>
         </div>
       </div>
+      {calculator.primaryNumber && calculator.secondaryNumber && (
+        <GoogleAd slotId="9185479703" className="w-full mt-4" />
+      )}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
@@ -809,7 +809,7 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
         </section>
       )}
 
-      {groupedByEffectiveness && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {groupedByEffectiveness && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       {/* Empty state */}
       {selectedTypes.length === 0 && (

--- a/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
@@ -9,6 +9,7 @@ import {
 } from '@components/complex/Service/interactiveStyles';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
+import GoogleAd from '@components/google/GoogleAd';
 import {
   Bug,
   Crown,
@@ -807,6 +808,8 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
           </div>
         </section>
       )}
+
+      {groupedByEffectiveness && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       {/* Empty state */}
       {selectedTypes.length === 0 && (

--- a/src/app/[lng]/(mobile)/qr-generator/components/QrGenerator.tsx
+++ b/src/app/[lng]/(mobile)/qr-generator/components/QrGenerator.tsx
@@ -131,7 +131,7 @@ export default function QrGenerator({ lng }: UrlQrGeneratorProps) {
           )}
         </div>
       </div>
-      {url.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {url.length > 0 && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/qr-generator/components/QrGenerator.tsx
+++ b/src/app/[lng]/(mobile)/qr-generator/components/QrGenerator.tsx
@@ -12,6 +12,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface UrlQrGeneratorProps {
   lng: Language;
@@ -130,6 +131,7 @@ export default function QrGenerator({ lng }: UrlQrGeneratorProps) {
           )}
         </div>
       </div>
+      {url.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/roman-converter/components/RomanConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/roman-converter/components/RomanConverterClient.tsx
@@ -11,6 +11,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 type RomanConverterClientProps = {
   lng: Language;
@@ -268,6 +269,9 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
           placeholder={t('empty')}
         />
       </div>
+      {(romanOutput || parsedRoman.value) && (
+        <GoogleAd slotId="9185479703" className="w-full mt-4" />
+      )}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/roman-converter/components/RomanConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/roman-converter/components/RomanConverterClient.tsx
@@ -270,7 +270,7 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
         />
       </div>
       {(romanOutput || parsedRoman.value) && (
-        <GoogleAd slotId="9185479703" className="w-full mt-4" />
+        <GoogleAd slotId="7911066601" className="w-full mt-4" />
       )}
     </div>
   );

--- a/src/app/[lng]/(mobile)/salary-converter/components/SalaryConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/salary-converter/components/SalaryConverterClient.tsx
@@ -6,6 +6,7 @@ import { Language } from '~/app/i18n/settings';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 import { cn } from '@utils/cn';
 import {
   DEFAULT_DAYS,
@@ -180,6 +181,10 @@ export default function SalaryConverterClient({ lng }: SalaryConverterClientProp
           </Button>
         </div>
       </section>
+
+      {(annualSalary || monthlySalary || hourlyWage) && (
+        <GoogleAd slotId="9185479703" className="w-full mt-4" />
+      )}
 
       <section className={`${SERVICE_PANEL_SOFT} space-y-3 p-4`}>
         <div className="space-y-1">

--- a/src/app/[lng]/(mobile)/salary-converter/components/SalaryConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/salary-converter/components/SalaryConverterClient.tsx
@@ -183,7 +183,7 @@ export default function SalaryConverterClient({ lng }: SalaryConverterClientProp
       </section>
 
       {(annualSalary || monthlySalary || hourlyWage) && (
-        <GoogleAd slotId="9185479703" className="w-full mt-4" />
+        <GoogleAd slotId="7911066601" className="w-full mt-4" />
       )}
 
       <section className={`${SERVICE_PANEL_SOFT} space-y-3 p-4`}>

--- a/src/app/[lng]/(mobile)/sales-tax-calculator/components/SalesTaxCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/sales-tax-calculator/components/SalesTaxCalculatorClient.tsx
@@ -10,6 +10,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface SalesTaxCalculatorClientProps {
   lng: Language;
@@ -102,6 +103,8 @@ export default function SalesTaxCalculatorClient({ lng }: SalesTaxCalculatorClie
           </Button>
         </div>
       </section>
+
+      {price && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-4 p-4')}>
         <h3 className="text-base font-semibold text-fg-1">{t('summary.title')}</h3>

--- a/src/app/[lng]/(mobile)/sales-tax-calculator/components/SalesTaxCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/sales-tax-calculator/components/SalesTaxCalculatorClient.tsx
@@ -104,7 +104,7 @@ export default function SalesTaxCalculatorClient({ lng }: SalesTaxCalculatorClie
         </div>
       </section>
 
-      {price && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {price && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <section className={cn(SERVICE_PANEL_SOFT, SERVICE_CARD_INTERACTIVE, 'space-y-4 p-4')}>
         <h3 className="text-base font-semibold text-fg-1">{t('summary.title')}</h3>

--- a/src/app/[lng]/(mobile)/slug-generator/components/SlugGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/slug-generator/components/SlugGeneratorClient.tsx
@@ -83,7 +83,7 @@ export default function SlugGeneratorClient({ lng }: SlugGeneratorClientProps) {
           placeholder={t('empty')}
         />
       </div>
-      {slug && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {slug && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/slug-generator/components/SlugGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/slug-generator/components/SlugGeneratorClient.tsx
@@ -12,6 +12,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface SlugGeneratorClientProps {
   lng: Language;
@@ -82,6 +83,7 @@ export default function SlugGeneratorClient({ lng }: SlugGeneratorClientProps) {
           placeholder={t('empty')}
         />
       </div>
+      {slug && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
@@ -97,7 +97,7 @@ export default function TextCounterClient({ lng }: TextCounterClientProps) {
         ))}
       </div>
 
-      {text.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {text.length > 0 && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
@@ -12,6 +12,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 type TextCounterClientProps = {
   lng: Language;
@@ -95,6 +96,8 @@ export default function TextCounterClient({ lng }: TextCounterClientProps) {
           </div>
         ))}
       </div>
+
+      {text.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/text-repeater/components/TextRepeaterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-repeater/components/TextRepeaterClient.tsx
@@ -12,6 +12,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 interface TextRepeaterClientProps {
   lng: Language;
@@ -124,6 +125,7 @@ export default function TextRepeaterClient({ lng }: TextRepeaterClientProps) {
           readOnly
           placeholder={t('empty')}
         />
+        {output && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
       </div>
     </div>
   );

--- a/src/app/[lng]/(mobile)/text-repeater/components/TextRepeaterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-repeater/components/TextRepeaterClient.tsx
@@ -125,7 +125,7 @@ export default function TextRepeaterClient({ lng }: TextRepeaterClientProps) {
           readOnly
           placeholder={t('empty')}
         />
-        {output && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+        {output && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
       </div>
     </div>
   );

--- a/src/app/[lng]/(mobile)/text-reverser/components/TextReverserClient.tsx
+++ b/src/app/[lng]/(mobile)/text-reverser/components/TextReverserClient.tsx
@@ -118,7 +118,7 @@ export default function TextReverserClient({ lng }: TextReverserClientProps) {
           placeholder={t('empty')}
         />
       </section>
-      {reversed && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {reversed && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/text-reverser/components/TextReverserClient.tsx
+++ b/src/app/[lng]/(mobile)/text-reverser/components/TextReverserClient.tsx
@@ -18,6 +18,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 type ReverseMode = 'characters' | 'words' | 'lines';
 
@@ -117,6 +118,7 @@ export default function TextReverserClient({ lng }: TextReverserClientProps) {
           placeholder={t('empty')}
         />
       </section>
+      {reversed && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/url-parser/components/UrlParserClient.tsx
+++ b/src/app/[lng]/(mobile)/url-parser/components/UrlParserClient.tsx
@@ -21,6 +21,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 type UrlParserClientProps = {
   lng: Language;
@@ -225,6 +226,8 @@ export default function UrlParserClient({ lng }: UrlParserClientProps) {
           </div>
         ) : null}
       </div>
+
+      {parsed.url && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       <div className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
         <Text variant="d2" className="font-semibold text-fg-3">

--- a/src/app/[lng]/(mobile)/url-parser/components/UrlParserClient.tsx
+++ b/src/app/[lng]/(mobile)/url-parser/components/UrlParserClient.tsx
@@ -227,7 +227,7 @@ export default function UrlParserClient({ lng }: UrlParserClientProps) {
         ) : null}
       </div>
 
-      {parsed.url && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {parsed.url && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <div className={cn(SERVICE_PANEL_SOFT, 'space-y-3 p-4')}>
         <Text variant="d2" className="font-semibold text-fg-3">

--- a/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
@@ -21,6 +21,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 
 const MAX_COUNT = 20;
 const MIN_COUNT = 1;
@@ -151,6 +152,7 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
           placeholder={t('placeholder.output')}
         />
       </section>
+      {uuids.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
@@ -152,7 +152,7 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
           placeholder={t('placeholder.output')}
         />
       </section>
-      {uuids.length > 0 && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {uuids.length > 0 && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
     </div>
   );
 }

--- a/src/app/[lng]/(mobile)/water-intake/components/WaterIntakeClient.tsx
+++ b/src/app/[lng]/(mobile)/water-intake/components/WaterIntakeClient.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@components/basic/Select';
 import { SERVICE_PANEL, SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import GoogleAd from '@components/google/GoogleAd';
 import { cn } from '@utils/cn';
 import type { Language } from '~/app/i18n/settings';
 
@@ -135,6 +136,8 @@ export default function WaterIntakeClient({ lng }: Props) {
           )}
         </div>
       </section>
+
+      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
 
       <section className={cn(SERVICE_PANEL, 'p-4 space-y-3')}>
         <header className="space-y-1">

--- a/src/app/[lng]/(mobile)/water-intake/components/WaterIntakeClient.tsx
+++ b/src/app/[lng]/(mobile)/water-intake/components/WaterIntakeClient.tsx
@@ -137,7 +137,7 @@ export default function WaterIntakeClient({ lng }: Props) {
         </div>
       </section>
 
-      {result && <GoogleAd slotId="9185479703" className="w-full mt-4" />}
+      {result && <GoogleAd slotId="7911066601" className="w-full mt-4" />}
 
       <section className={cn(SERVICE_PANEL, 'p-4 space-y-3')}>
         <header className="space-y-1">


### PR DESCRIPTION
## Summary

- **(mobile) 레이아웃**: 모바일(lg 미만)에서 콘텐츠 하단 배너 광고 추가 — 30개+ 서비스 페이지 전체 적용
- **35개 서비스 컴포넌트** 결과 표시 시점에 인라인 광고 조건부 렌더링
- 광고는 결과 state가 유효할 때만 노출, 초기 빈 상태에서는 미표시

## 적용 서비스

| 분류 | 서비스 |
|------|--------|
| 계산기 (7) | BMI, 나이, 부가세, 급여, 출퇴근비용, 수분섭취, 퍼센트 |
| 생성기 (6) | UUID, 로또, 패스프레이즈, QR코드, 동전던지기, 슬러그 |
| 변환기 (9) | JWT, JSON↔YAML, CSV↔JSON, 데이터사이즈, 로마숫자, 한국어금액, 텍스트반복/반전, URL파서 |
| 분석기 (12) | IP조회, BPM, 날짜차이, 대비율, 마크다운테이블, 기념일, 취침계획, 텍스트카운터, Cron, 네트워크계산기 3종 |

## 제외 페이지

메인 · 블로그 · 멀티라이브 · 메뉴 · privacy · terms

## Test plan

- [ ] 각 서비스에서 결과 생성 전에는 광고가 노출되지 않는지 확인
- [ ] 결과 생성 후 광고가 결과 아래에 자연스럽게 표시되는지 확인
- [ ] 모바일(lg 미만)에서 레이아웃 하단 배너 광고 확인
- [ ] 데스크톱(lg 이상)에서 기존 사이드 광고 정상 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)