### PR TITLE
fix: Sentry 이슈 개선 (FRONT-9, FRONT-16/18, FRONT-1G)

### DIFF
--- a/src/app/[lng]/blog/[urlSlug]/page.tsx
+++ b/src/app/[lng]/blog/[urlSlug]/page.tsx
@@ -24,18 +24,22 @@ export async function generateStaticParams() {
   }
 }
 
-const getPost = cache(async (urlSlug: string) => {
-  try {
-    const { data } = await blogApi.getBlogUrlSlug(decodeURIComponent(urlSlug));
+const getPost = cache(
+  async (urlSlug: string) => {
+    try {
+      const { data } = await blogApi.getBlogUrlSlug(decodeURIComponent(urlSlug));
 
-    return data;
-  } catch (error) {
-    if (axios.isAxiosError<BaseException, never>(error)) {
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError<BaseException, never>(error)) {
+        return notFound();
+      }
       return notFound();
     }
-    return notFound();
-  }
-});
+  },
+  ['blog-post'],
+  { revalidate: 3600, tags: ['blog-post'] },
+);
 
 export const generateMetadata = async (props: BlogDetailProps) => {
   const params = await props.params;

--- a/src/components/complex/MarkDown/Code.tsx
+++ b/src/components/complex/MarkDown/Code.tsx
@@ -5,11 +5,11 @@ const Code: MarkdownComponent = function Code({ children }) {
   useEffect(() => {
     const highlight = async () => {
       const Prism = (await import('prismjs')).default;
+      await import('prismjs/components/prism-typescript');
+      await import('prismjs/components/prism-jsx');
+      await import('prismjs/components/prism-tsx');
       await Promise.all([
-        import('prismjs/components/prism-typescript'),
         import('prismjs/components/prism-javascript'),
-        import('prismjs/components/prism-jsx'),
-        import('prismjs/components/prism-tsx'),
         import('prismjs/components/prism-json'),
         import('prismjs/components/prism-yaml'),
         import('prismjs/components/prism-java'),

--- a/src/components/google/GoogleAd.tsx
+++ b/src/components/google/GoogleAd.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 declare global {
   interface Window {
@@ -14,17 +14,21 @@ type GoogleAdProps = {
 };
 
 function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
+  const insRef = useRef<HTMLModElement>(null);
+
   useEffect(() => {
+    if (!insRef.current || insRef.current.offsetWidth === 0) return;
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
-    } catch (error) {
-      // console.error('Google Ad error:', error);
+    } catch (_) {
+      // adsbygoogle push errors are non-fatal
     }
   }, []);
 
   return (
     <div className={className}>
       <ins
+        ref={insRef}
         className="adsbygoogle"
         style={{ display: 'block' }}
         data-ad-client={process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_CLIENT_ID}


### PR DESCRIPTION
## Summary

- **FRONT-9** (694 events, 439 users): `GoogleAd` 컴포넌트에서 `offsetWidth === 0` 체크 추가 — `lg:hidden` 상태일 때 `adsbygoogle.push()` 호출 차단
- **FRONT-16/18** (12 events, 11 users): `Code.tsx`에서 prismjs 언어 의존성 순서 보장 — `prism-typescript` → `prism-jsx` → `prism-tsx` 순차 import로 race condition 수정
- **FRONT-1G** (90 events): `unstable_cache` tags를 ASCII-safe(`['blog-post']`)로 명시해 한글 urlSlug가 `x-next-cache-tags` 헤더에 포함될 때 발생하는 RFC 7230 위반 에러 방지

## Test plan

- [ ] 모바일 뷰에서 `lg:hidden` 광고 영역이 있는 페이지 접속 → 콘솔에 adsbygoogle 에러 없음
- [ ] 코드 블록이 있는 블로그 포스트 접속 → tsx/typescript 코드 하이라이팅 정상 동작, 콘솔 에러 없음
- [ ] 한글 slug 블로그 포스트 접속 → 서버 에러 없음 (500 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)