### PR TITLE
fix: Sentry 이슈 개선 2차 (FRONT-19, FRONT-1T)

### DIFF
--- a/src/app/[lng]/global-error.tsx
+++ b/src/app/[lng]/global-error.tsx
@@ -1,22 +1,71 @@
 'use client';
 
 import * as Sentry from '@sentry/nextjs';
-import NextError from 'next/error';
 import { useEffect } from 'react';
 
-export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
+const STALE_RELOAD_KEY = 'sentry_stale_action_reloaded';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const isStaleDeployment = error.message?.includes('Failed to find Server Action');
+
   useEffect(() => {
+    if (isStaleDeployment) {
+      const alreadyReloaded = sessionStorage.getItem(STALE_RELOAD_KEY);
+      if (!alreadyReloaded) {
+        sessionStorage.setItem(STALE_RELOAD_KEY, '1');
+        window.location.reload();
+      }
+      return;
+    }
     Sentry.captureException(error);
-  }, [error]);
+  }, [error, isStaleDeployment]);
+
+  if (isStaleDeployment) {
+    return (
+      <html lang="en">
+        <body
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            height: '100vh',
+            fontFamily: 'sans-serif',
+          }}
+        >
+          <div style={{ textAlign: 'center' }}>
+            <p>페이지를 업데이트하는 중입니다...</p>
+            <button type="button" onClick={() => window.location.reload()}>
+              새로고침
+            </button>
+          </div>
+        </body>
+      </html>
+    );
+  }
 
   return (
     <html lang="en">
-      <body>
-        {/* `NextError` is the default Next.js error page component. Its type
-        definition requires a `statusCode` prop. However, since the App Router
-        does not expose status codes for errors, we simply pass 0 to render a
-        generic error message. */}
-        <NextError statusCode={0} />
+      <body
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ textAlign: 'center' }}>
+          <p>오류가 발생했습니다.</p>
+          <button type="button" onClick={reset}>
+            다시 시도
+          </button>
+        </div>
       </body>
     </html>
   );

--- a/src/spec/api/index.ts
+++ b/src/spec/api/index.ts
@@ -111,7 +111,9 @@ const refreshAccessToken = async (): Promise<string> => {
 apiInstance.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
-    Sentry.captureException(error);
+    if (error.response) {
+      Sentry.captureException(error);
+    }
     const originalRequest = error.config as RetryableRequestConfig | undefined;
     if (!originalRequest) {
       return Promise.reject(error);


### PR DESCRIPTION
## Summary

- **FRONT-19** (163 events, 57 users, 진행 중): `api/index.ts` response interceptor에서 Network Error(`error.response` 없음)는 Sentry 전송 제외 — 네트워크 불안정으로 인한 노이즈 제거, 실제 서버 에러(응답 있는 경우)는 여전히 전송
- **FRONT-1T** (1 event): `global-error.tsx`에서 "Failed to find Server Action" 에러(배포 불일치) 감지 시 `sessionStorage` 플래그로 1회 자동 새로고침, Sentry 미전송 처리
- **FRONT-1S** (2 events): Android 4.0.4 구형 기기 스트리밍 연결 에러 — 코드 수정 불가, Sentry에서 `ignored(forever)` 처리

## Test plan

- [ ] 네트워크 오프라인 상태에서 API 호출 → Sentry 이벤트 미전송 확인 (응답 있는 4xx/5xx는 여전히 전송)
- [ ] 배포 불일치 상황에서 Server Action POST 요청 → "페이지를 업데이트하는 중입니다..." UI + 자동 새로고침 확인, Sentry 미전송 확인
- [ ] 일반 에러 발생 시 "오류가 발생했습니다." UI + Sentry 정상 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)