### PR TITLE
feat: GA4 전체 이벤트 태깅 구현 (Phase 1~4)

### DIFF
--- a/src/app/[lng]/(mobile)/age-calculator/components/AgeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/age-calculator/components/AgeCalculatorClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   addMonths,
   addYears,
@@ -29,6 +29,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface AgeCalculatorClientProps {
   lng: Language;
@@ -38,13 +39,20 @@ const todayString = () => format(new Date(), 'yyyy-MM-dd');
 
 export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
   const { t } = useTranslation(lng, 'age-calculator');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'age-calculator',
+    'calculator',
+  );
   const [birthDate, setBirthDate] = useState('');
   const [referenceDate, setReferenceDate] = useState(todayString());
   const [copied, setCopied] = useState(false);
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     setCopied(false);
   }, [birthDate, referenceDate]);
+
+  // result/data 정의는 아래 useMemo 이후에 사용
 
   const result = useMemo(() => {
     if (!birthDate) return { error: null, data: null };
@@ -84,6 +92,16 @@ export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
     };
   }, [birthDate, referenceDate, t]);
 
+  useEffect(() => {
+    if (result.data) {
+      const key = `${birthDate}|${referenceDate}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({ action_type: 'calculate', success: true, age_years: result.data.years });
+      }
+    }
+  }, [result, birthDate, referenceDate, trackUse]);
+
   const handleCopy = async () => {
     if (!result.data) return;
     const summary = t('results.summary', {
@@ -97,6 +115,7 @@ export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
     try {
       await navigator.clipboard.writeText(summary);
       setCopied(true);
+      trackCopy();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy summary:', error);
@@ -125,7 +144,10 @@ export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
               id="birth-date"
               type="date"
               value={birthDate}
-              onChange={(event) => setBirthDate(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setBirthDate(event.target.value);
+              }}
             />
           </div>
           <div className="space-y-2">
@@ -136,7 +158,10 @@ export default function AgeCalculatorClient({ lng }: AgeCalculatorClientProps) {
               id="reference-date"
               type="date"
               value={referenceDate}
-              onChange={(event) => setReferenceDate(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setReferenceDate(event.target.value);
+              }}
             />
             <div className="flex flex-wrap gap-2">
               <Button type="button" className="px-3 py-2 text-xs" onClick={handleToday}>

--- a/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/anniversary-counter/components/AnniversaryCounterClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Clipboard, ClipboardCheck, RotateCcw } from 'lucide-react';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
@@ -12,6 +12,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { addDays, calculateDDay, formatDateInput } from '../utils/anniversaryCounter';
 
 interface AnniversaryCounterClientProps {
@@ -20,9 +21,14 @@ interface AnniversaryCounterClientProps {
 
 export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClientProps) {
   const { t } = useTranslation(lng, 'anniversary-counter');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'anniversary-counter',
+    'calculator',
+  );
   const [date, setDate] = useState('');
   const [includeToday, setIncludeToday] = useState(true);
   const [copied, setCopied] = useState(false);
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   const today = new Date();
 
@@ -61,6 +67,16 @@ export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClie
     setCopied(false);
   }, [date, includeToday]);
 
+  useEffect(() => {
+    if (result) {
+      const key = `${date}|${includeToday}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({ action_type: 'calculate', success: true, diff_days: result.diffDays });
+      }
+    }
+  }, [result, date, includeToday, trackUse]);
+
   const handleQuickDate = (amount: number) => {
     const next = formatDateInput(addDays(new Date(), amount));
     setDate(next);
@@ -89,6 +105,7 @@ export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClie
 
       await navigator.clipboard.writeText(copyText);
       setCopied(true);
+      trackCopy();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy result:', error);
@@ -106,7 +123,10 @@ export default function AnniversaryCounterClient({ lng }: AnniversaryCounterClie
             id="anniversary-date"
             type="date"
             value={date}
-            onChange={(event) => setDate(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setDate(event.target.value);
+            }}
           />
           <p className="text-xs text-fg-5">{t('helper')}</p>
         </div>

--- a/src/app/[lng]/(mobile)/auth/login/page.tsx
+++ b/src/app/[lng]/(mobile)/auth/login/page.tsx
@@ -13,6 +13,7 @@ import useStore from '@hooks/useStore';
 import { useTranslation } from '~/app/i18n/client';
 import { LanguageParams } from '~/app/[lng]/layout';
 import UserTokenUtil from '~/utils/userTokenUtil';
+import { sendGAEvent } from '@libs/client/gtag';
 import { Language } from '~/app/i18n/settings';
 import { Text } from '@components/basic/Text';
 import { Button } from '@components/basic/Button';
@@ -39,6 +40,10 @@ export default function LoginPage({ params }: LanguageParams) {
         .then(({ data: { access_token, refresh_token, user_id } }) => {
           userApi.getUserUserId(`Bearer ${access_token}`, user_id).then(({ data }) => {
             setUser(data);
+            sendGAEvent('login_success', 'google', {
+              provider: 'google',
+              is_new_user: false,
+            });
 
             // 토큰과 사용자 정보를 클라이언트 쿠키에 직접 저장
             UserTokenUtil.setAccessToken(access_token);
@@ -48,6 +53,10 @@ export default function LoginPage({ params }: LanguageParams) {
           });
         })
         .catch(() => {
+          sendGAEvent('login_failure', 'google', {
+            provider: 'google',
+            error_code: 'oauth_failed',
+          });
           push('/auth/login');
         })
         .finally(() => {
@@ -84,6 +93,10 @@ export default function LoginPage({ params }: LanguageParams) {
     const state = Math.random().toString(36).substring(2, 15);
     const url = `${oauthUrl}?scope=${scope}&include_granted_scopes=true&response_type=token&state=${state}&redirect_uri=${window.location.origin}/auth/login&client_id=${clientId}`;
     Cookies.set('login_state', state);
+    sendGAEvent('login_attempt', 'google', {
+      provider: 'google',
+      from_path: window.location.pathname,
+    });
     window.location.href = url;
   };
 

--- a/src/app/[lng]/(mobile)/bedtime-planner/components/BedtimePlannerClient.tsx
+++ b/src/app/[lng]/(mobile)/bedtime-planner/components/BedtimePlannerClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Select,
   SelectContent,
@@ -17,6 +17,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface BedtimePlannerClientProps {
   lng: Language;
@@ -36,8 +37,10 @@ const addMinutes = (base: Date, minutes: number) => new Date(base.getTime() + mi
 
 export default function BedtimePlannerClient({ lng }: BedtimePlannerClientProps) {
   const { t } = useTranslation(lng, 'bedtime-planner');
+  const { trackInputStarted, trackUse } = useToolTracking('bedtime-planner', 'calculator');
   const [mode, setMode] = useState('wake');
   const [time, setTime] = useState('07:00');
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   const formatter = useMemo(
     () =>
@@ -71,6 +74,16 @@ export default function BedtimePlannerClient({ lng }: BedtimePlannerClientProps)
     });
   }, [mode, time]);
 
+  useEffect(() => {
+    if (results.length > 0) {
+      const key = `${mode}|${time}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({ action_type: 'calculate', success: true, mode });
+      }
+    }
+  }, [results, mode, time, trackUse]);
+
   const getDayLabel = (dayDiff: number) => {
     if (dayDiff === -1) return t('result.previousDay');
     if (dayDiff === 1) return t('result.nextDay');
@@ -84,7 +97,13 @@ export default function BedtimePlannerClient({ lng }: BedtimePlannerClientProps)
           <label htmlFor="mode" className="text-sm font-medium text-fg-3">
             {t('label.mode')}
           </label>
-          <Select value={mode} onValueChange={setMode}>
+          <Select
+            value={mode}
+            onValueChange={(value) => {
+              trackInputStarted();
+              setMode(value);
+            }}
+          >
             <SelectTrigger className="w-full">
               <SelectValue />
             </SelectTrigger>
@@ -102,7 +121,10 @@ export default function BedtimePlannerClient({ lng }: BedtimePlannerClientProps)
             id="time"
             type="time"
             value={time}
-            onChange={(event) => setTime(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setTime(event.target.value);
+            }}
           />
           <p className="mt-1 text-xs text-fg-5">{t('helper')}</p>
         </div>

--- a/src/app/[lng]/(mobile)/bmi-calculator/components/BmiCalculator.tsx
+++ b/src/app/[lng]/(mobile)/bmi-calculator/components/BmiCalculator.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { Text } from '@components/basic/Text';
 import { cn } from '@utils/cn';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
@@ -33,9 +34,14 @@ const BMI_CATEGORIES: BmiCategory[] = [
 
 export default function BmiCalculator({ lng }: BmiCalculatorProps) {
   const { t } = useTranslation(lng, 'bmi-calculator');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'bmi-calculator',
+    'calculator',
+  );
   const [height, setHeight] = useState('');
   const [weight, setWeight] = useState('');
   const [copied, setCopied] = useState(false);
+  const lastTrackedBmiRef = useRef<number | null>(null);
 
   const result = useMemo(() => {
     const heightCm = Number(height);
@@ -63,6 +69,13 @@ export default function BmiCalculator({ lng }: BmiCalculatorProps) {
     };
   }, [height, weight]);
 
+  useEffect(() => {
+    if (result?.valid && result.bmi && lastTrackedBmiRef.current !== result.bmi) {
+      lastTrackedBmiRef.current = result.bmi;
+      trackUse({ action_type: 'calculate', success: true, category: result.category ?? 'unknown' });
+    }
+  }, [result, trackUse]);
+
   const handleReset = () => {
     setHeight('');
     setWeight('');
@@ -77,6 +90,7 @@ export default function BmiCalculator({ lng }: BmiCalculatorProps) {
     try {
       await navigator.clipboard.writeText(message);
       setCopied(true);
+      trackCopy();
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {
       setCopied(false);
@@ -104,7 +118,10 @@ export default function BmiCalculator({ lng }: BmiCalculatorProps) {
             step="0.1"
             placeholder={t('placeholder.height')}
             value={height}
-            onChange={(event) => setHeight(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setHeight(event.target.value);
+            }}
           />
         </div>
         <div className="space-y-2">
@@ -118,7 +135,10 @@ export default function BmiCalculator({ lng }: BmiCalculatorProps) {
             step="0.1"
             placeholder={t('placeholder.weight')}
             value={weight}
-            onChange={(event) => setWeight(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setWeight(event.target.value);
+            }}
           />
         </div>
         <Text variant="d3" color="basic-5" className="block">

--- a/src/app/[lng]/(mobile)/bpm-tapper/components/BpmTapperClient.tsx
+++ b/src/app/[lng]/(mobile)/bpm-tapper/components/BpmTapperClient.tsx
@@ -13,6 +13,8 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
+import { sendGAEvent } from '@libs/client/gtag';
 
 interface BpmTapperClientProps {
   lng: Language;
@@ -28,6 +30,7 @@ export default function BpmTapperClient({ lng }: BpmTapperClientProps) {
   const { t } = useTranslation(lng, 'bpm-tapper');
   const [taps, setTaps] = useState<number[]>([]);
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('bpm-tapper', 'utility');
 
   const { bpm, averageInterval } = useMemo(() => {
     if (taps.length < 2) {
@@ -47,10 +50,34 @@ export default function BpmTapperClient({ lng }: BpmTapperClientProps) {
 
   const handleTap = () => {
     const now = Date.now();
-    setTaps((prev) => [...prev, now]);
+    trackInputStarted();
+    setTaps((prev) => {
+      // 첫 탭 시 세션 시작 이벤트 발화
+      if (prev.length === 0) {
+        sendGAEvent('tool_session_start', 'bpm-tapper', {
+          tool_id: 'bpm-tapper',
+          tool_category: 'utility',
+        });
+      }
+      const next = [...prev, now];
+      // 2번째 탭부터 BPM 계산 가능 → tool_use 발화
+      if (next.length >= 2) {
+        trackUse({ action_type: 'tap', success: true });
+      }
+      return next;
+    });
   };
 
   const handleReset = () => {
+    if (taps.length > 0) {
+      const durationSec =
+        taps.length >= 2 ? Math.floor((taps[taps.length - 1] - taps[0]) / 1000) : 0;
+      sendGAEvent('tool_session_end', 'bpm-tapper', {
+        tool_id: 'bpm-tapper',
+        tool_category: 'utility',
+        duration_sec: durationSec,
+      });
+    }
     setTaps([]);
     setCopied(false);
   };
@@ -60,6 +87,7 @@ export default function BpmTapperClient({ lng }: BpmTapperClientProps) {
     try {
       await navigator.clipboard.writeText(String(bpm));
       setCopied(true);
+      trackCopy();
       setTimeout(() => setCopied(false), 1500);
     } catch (error) {
       setCopied(false);

--- a/src/app/[lng]/(mobile)/choseong-maker/page.tsx
+++ b/src/app/[lng]/(mobile)/choseong-maker/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from '~/app/i18n/client';
 import { toChoseong } from '@utils/choseongUtils';
 import { LanguageParams } from '~/app/[lng]/layout';
@@ -9,13 +9,25 @@ import { getServiceCategoryBadge } from '@assets/datas/serviceCategories';
 import { Textarea } from '@components/basic/Textarea';
 import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 export default function ChoseongMakerPage({ params }: LanguageParams) {
   const { lng } = React.use(params);
   const language = lng as Language;
   const { t } = useTranslation(language, 'choseong-maker');
   const badge = getServiceCategoryBadge(language, '/choseong-maker');
+  const { trackInputStarted, trackUse } = useToolTracking('choseong-maker', 'converter');
+  const hasResultRef = useRef(false);
   const [value, setValue] = useState('');
+  const choseongResult = toChoseong(value);
+
+  useEffect(() => {
+    const has = Boolean(choseongResult);
+    if (has && !hasResultRef.current) {
+      trackUse({ action_type: 'convert', success: true });
+    }
+    hasResultRef.current = has;
+  }, [choseongResult, trackUse]);
 
   return (
     <div className="space-y-4">
@@ -29,9 +41,12 @@ export default function ChoseongMakerPage({ params }: LanguageParams) {
           className="h-32 resize-none"
           placeholder={t('placeholder')}
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => {
+            trackInputStarted();
+            setValue(e.target.value);
+          }}
         />
-        <Textarea className="h-32 resize-none" value={toChoseong(value)} readOnly />
+        <Textarea className="h-32 resize-none" value={choseongResult} readOnly />
       </section>
     </div>
   );

--- a/src/app/[lng]/(mobile)/coder/page.tsx
+++ b/src/app/[lng]/(mobile)/coder/page.tsx
@@ -25,6 +25,7 @@ import { Textarea } from '@components/basic/Textarea';
 import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import { getServiceCategoryBadge } from '@assets/datas/serviceCategories';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const coderList: CoderType[] = [
   'BASE64',
@@ -42,6 +43,7 @@ function CoderPage({ params }: LanguageParams) {
   const { t } = useTranslation(language, 'coder');
   const badge = getServiceCategoryBadge(language, '/coder');
   const [copied, setCopied] = useState<boolean>(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('coder', 'utility');
 
   const {
     register,
@@ -80,6 +82,7 @@ function CoderPage({ params }: LanguageParams) {
     const result = runCoder(data);
     setResultList(result);
     setIsMoreOpen(false);
+    trackUse({ action_type: 'run', success: Boolean(result && result.length > 0) });
   };
 
   const setServicesValueDebounced = useMemo(() => debounce(() => setCopied(false), 1000), []);
@@ -89,6 +92,7 @@ function CoderPage({ params }: LanguageParams) {
     navigator.clipboard.writeText(resultList[resultList.length - 1]);
 
     setCopied(true);
+    trackCopy({ result_format: 'code' });
     setServicesValueDebounced();
   };
 
@@ -163,7 +167,12 @@ function CoderPage({ params }: LanguageParams) {
           />
         </div>
 
-        <Textarea className="resize-none h-32 w-full" {...register('value')} />
+        <Textarea
+          className="resize-none h-32 w-full"
+          {...register('value', {
+            onChange: () => trackInputStarted(),
+          })}
+        />
         <button type="button" className="button w-full" onClick={handleSubmit(onSubmit)}>
           {t('submit')}
         </button>

--- a/src/app/[lng]/(mobile)/coin-flip/components/CoinFlipClient.tsx
+++ b/src/app/[lng]/(mobile)/coin-flip/components/CoinFlipClient.tsx
@@ -11,6 +11,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const MAX_COINS = 20;
 
@@ -48,6 +49,7 @@ export default function CoinFlipClient({ lng }: CoinFlipClientProps) {
   const { t } = useTranslation(lng, 'coin-flip');
   const [countInput, setCountInput] = useState('1');
   const [results, setResults] = useState<CoinResult[]>([]);
+  const { trackInputStarted, trackUse } = useToolTracking('coin-flip', 'utility');
 
   const safeCount = useMemo(() => getSafeCount(countInput), [countInput]);
   const summary = useMemo(() => {
@@ -63,6 +65,7 @@ export default function CoinFlipClient({ lng }: CoinFlipClientProps) {
   const handleFlip = () => {
     const nextResults = buildResults(safeCount);
     setResults(nextResults);
+    trackUse({ action_type: 'flip', success: true });
   };
 
   const handleReset = () => {
@@ -84,7 +87,10 @@ export default function CoinFlipClient({ lng }: CoinFlipClientProps) {
               min={1}
               max={MAX_COINS}
               value={countInput}
-              onChange={(event) => setCountInput(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setCountInput(event.target.value);
+              }}
               className="font-mono"
             />
             <p className="text-xs text-fg-5">{t('helper')}</p>

--- a/src/app/[lng]/(mobile)/commute-cost/components/CommuteCostClient.tsx
+++ b/src/app/[lng]/(mobile)/commute-cost/components/CommuteCostClient.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const DEFAULT_WEEKS = 4.3;
 const DEFAULT_DAYS = 5;
@@ -22,10 +23,12 @@ type CommuteCostClientProps = {
 
 export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
   const { t } = useTranslation(lng, 'commute-cost');
+  const { trackInputStarted, trackUse } = useToolTracking('commute-cost', 'calculator');
   const [roundTrip, setRoundTrip] = useState('');
   const [daysPerWeek, setDaysPerWeek] = useState(String(DEFAULT_DAYS));
   const [weeksPerMonth, setWeeksPerMonth] = useState(String(DEFAULT_WEEKS));
   const [monthlyPass, setMonthlyPass] = useState('');
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   const values = useMemo(() => {
     const roundTripValue = numberOrZero(roundTrip);
@@ -46,6 +49,16 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
     };
   }, [roundTrip, daysPerWeek, weeksPerMonth, monthlyPass]);
 
+  useEffect(() => {
+    if (roundTrip && values.monthlyCost > 0) {
+      const key = `${roundTrip}|${daysPerWeek}|${weeksPerMonth}|${monthlyPass}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({ action_type: 'calculate', success: true, monthly_cost: values.monthlyWithPass });
+      }
+    }
+  }, [roundTrip, daysPerWeek, weeksPerMonth, monthlyPass, values, trackUse]);
+
   const reset = () => {
     setRoundTrip('');
     setDaysPerWeek(String(DEFAULT_DAYS));
@@ -65,7 +78,10 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
               step="100"
               placeholder={t('roundTripPlaceholder')}
               value={roundTrip}
-              onChange={(event) => setRoundTrip(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setRoundTrip(event.target.value);
+              }}
             />
           </div>
           <div className="space-y-2">
@@ -76,7 +92,10 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
               max={7}
               step="1"
               value={daysPerWeek}
-              onChange={(event) => setDaysPerWeek(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setDaysPerWeek(event.target.value);
+              }}
             />
           </div>
           <div className="space-y-2">
@@ -86,7 +105,10 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
               min={1}
               step="0.1"
               value={weeksPerMonth}
-              onChange={(event) => setWeeksPerMonth(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setWeeksPerMonth(event.target.value);
+              }}
             />
           </div>
           <div className="space-y-2">
@@ -97,7 +119,10 @@ export default function CommuteCostClient({ lng }: CommuteCostClientProps) {
               step="1000"
               placeholder={t('passPlaceholder')}
               value={monthlyPass}
-              onChange={(event) => setMonthlyPass(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setMonthlyPass(event.target.value);
+              }}
             />
           </div>
         </div>

--- a/src/app/[lng]/(mobile)/contrast-checker/components/ContrastCheckerClient.tsx
+++ b/src/app/[lng]/(mobile)/contrast-checker/components/ContrastCheckerClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { Text } from '@components/basic/Text';
@@ -82,6 +83,7 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
   const [foreground, setForeground] = useState(DEFAULT_FOREGROUND);
   const [background, setBackground] = useState(DEFAULT_BACKGROUND);
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('contrast-checker', 'utility');
 
   const normalizedForeground = useMemo(() => normalizeHex(foreground), [foreground]);
   const normalizedBackground = useMemo(() => normalizeHex(background), [background]);
@@ -93,6 +95,20 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
   }, [normalizedForeground, normalizedBackground]);
 
   const ratioText = ratio ? ratio.toFixed(2) : '--';
+
+  const wcagLevel = useMemo(() => {
+    if (!ratio) return 'fail';
+    if (ratio >= 7) return 'AAA';
+    if (ratio >= 4.5) return 'AA';
+    return 'fail';
+  }, [ratio]);
+
+  useEffect(() => {
+    if (ratio !== null) {
+      trackUse({ action_type: 'check', success: true, wcag_level: wcagLevel });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ratio, wcagLevel]);
 
   const handleSwap = () => {
     setForeground(background);
@@ -110,6 +126,7 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
     }
     await navigator.clipboard.writeText(ratio.toFixed(2));
     setCopied(true);
+    trackCopy();
     window.setTimeout(() => setCopied(false), 1500);
   };
 
@@ -148,12 +165,18 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
               id="contrast-foreground"
               type="color"
               value={normalizedForeground ?? DEFAULT_FOREGROUND}
-              onChange={(event) => setForeground(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setForeground(event.target.value);
+              }}
               className="h-10 w-10 cursor-pointer rounded border border-basic-3 dark:border-basic-4"
             />
             <Input
               value={foreground}
-              onChange={(event) => setForeground(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setForeground(event.target.value);
+              }}
               placeholder="#111827"
               aria-label={t('label.foreground')}
             />
@@ -174,12 +197,18 @@ function ContrastCheckerClient({ lng }: ContrastCheckerClientProps) {
               id="contrast-background"
               type="color"
               value={normalizedBackground ?? DEFAULT_BACKGROUND}
-              onChange={(event) => setBackground(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setBackground(event.target.value);
+              }}
               className="h-10 w-10 cursor-pointer rounded border border-basic-3 dark:border-basic-4"
             />
             <Input
               value={background}
-              onChange={(event) => setBackground(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setBackground(event.target.value);
+              }}
               placeholder="#ffffff"
               aria-label={t('label.background')}
             />

--- a/src/app/[lng]/(mobile)/cron-generator/components/CronGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/cron-generator/components/CronGeneratorClient.tsx
@@ -8,6 +8,7 @@ import ServiceInfoNotice from '@components/complex/Service/ServiceInfoNotice';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import CronExpressionInput from './CronExpressionInput';
 import CronFieldBuilder, { CronFieldMode } from './CronFieldBuilder';
 import CronGuideGrid from './CronGuideGrid';
@@ -81,6 +82,7 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
   const [builderState, setBuilderState] = useState<CronBuilderState>(INITIAL_BUILDER_STATE);
   const [humanReadable, setHumanReadable] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const { trackInputStarted, trackUse } = useToolTracking('cron-generator', 'generator');
 
   const expression = useMemo(() => {
     return [
@@ -93,6 +95,7 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
   }, [builderState]);
 
   const updateFieldMode = (fieldKey: CronFieldKey, mode: CronFieldMode) => {
+    trackInputStarted();
     setBuilderState((prev) => ({
       ...prev,
       [fieldKey]: {
@@ -103,6 +106,7 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
   };
 
   const updateFieldEnabled = (fieldKey: CronFieldKey, enabled: boolean) => {
+    trackInputStarted();
     setBuilderState((prev) => ({
       ...prev,
       [fieldKey]: {
@@ -113,6 +117,7 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
   };
 
   const updateFieldValue = (fieldKey: CronFieldKey, value: number) => {
+    trackInputStarted();
     const { min, max } = FIELD_CONSTRAINTS[fieldKey];
 
     setBuilderState((prev) => ({
@@ -129,11 +134,13 @@ function CronGeneratorClient({ lng }: CronGeneratorClientProps) {
       const desc = cronstrue.toString(expression, { locale: CRONSTRUE_LOCALE[lng] });
       setHumanReadable(desc);
       setError(null);
+      trackUse({ action_type: 'parse', success: true });
     } catch {
       setHumanReadable('');
       setError(t('invalid'));
+      trackUse({ action_type: 'parse', success: false, error_code: 'invalid_expression' });
     }
-  }, [expression, lng, t]);
+  }, [expression, lng, t, trackUse]);
 
   return (
     <div className="w-full space-y-6">

--- a/src/app/[lng]/(mobile)/css-generator/components/CodeBlock.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/CodeBlock.tsx
@@ -5,12 +5,14 @@ interface CodeBlockProps {
   code: string;
   id: string;
   tooltip: string;
+  onCopy?: () => void;
 }
 
-export function CodeBlock({ title, code, id, tooltip }: CodeBlockProps) {
+export function CodeBlock({ title, code, id, tooltip, onCopy }: CodeBlockProps) {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);
+      onCopy?.();
     } catch {
       // Ignore clipboard write failures to keep UI interaction non-blocking.
     }
@@ -34,3 +36,7 @@ export function CodeBlock({ title, code, id, tooltip }: CodeBlockProps) {
     </div>
   );
 }
+
+CodeBlock.defaultProps = {
+  onCopy: undefined,
+};

--- a/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
+++ b/src/app/[lng]/(mobile)/css-generator/components/CssGenerator.tsx
@@ -7,6 +7,7 @@ import { cn } from '@utils/cn';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { CodeBlock } from './CodeBlock';
 import { Control } from './Control';
 import { GeneratorTabs } from './GeneratorTabs';
@@ -85,6 +86,7 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
   const [radius, setRadius] = useState<RadiusState>(INITIAL_RADIUS);
   const [flex, setFlex] = useState<FlexState>(INITIAL_FLEX);
   const [grid, setGrid] = useState<GridState>(INITIAL_GRID);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('css-generator', 'generator');
 
   const shadowCss = useMemo(() => buildShadowCss(shadow), [shadow]);
   const shadowTailwind = useMemo(() => buildShadowTailwind(shadow), [shadow]);
@@ -166,22 +168,32 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
   );
 
   const updateShadow = <K extends keyof ShadowState>(key: K, value: ShadowState[K]) => {
+    trackInputStarted();
+    trackUse({ action_type: 'generate', success: true, generator: 'shadow' });
     setShadow((prev) => ({ ...prev, [key]: value }));
   };
 
   const updateGradient = <K extends keyof GradientState>(key: K, value: GradientState[K]) => {
+    trackInputStarted();
+    trackUse({ action_type: 'generate', success: true, generator: 'gradient' });
     setGradient((prev) => ({ ...prev, [key]: value }));
   };
 
   const updateRadius = <K extends keyof RadiusState>(key: K, value: RadiusState[K]) => {
+    trackInputStarted();
+    trackUse({ action_type: 'generate', success: true, generator: 'radius' });
     setRadius((prev) => ({ ...prev, [key]: value }));
   };
 
   const updateFlex = <K extends keyof FlexState>(key: K, value: FlexState[K]) => {
+    trackInputStarted();
+    trackUse({ action_type: 'generate', success: true, generator: 'flex' });
     setFlex((prev) => ({ ...prev, [key]: value }));
   };
 
   const updateGrid = <K extends keyof GridState>(key: K, value: GridState[K]) => {
+    trackInputStarted();
+    trackUse({ action_type: 'generate', success: true, generator: 'grid' });
     setGrid((prev) => ({ ...prev, [key]: value }));
   };
 
@@ -199,7 +211,10 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
     <div className={cn(SERVICE_PANEL_SOFT, 'w-full space-y-8 p-4')}>
       <GeneratorTabs
         activeTab={activeTab}
-        onTabChange={setActiveTab}
+        onTabChange={(tab) => {
+          trackInputStarted();
+          setActiveTab(tab);
+        }}
         shadowLabel={t('tab.shadow')}
         gradientLabel={t('tab.gradient')}
         radiusLabel={t('tab.radius')}
@@ -283,12 +298,14 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
               title={t('code.css')}
               code={`box-shadow: ${shadowCss};`}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'css' })}
             />
             <CodeBlock
               id={`${baseId}-code-tailwind`}
               title={t('code.tailwind')}
               code={shadowTailwind}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'tailwind' })}
             />
           </div>
         </div>
@@ -357,12 +374,14 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
               title={t('code.css')}
               code={`background: ${gradientCss};`}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'css' })}
             />
             <CodeBlock
               id={`${baseId}-code-grad-tw`}
               title={`${t('code.tailwind')} (Arbitrary)`}
               code={gradientTailwind}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'tailwind' })}
             />
           </div>
         </div>
@@ -419,12 +438,14 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
               title={t('code.css')}
               code={`border-radius: ${radiusCss};`}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'css' })}
             />
             <CodeBlock
               id={`${baseId}-code-radius-tailwind`}
               title={`${t('code.tailwind')} (Arbitrary)`}
               code={radiusTailwind}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'tailwind' })}
             />
           </div>
         </div>
@@ -503,12 +524,14 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
               title={t('code.css')}
               code={flexCss}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'css' })}
             />
             <CodeBlock
               id={`${baseId}-code-flex-tailwind`}
               title={`${t('code.tailwind')} (Arbitrary)`}
               code={flexTailwind}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'tailwind' })}
             />
           </div>
         </div>
@@ -595,12 +618,14 @@ export default function CssGenerator({ lng }: CssGeneratorProps) {
               title={t('code.css')}
               code={gridCss}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'css' })}
             />
             <CodeBlock
               id={`${baseId}-code-grid-tailwind`}
               title={`${t('code.tailwind')} (Arbitrary)`}
               code={gridTailwind}
               tooltip={t('code.copy')}
+              onCopy={() => trackCopy({ result_format: 'tailwind' })}
             />
           </div>
         </div>

--- a/src/app/[lng]/(mobile)/csv-json-converter/components/CsvJsonConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/csv-json-converter/components/CsvJsonConverterClient.tsx
@@ -20,6 +20,7 @@ import {
   CsvRecord,
 } from '~/app/[lng]/(mobile)/csv-json-converter/utils/csv';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const delimiterOptions = [
   { label: ',', value: ',' },
@@ -34,6 +35,10 @@ type CsvJsonConverterClientProps = {
 
 export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientProps) {
   const { t } = useTranslation(lng, 'csv-json-converter');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'csv-json-converter',
+    'converter',
+  );
   const [delimiter, setDelimiter] = useState(',');
   const [hasHeader, setHasHeader] = useState(true);
   const [csvInput, setCsvInput] = useState('');
@@ -66,13 +71,16 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
       const { records } = parseCsv(csvInput, normalizedDelimiter, hasHeader);
       if (!records.length) {
         setError(t('error.emptyCsv'));
+        trackUse({ action_type: 'csv-to-json', success: false, error_code: 'empty_csv' });
         return;
       }
       const json = JSON.stringify(records, null, 2);
       setJsonInput(json);
       setError('');
+      trackUse({ action_type: 'csv-to-json', success: true });
     } catch (err) {
       setError(t('error.invalidCsv'));
+      trackUse({ action_type: 'csv-to-json', success: false, error_code: 'invalid_csv' });
     }
   };
 
@@ -81,6 +89,7 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
       const parsed = JSON.parse(jsonInput);
       if (!Array.isArray(parsed) || parsed.length === 0) {
         setError(t('error.invalidJson'));
+        trackUse({ action_type: 'json-to-csv', success: false, error_code: 'invalid_json' });
         return;
       }
       const records: CsvRecord[] = parsed.map((row: Record<string, unknown>) =>
@@ -92,19 +101,23 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
       const csv = stringifyCsv(records, normalizedDelimiter, hasHeader);
       setCsvInput(csv);
       setError('');
+      trackUse({ action_type: 'json-to-csv', success: true });
     } catch (err) {
       setError(t('error.invalidJson'));
+      trackUse({ action_type: 'json-to-csv', success: false, error_code: 'invalid_json' });
     }
   };
 
   const copyJson = async () => {
     if (!jsonInput) return;
     await navigator.clipboard.writeText(jsonInput);
+    trackCopy({ result_format: 'json' });
   };
 
   const copyCsv = async () => {
     if (!csvInput) return;
     await navigator.clipboard.writeText(csvInput);
+    trackCopy({ result_format: 'csv' });
   };
 
   return (
@@ -191,7 +204,10 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
             className="min-h-[220px]"
             placeholder={t('placeholder.csv')}
             value={csvInput}
-            onChange={(event) => setCsvInput(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setCsvInput(event.target.value);
+            }}
           />
         </div>
         <div className="space-y-2">
@@ -207,7 +223,10 @@ export default function CsvJsonConverterClient({ lng }: CsvJsonConverterClientPr
             className="min-h-[220px]"
             placeholder={t('placeholder.json')}
             value={jsonInput}
-            onChange={(event) => setJsonInput(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setJsonInput(event.target.value);
+            }}
           />
         </div>
       </div>

--- a/src/app/[lng]/(mobile)/data-size-converter/components/DataSizeConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/data-size-converter/components/DataSizeConverterClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { Input } from '@components/basic/Input';
@@ -14,6 +14,7 @@ import {
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const localeMap: Record<Language, string> = {
   ko: 'ko-KR',
@@ -44,6 +45,8 @@ interface DataSizeConverterClientProps {
 
 export default function DataSizeConverterClient({ lng }: DataSizeConverterClientProps) {
   const { t } = useTranslation(lng, 'data-size-converter');
+  const { trackInputStarted, trackUse } = useToolTracking('data-size-converter', 'converter');
+  const hasResultRef = useRef(false);
   const [value, setValue] = useState('');
   const [unit, setUnit] = useState<UnitKey>('megabyte');
   const [standard, setStandard] = useState<StandardKey>('binary');
@@ -77,6 +80,14 @@ export default function DataSizeConverterClient({ lng }: DataSizeConverterClient
     });
   }, [standard, unit, value]);
 
+  useEffect(() => {
+    const has = results !== null;
+    if (has && !hasResultRef.current) {
+      trackUse({ action_type: 'convert', success: true });
+    }
+    hasResultRef.current = has;
+  }, [results, trackUse]);
+
   return (
     <div className="w-full space-y-6">
       <div className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-4')}>
@@ -91,7 +102,10 @@ export default function DataSizeConverterClient({ lng }: DataSizeConverterClient
             className="font-mono"
             placeholder={t('placeholder')}
             value={value}
-            onChange={(event) => setValue(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setValue(event.target.value);
+            }}
           />
           <Select value={unit} onValueChange={(nextValue) => setUnit(nextValue as UnitKey)}>
             <SelectTrigger>

--- a/src/app/[lng]/(mobile)/date-diff/components/DateDiffClient.tsx
+++ b/src/app/[lng]/(mobile)/date-diff/components/DateDiffClient.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useId, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Button } from '@components/basic/Button';
 import { Input } from '@components/basic/Input';
 import { Text } from '@components/basic/Text';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { calculateDateRange, formatDateInput } from '../utils/dateDiff';
 
 type Labels = {
@@ -34,11 +35,13 @@ type DateDiffClientProps = {
 };
 
 function DateDiffClient({ labels }: DateDiffClientProps) {
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('date-diff', 'calculator');
   const today = useMemo(() => formatDateInput(new Date()), []);
   const [startDate, setStartDate] = useState(today);
   const [endDate, setEndDate] = useState(today);
   const [includeEnd, setIncludeEnd] = useState(false);
   const [copied, setCopied] = useState(false);
+  const lastTrackedKeyRef = useRef<string | null>(null);
   const startId = useId();
   const endId = useId();
   const includeEndId = useId();
@@ -53,6 +56,16 @@ function DateDiffClient({ labels }: DateDiffClientProps) {
     return calculateDateRange(startDate, endDate, includeEnd) === null;
   }, [startDate, endDate, includeEnd]);
 
+  useEffect(() => {
+    if (result) {
+      const key = `${startDate}|${endDate}|${includeEnd}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({ action_type: 'calculate', success: true, total_days: result.totalDays });
+      }
+    }
+  }, [result, startDate, endDate, includeEnd, trackUse]);
+
   const summary = useMemo(() => {
     if (!result) return '';
     return `${labels.summaryTitle}: ${result.totalDays} ${labels.dayUnit} · ${result.weeks} ${labels.weekUnit} ${result.remainingDays} ${labels.dayUnit} · ${labels.weekdays} ${result.weekdays} / ${labels.weekends} ${result.weekends}`;
@@ -63,6 +76,7 @@ function DateDiffClient({ labels }: DateDiffClientProps) {
     try {
       await navigator.clipboard.writeText(summary);
       setCopied(true);
+      trackCopy();
       setTimeout(() => setCopied(false), 2000);
     } catch {
       setCopied(false);
@@ -91,7 +105,10 @@ function DateDiffClient({ labels }: DateDiffClientProps) {
               id={startId}
               type="date"
               value={startDate}
-              onChange={(event) => setStartDate(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setStartDate(event.target.value);
+              }}
             />
           </label>
           <label className="space-y-1" htmlFor={endId}>
@@ -100,7 +117,10 @@ function DateDiffClient({ labels }: DateDiffClientProps) {
               id={endId}
               type="date"
               value={endDate}
-              onChange={(event) => setEndDate(event.target.value)}
+              onChange={(event) => {
+                trackInputStarted();
+                setEndDate(event.target.value);
+              }}
             />
           </label>
         </div>

--- a/src/app/[lng]/(mobile)/ip-lookup/components/IpLookupClient.tsx
+++ b/src/app/[lng]/(mobile)/ip-lookup/components/IpLookupClient.tsx
@@ -28,6 +28,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import type { PortInfo } from '~/app/api/ip-lookup/port-scan/route';
 
 interface IpLookupClientProps {
@@ -152,6 +153,7 @@ export default function IpLookupClient({ lng }: IpLookupClientProps) {
   const [portLoading, setPortLoading] = useState(false);
 
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('ip-lookup', 'utility');
 
   const runPortScan = useCallback(async (ip: string) => {
     setPortLoading(true);
@@ -172,6 +174,7 @@ export default function IpLookupClient({ lng }: IpLookupClientProps) {
   }, []);
 
   const fetchIpInfo = useCallback(async () => {
+    trackInputStarted();
     setIpLoading(true);
     setIpError(null);
     setIpData(null);
@@ -183,13 +186,16 @@ export default function IpLookupClient({ lng }: IpLookupClientProps) {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to fetch');
       setIpData(data);
+      // PII 안전: IP 주소 미포함, 결과 존재 여부만 전송
+      trackUse({ action_type: 'lookup', success: Boolean(data?.ip) });
       runPortScan(data.ip);
     } catch (e) {
       setIpError(e instanceof Error ? e.message : 'Unknown error');
+      trackUse({ action_type: 'lookup', success: false, error_code: 'fetch_failed' });
     } finally {
       setIpLoading(false);
     }
-  }, [runPortScan]);
+  }, [runPortScan, trackInputStarted, trackUse]);
 
   useEffect(() => {
     fetchIpInfo();
@@ -200,6 +206,8 @@ export default function IpLookupClient({ lng }: IpLookupClientProps) {
     try {
       await navigator.clipboard.writeText(ipData.ip);
       setCopied(true);
+      // PII 안전: 채널만 기록
+      trackCopy();
       setTimeout(() => setCopied(false), 2000);
     } catch {
       // ignore

--- a/src/app/[lng]/(mobile)/json-yaml-converter/components/JsonYamlConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/json-yaml-converter/components/JsonYamlConverterClient.tsx
@@ -14,6 +14,7 @@ import {
 } from '@components/complex/Service/interactiveStyles';
 import { parse, stringify } from 'yaml';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface JsonYamlConverterClientProps {
   lng: Language;
@@ -39,6 +40,10 @@ enabled: true
 
 export default function JsonYamlConverterClient({ lng }: JsonYamlConverterClientProps) {
   const { t } = useTranslation(lng, 'json-yaml-converter');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'json-yaml-converter',
+    'converter',
+  );
   const [direction, setDirection] = useState<Direction>('json-to-yaml');
   const [input, setInput] = useState('');
   const [output, setOutput] = useState('');
@@ -68,9 +73,15 @@ export default function JsonYamlConverterClient({ lng }: JsonYamlConverterClient
         const parsed = parse(input);
         setOutput(JSON.stringify(parsed, null, 2));
       }
+      trackUse({ action_type: direction, success: true });
     } catch (convertError) {
       setOutput('');
       setError(direction === 'json-to-yaml' ? t('error.invalidJson') : t('error.invalidYaml'));
+      trackUse({
+        action_type: direction,
+        success: false,
+        error_code: direction === 'json-to-yaml' ? 'invalid_json' : 'invalid_yaml',
+      });
     }
   };
 
@@ -94,6 +105,7 @@ export default function JsonYamlConverterClient({ lng }: JsonYamlConverterClient
     try {
       await navigator.clipboard.writeText(output);
       setCopied(true);
+      trackCopy({ result_format: direction === 'json-to-yaml' ? 'yaml' : 'json' });
       setTimeout(() => setCopied(false), 1200);
     } catch (copyError) {
       setCopied(false);
@@ -159,7 +171,10 @@ export default function JsonYamlConverterClient({ lng }: JsonYamlConverterClient
             className="min-h-[180px] font-mono text-sm"
             placeholder={t('placeholder.input')}
             value={input}
-            onChange={(event) => setInput(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setInput(event.target.value);
+            }}
           />
         </div>
         {error && (

--- a/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
+++ b/src/app/[lng]/(mobile)/jwt-decoder/components/JwtDecoderClient.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import GoogleAd from '@components/google/GoogleAd';
 import JwtTokenInput from './JwtTokenInput';
 import JwtDecodedPanel from './JwtDecodedPanel';
@@ -26,6 +27,7 @@ function JwtDecoderClient({ lng }: JwtDecoderClientProps) {
   const [token, setToken] = useState('');
   const [decoded, setDecoded] = useState<DecodedToken | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { trackInputStarted, trackUse } = useToolTracking('jwt-decoder', 'utility');
 
   useEffect(() => {
     const trimmedToken = token.trim();
@@ -45,11 +47,23 @@ function JwtDecoderClient({ lng }: JwtDecoderClientProps) {
       const payload = jwtDecode<JwtPayload>(trimmedToken);
       setDecoded({ header, payload });
       setError(null);
+      // PII 안전: 디코딩 성공 여부만 전송, payload 내용 절대 포함 금지
+      trackUse({ action_type: 'decode', success: true });
     } catch (err) {
       setDecoded(null);
       setError(t('error.invalidFormat'));
+      // PII 안전: 토큰 본문 미포함, 실패 카테고리만 전송
+      trackUse({ action_type: 'decode', success: false, error_code: 'invalid_format' });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token, t]);
+
+  const handleTokenChange = (next: string) => {
+    if (next.length > 0) {
+      trackInputStarted();
+    }
+    setToken(next);
+  };
 
   return (
     <div className={cn(SERVICE_PANEL_SOFT, 'w-full space-y-6 p-4')}>
@@ -58,7 +72,7 @@ function JwtDecoderClient({ lng }: JwtDecoderClientProps) {
         placeholder={t('placeholder')}
         token={token}
         error={error}
-        onChange={setToken}
+        onChange={handleTokenChange}
       />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <JwtDecodedPanel

--- a/src/app/[lng]/(mobile)/korean-amount/components/KoreanAmountClient.tsx
+++ b/src/app/[lng]/(mobile)/korean-amount/components/KoreanAmountClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { Textarea } from '@components/basic/Textarea';
@@ -18,6 +18,7 @@ import {
   MAX_KOREAN_AMOUNT_FORMATTED_LENGTH,
 } from '~/app/[lng]/(mobile)/korean-amount/utils/convertKoreanAmount';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface KoreanAmountClientProps {
   lng: Language;
@@ -27,6 +28,8 @@ const exampleValues = ['12000', '305040100', '9900000000'];
 
 export default function KoreanAmountClient({ lng }: KoreanAmountClientProps) {
   const { t } = useTranslation(lng, 'korean-amount');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('korean-amount', 'converter');
+  const hasResultRef = useRef(false);
   const [rawValue, setRawValue] = useState('');
   const [includeCurrency, setIncludeCurrency] = useState(true);
   const [copied, setCopied] = useState(false);
@@ -50,11 +53,20 @@ export default function KoreanAmountClient({ lng }: KoreanAmountClientProps) {
     return t('helper.valid');
   }, [rawValue, t]);
 
+  useEffect(() => {
+    const has = Boolean(result);
+    if (has && !hasResultRef.current) {
+      trackUse({ action_type: 'convert', success: true });
+    }
+    hasResultRef.current = has;
+  }, [result, trackUse]);
+
   const onCopy = async () => {
     if (!result) return;
     try {
       await navigator.clipboard.writeText(result);
       setCopied(true);
+      trackCopy();
       setTimeout(() => setCopied(false), 1500);
     } catch (error) {
       setCopied(false);
@@ -67,6 +79,7 @@ export default function KoreanAmountClient({ lng }: KoreanAmountClientProps) {
   };
 
   const onAmountChange = (value: string) => {
+    trackInputStarted();
     const digitsOnly = value.replace(/[^0-9]/g, '');
 
     if (!digitsOnly) {
@@ -115,7 +128,10 @@ export default function KoreanAmountClient({ lng }: KoreanAmountClientProps) {
                 key={value}
                 type="button"
                 className="px-3 py-1 text-sm bg-basic-2 hover:bg-basic-3 text-fg-2"
-                onClick={() => setRawValue(value)}
+                onClick={() => {
+                  trackInputStarted();
+                  setRawValue(value);
+                }}
               >
                 {value}
               </Button>

--- a/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
+++ b/src/app/[lng]/(mobile)/lotto-generator/components/LottoGenerator.tsx
@@ -11,6 +11,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface LottoGeneratorStrings {
   settingsTitle: string;
@@ -105,6 +106,7 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
   const [results, setResults] = useState<LottoResult[]>([]);
   const [error, setError] = useState('');
   const [copied, setCopied] = useState(false);
+  const { trackUse, trackCopy } = useToolTracking('lotto-generator', 'generator');
 
   const resultsText = useMemo(() => {
     if (results.length === 0) return '';
@@ -124,6 +126,7 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
 
     if (minNumber >= maxNumber) {
       setError(strings.validation.range);
+      trackUse({ action_type: 'generate', success: false, error_code: 'invalid_range' });
       return;
     }
 
@@ -132,11 +135,13 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
 
     if (totalNeeded > rangeSize) {
       setError(strings.validation.picks);
+      trackUse({ action_type: 'generate', success: false, error_code: 'invalid_picks' });
       return;
     }
 
     if (ticketCount < 1 || ticketCount > 20) {
       setError(strings.validation.tickets);
+      trackUse({ action_type: 'generate', success: false, error_code: 'invalid_tickets' });
       return;
     }
 
@@ -145,6 +150,7 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
     );
 
     setResults(nextResults);
+    trackUse({ action_type: 'generate', success: true });
   };
 
   const handleClear = () => {
@@ -169,6 +175,7 @@ export default function LottoGenerator({ strings }: LottoGeneratorProps) {
       await navigator.clipboard.writeText(resultsText);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1600);
+      trackCopy({ result_format: 'text' });
     } catch (copyError) {
       setCopied(false);
     }

--- a/src/app/[lng]/(mobile)/markdown-table-generator/components/MarkdownTableGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/markdown-table-generator/components/MarkdownTableGeneratorClient.tsx
@@ -20,6 +20,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const DELIMITERS = [
   { value: 'comma', symbol: ',', labelKey: 'delimiter.comma' },
@@ -121,6 +122,11 @@ export default function MarkdownTableGeneratorClient({ lng }: MarkdownTableGener
   const [alignment, setAlignment] = useState<AlignmentValue>('left');
   const [useHeader, setUseHeader] = useState(true);
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'markdown-table-generator',
+    'generator',
+  );
+  const generatedRef = React.useRef(false);
 
   const rows = useMemo(() => parseInput(input, delimiter), [input, delimiter]);
   const output = useMemo(
@@ -135,7 +141,14 @@ export default function MarkdownTableGeneratorClient({ lng }: MarkdownTableGener
 
   useEffect(() => {
     setCopied(false);
-  }, [output]);
+    if (output && !generatedRef.current) {
+      generatedRef.current = true;
+      trackUse({ action_type: 'generate', success: true });
+    }
+    if (!output) {
+      generatedRef.current = false;
+    }
+  }, [output, trackUse]);
 
   const handleCopy = async () => {
     if (!output) return;
@@ -143,6 +156,7 @@ export default function MarkdownTableGeneratorClient({ lng }: MarkdownTableGener
       await navigator.clipboard.writeText(output);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
+      trackCopy({ result_format: 'markdown' });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy markdown table:', error);
@@ -192,7 +206,10 @@ export default function MarkdownTableGeneratorClient({ lng }: MarkdownTableGener
           className="min-h-[180px] font-mono text-sm"
           placeholder={t('placeholder.input')}
           value={input}
-          onChange={(event) => setInput(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setInput(event.target.value);
+          }}
         />
         <p className="text-xs text-fg-5">{t('helper')}</p>
       </div>

--- a/src/app/[lng]/(mobile)/menu/components/MenuDirectoryClient.tsx
+++ b/src/app/[lng]/(mobile)/menu/components/MenuDirectoryClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
-import Link from 'next/link';
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from '@components/basic/Link';
 import { ArrowUpRight, Search, X } from 'lucide-react';
 import { MenuItem, menus } from '@assets/datas/menus';
 import {
@@ -16,6 +16,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import { cn } from '@utils/cn';
+import { sendGAEvent } from '@libs/client/gtag';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 
@@ -45,6 +46,17 @@ const getLinkPreview = (link: string) => {
 };
 
 const normalizeKeyword = (value: string) => value.trim().toLowerCase();
+
+const getToolId = (link: string) => {
+  if (link.startsWith('/')) {
+    return link.replace(/^\//, '') || '/';
+  }
+  try {
+    return new URL(link).hostname.replace(/^www\./, '');
+  } catch {
+    return link;
+  }
+};
 
 const matchesKeyword = (menu: MenuItem, lng: Language, keyword: string) => {
   if (!keyword) {
@@ -140,7 +152,18 @@ export default function MenuDirectoryClient({ lng }: MenuDirectoryClientProps) {
   const totalMenuCount = menus.service.length + menus.out.length + menus.trash.length;
   const totalVisibleCount = sections.reduce((sum, section) => sum + section.items.length, 0);
 
-  const renderMenuItem = (menu: MenuItem) => {
+  useEffect(() => {
+    if (!query.trim()) return undefined;
+    const timer = setTimeout(() => {
+      sendGAEvent('menu_search', query.trim().slice(0, 50), {
+        search_keyword: query.trim().slice(0, 50),
+        results_count: totalVisibleCount,
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [query, totalVisibleCount]);
+
+  const renderMenuItem = (menu: MenuItem, sectionKey: SectionKey) => {
     const title = menu.title[lng] || menu.title.en;
     const isInternal = menu.link.startsWith('/');
 
@@ -149,9 +172,15 @@ export default function MenuDirectoryClient({ lng }: MenuDirectoryClientProps) {
         <CursorGlowCard>
           <Link
             href={menu.link}
-            target={isInternal ? '_self' : '_blank'}
+            hasTargetBlank={!isInternal}
             rel={isInternal ? undefined : 'noopener noreferrer'}
             prefetch={isInternal}
+            analyticsKey="tool_open"
+            analyticsParams={{
+              tool_id: getToolId(menu.link),
+              tool_category: sectionKey,
+              from: query.trim() ? 'search' : 'menu_grid',
+            }}
             className={cn(
               SERVICE_PANEL_SOFT,
               SERVICE_CARD_INTERACTIVE,
@@ -225,7 +254,9 @@ export default function MenuDirectoryClient({ lng }: MenuDirectoryClientProps) {
                 {section.items.length}
               </span>
             </div>
-            <ul className="space-y-3">{section.items.map(renderMenuItem)}</ul>
+            <ul className="space-y-3">
+              {section.items.map((menu) => renderMenuItem(menu, section.key))}
+            </ul>
           </section>
         ))
       ) : (

--- a/src/app/[lng]/(mobile)/network-calculator/components/IpSubnetCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/IpSubnetCalculator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@utils/cn';
 import { Button } from '@components/basic/Button';
 import { Input } from '@components/basic/Input';
@@ -20,6 +20,7 @@ import {
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import {
   calculateSubnet,
   cidrToSubnetMask,
@@ -84,10 +85,12 @@ function BinaryDisplay({ segments, cidr }: BinaryDisplayProps) {
 
 export function IpSubnetCalculator({ lng }: IpSubnetCalculatorProps) {
   const { t } = useTranslation(lng, 'network-calculator');
+  const { trackInputStarted, trackUse } = useToolTracking('network-calculator', 'calculator');
 
   const [ip, setIp] = useState('192.168.1.10');
   const [mask, setMask] = useState('255.255.255.0');
   const [error, setError] = useState<string | null>(null);
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   const result = useMemo(() => {
     if (!ip || !mask) return null;
@@ -98,13 +101,30 @@ export function IpSubnetCalculator({ lng }: IpSubnetCalculatorProps) {
     return calculateSubnet(ip, cidr);
   }, [ip, mask]);
 
+  useEffect(() => {
+    if (result) {
+      const key = `ipSubnet|${ip}|${mask}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({
+          action_type: 'calculate',
+          success: true,
+          calc_type: 'ipSubnet',
+          cidr: result.cidr,
+        });
+      }
+    }
+  }, [result, ip, mask, trackUse]);
+
   const handleCidrSelect = (value: string) => {
+    trackInputStarted();
     const cidr = Number(value);
     setMask(cidrToSubnetMask(cidr));
     setError(null);
   };
 
   const handleMaskChange = (value: string) => {
+    trackInputStarted();
     setMask(value);
     setError(null);
     if (value && !isValidSubnetMask(value)) {
@@ -113,6 +133,7 @@ export function IpSubnetCalculator({ lng }: IpSubnetCalculatorProps) {
   };
 
   const handleIpChange = (value: string) => {
+    trackInputStarted();
     setIp(value);
     setError(null);
     if (value && !isValidIp(value)) {

--- a/src/app/[lng]/(mobile)/network-calculator/components/VlsmCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/VlsmCalculator.tsx
@@ -21,6 +21,7 @@ import {
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import {
   calculateVlsm,
   cidrToSubnetMask,
@@ -55,6 +56,7 @@ const DEFAULT_ROWS: SubnetRow[] = [
 
 export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
   const { t } = useTranslation(lng, 'network-calculator');
+  const { trackInputStarted, trackUse } = useToolTracking('network-calculator', 'calculator');
 
   const [baseNetwork, setBaseNetwork] = useState('192.168.0.0');
   const [baseCidr, setBaseCidr] = useState('16');
@@ -63,6 +65,7 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
   const [error, setError] = useState<string | null>(null);
 
   const handleAddRow = () => {
+    trackInputStarted();
     setRows((prev) => [...prev, { id: newId(), name: '', requiredHosts: '' }]);
   };
 
@@ -71,6 +74,7 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
   };
 
   const handleRowChange = (id: string, field: keyof Omit<SubnetRow, 'id'>, value: string) => {
+    trackInputStarted();
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
     setError(null);
   };
@@ -81,16 +85,34 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
 
     if (!isValidIp(baseNetwork)) {
       setError(t('messages.invalidNetwork'));
+      trackUse({
+        action_type: 'calculate',
+        success: false,
+        calc_type: 'vlsm',
+        error_code: 'invalid_network',
+      });
       return;
     }
     const cidr = Number(baseCidr);
     if (!isValidCidr(cidr)) {
       setError(t('messages.invalidCidr'));
+      trackUse({
+        action_type: 'calculate',
+        success: false,
+        calc_type: 'vlsm',
+        error_code: 'invalid_cidr',
+      });
       return;
     }
     const validRows = rows.filter((r) => r.requiredHosts && Number(r.requiredHosts) > 0);
     if (validRows.length === 0) {
       setError(t('messages.minOneSubnet'));
+      trackUse({
+        action_type: 'calculate',
+        success: false,
+        calc_type: 'vlsm',
+        error_code: 'min_one_subnet',
+      });
       return;
     }
 
@@ -120,13 +142,31 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
         const lastBroadcastNum = ipToNumber(lastSubnet.broadcastAddress);
         if (lastBroadcastNum >= baseEnd) {
           setError(t('messages.subnetOverflow'));
+          trackUse({
+            action_type: 'calculate',
+            success: false,
+            calc_type: 'vlsm',
+            error_code: 'overflow',
+          });
           return;
         }
       }
 
       setResult(vlsmResult);
+      trackUse({
+        action_type: 'calculate',
+        success: true,
+        calc_type: 'vlsm',
+        subnet_count: vlsmResult.subnets.length,
+      });
     } catch {
       setError(t('messages.subnetOverflow'));
+      trackUse({
+        action_type: 'calculate',
+        success: false,
+        calc_type: 'vlsm',
+        error_code: 'overflow',
+      });
     }
   };
 
@@ -152,7 +192,10 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
               id="vlsm-base"
               type="text"
               value={baseNetwork}
-              onChange={(e) => setBaseNetwork(e.target.value)}
+              onChange={(e) => {
+                trackInputStarted();
+                setBaseNetwork(e.target.value);
+              }}
               placeholder={t('vlsm.baseNetworkPlaceholder')}
             />
           </div>
@@ -160,7 +203,13 @@ export function VlsmCalculator({ lng }: VlsmCalculatorProps) {
             <Text asChild variant="d2" color="basic-4">
               <label htmlFor="vlsm-cidr">{t('vlsm.baseCidr')}</label>
             </Text>
-            <Select value={baseCidr} onValueChange={setBaseCidr}>
+            <Select
+              value={baseCidr}
+              onValueChange={(value) => {
+                trackInputStarted();
+                setBaseCidr(value);
+              }}
+            >
               <SelectTrigger id="vlsm-cidr" aria-label={t('vlsm.baseCidr')}>
                 <SelectValue />
               </SelectTrigger>

--- a/src/app/[lng]/(mobile)/network-calculator/components/WildcardCalculator.tsx
+++ b/src/app/[lng]/(mobile)/network-calculator/components/WildcardCalculator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Clipboard, ClipboardCheck } from 'lucide-react';
 import { cn } from '@utils/cn';
 import { Button } from '@components/basic/Button';
@@ -21,6 +21,7 @@ import {
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import {
   calculateWildcard,
   cidrToSubnetMask,
@@ -35,10 +36,15 @@ interface WildcardCalculatorProps {
 
 export function WildcardCalculator({ lng }: WildcardCalculatorProps) {
   const { t } = useTranslation(lng, 'network-calculator');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'network-calculator',
+    'calculator',
+  );
 
   const [mask, setMask] = useState('255.255.255.0');
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   const result = useMemo(() => {
     if (!mask) return null;
@@ -48,7 +54,23 @@ export function WildcardCalculator({ lng }: WildcardCalculatorProps) {
     return { wildcard, cidr, subnetMask: mask };
   }, [mask]);
 
+  useEffect(() => {
+    if (result) {
+      const key = `wildcard|${mask}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({
+          action_type: 'calculate',
+          success: true,
+          calc_type: 'wildcard',
+          cidr: result.cidr,
+        });
+      }
+    }
+  }, [result, mask, trackUse]);
+
   const handleMaskChange = (value: string) => {
+    trackInputStarted();
     setMask(value);
     setCopied(false);
     setError(null);
@@ -58,6 +80,7 @@ export function WildcardCalculator({ lng }: WildcardCalculatorProps) {
   };
 
   const handleCidrSelect = (value: string) => {
+    trackInputStarted();
     setMask(cidrToSubnetMask(Number(value)));
     setCopied(false);
     setError(null);
@@ -74,6 +97,7 @@ export function WildcardCalculator({ lng }: WildcardCalculatorProps) {
     try {
       await navigator.clipboard.writeText(result.wildcard);
       setCopied(true);
+      trackCopy();
     } catch {
       // ignore
     }

--- a/src/app/[lng]/(mobile)/passphrase-generator/components/PassphraseGenerator.tsx
+++ b/src/app/[lng]/(mobile)/passphrase-generator/components/PassphraseGenerator.tsx
@@ -12,6 +12,7 @@ import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import { cn } from '@utils/cn';
 import { Text } from '@components/basic/Text';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 type PassphraseGeneratorProps = {
   lng: Language;
@@ -122,6 +123,7 @@ export default function PassphraseGenerator({ lng }: PassphraseGeneratorProps) {
   });
   const [passphrase, setPassphrase] = useState('');
   const [copied, setCopied] = useState(false);
+  const { trackUse, trackCopy } = useToolTracking('passphrase-generator', 'generator');
 
   const optionList = useMemo(
     () => [
@@ -155,6 +157,7 @@ export default function PassphraseGenerator({ lng }: PassphraseGeneratorProps) {
     const nextPassphrase = buildPassphrase(wordCount, separator, options);
     setPassphrase(nextPassphrase);
     setCopied(false);
+    trackUse({ action_type: 'generate', success: true });
   };
 
   const handleCopy = async () => {
@@ -162,6 +165,7 @@ export default function PassphraseGenerator({ lng }: PassphraseGeneratorProps) {
     await navigator.clipboard.writeText(passphrase);
     setCopied(true);
     setTimeout(() => setCopied(false), 1000);
+    trackCopy({ result_format: 'text' });
   };
 
   return (

--- a/src/app/[lng]/(mobile)/percent/components/PercentCalculatorCard.tsx
+++ b/src/app/[lng]/(mobile)/percent/components/PercentCalculatorCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { PercentCalculators } from '@stores/PercentStore/type';
 import useStore from '@hooks/useStore';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { observer } from 'mobx-react';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
@@ -33,10 +34,23 @@ function PercentCalculatorCard({
 }: PercentCalculatorCardProps) {
   const { valueChange, calculators } = useStore('percentStore');
   const { t } = useTranslation(lng, 'percent');
+  const { trackInputStarted, trackUse } = useToolTracking('percent', 'calculator');
 
   const calculator = useMemo(() => {
     return calculators[calculatorName];
   }, [calculatorName, calculators]);
+
+  const lastTrackedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (calculator.primaryNumber && calculator.secondaryNumber) {
+      const key = `${calculatorName}|${calculator.primaryNumber}|${calculator.secondaryNumber}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({ action_type: 'calculate', success: true, calculator: calculatorName });
+      }
+    }
+  }, [calculator.primaryNumber, calculator.secondaryNumber, calculatorName, trackUse]);
 
   return (
     <div className={cn(SERVICE_PANEL_SOFT, 'flex w-full flex-col space-y-4 p-4')}>
@@ -51,13 +65,14 @@ function PercentCalculatorCard({
             className="w-1/4 text-right"
             placeholder={placeholder[0]}
             value={calculator.primaryNumber}
-            onChange={(e) =>
+            onChange={(e) => {
+              trackInputStarted();
               valueChange({
                 target: calculatorName,
                 targetValue: 'primaryNumber',
                 value: e.target.value,
-              })
-            }
+              });
+            }}
           />
           <span className="t-d-2 t-basic-1">{text[0]}</span>
           <Input
@@ -66,13 +81,14 @@ function PercentCalculatorCard({
             className="w-1/4 text-right"
             placeholder={placeholder[1]}
             value={calculator.secondaryNumber}
-            onChange={(e) =>
+            onChange={(e) => {
+              trackInputStarted();
               valueChange({
                 target: calculatorName,
                 targetValue: 'secondaryNumber',
                 value: e.target.value,
-              })
-            }
+              });
+            }}
           />
           <span className="t-d-2 t-basic-1">{text[1]}</span>
           {'isIncrease' in calculator ? (

--- a/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/pokemon-type-calculator/components/PokemonTypeCalculatorClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Text } from '@components/basic/Text';
 import { cn } from '@utils/cn';
 import {
@@ -10,6 +10,7 @@ import {
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import {
   Bug,
   Crown,
@@ -672,9 +673,12 @@ const EFFECTIVENESS_TIERS = [
 
 export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculatorClientProps) {
   const { t } = useTranslation(lng, 'pokemon-type-calculator');
+  const { trackInputStarted, trackUse } = useToolTracking('pokemon-type-calculator', 'calculator');
   const [selectedTypes, setSelectedTypes] = useState<PokemonType[]>([]);
+  const lastTrackedKeyRef = useRef<string | null>(null);
 
   const toggleType = (type: PokemonType) => {
+    trackInputStarted();
     setSelectedTypes((prev) => {
       if (prev.includes(type)) {
         return prev.filter((item) => item !== type);
@@ -708,6 +712,20 @@ export default function PokemonTypeCalculatorClient({ lng }: PokemonTypeCalculat
 
   const isMaxSelected = selectedTypes.length >= 3;
   const getTypeName = (type: PokemonType) => t(`types.${type}`);
+
+  useEffect(() => {
+    if (selectedTypes.length > 0) {
+      const key = selectedTypes.join(',');
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({
+          action_type: 'calculate',
+          success: true,
+          type_count: selectedTypes.length,
+        });
+      }
+    }
+  }, [selectedTypes, trackUse]);
 
   return (
     <div className="w-full space-y-5">

--- a/src/app/[lng]/(mobile)/ppollong/page.tsx
+++ b/src/app/[lng]/(mobile)/ppollong/page.tsx
@@ -14,6 +14,7 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const MAX_ALLOWED_NUMBER = 200;
 const MAX_BALLS_DISPLAY = 100;
@@ -36,6 +37,7 @@ export default function PpollongPage({ params }: LanguageParams) {
   const [error, setError] = useState<string | null>(null);
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const drawIntervalRef = useRef<number | null>(null);
+  const { trackInputStarted, trackUse } = useToolTracking('ppollong', 'utility');
 
   const drawnSet = useMemo(() => new Set(drawnNumbers), [drawnNumbers]);
 
@@ -106,9 +108,10 @@ export default function PpollongPage({ params }: LanguageParams) {
         setCurrentNumber(drawn);
         setDrawnNumbers((prev) => [...prev, drawn].sort((a, b) => a - b));
         setIsLoading(false);
+        trackUse({ action_type: 'draw', success: true });
       }
     }, DRAW_INTERVAL_MS);
-  }, [availableNumbers, clearDrawInterval, isInitialized, t]);
+  }, [availableNumbers, clearDrawInterval, isInitialized, t, trackUse]);
 
   const handleReset = useCallback(() => {
     clearDrawInterval();
@@ -163,7 +166,10 @@ export default function PpollongPage({ params }: LanguageParams) {
           <Input
             type="number"
             value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
+            onChange={(e) => {
+              trackInputStarted();
+              setInputValue(e.target.value);
+            }}
             placeholder={t('maxNumberPlaceholder')}
             className="w-full"
             disabled={isInitialized || isLoading}

--- a/src/app/[lng]/(mobile)/qr-generator/components/QrGenerator.tsx
+++ b/src/app/[lng]/(mobile)/qr-generator/components/QrGenerator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { QRCodeCanvas } from 'qrcode.react';
@@ -13,6 +13,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface UrlQrGeneratorProps {
   lng: Language;
@@ -22,6 +23,18 @@ export default function QrGenerator({ lng }: UrlQrGeneratorProps) {
   const { t } = useTranslation(lng, 'qr-generator');
   const [url, setUrl] = useState('');
   const qrRef = useRef<HTMLDivElement>(null);
+  const { trackInputStarted, trackUse, trackShare } = useToolTracking('qr-generator', 'generator');
+  const generatedRef = useRef(false);
+
+  useEffect(() => {
+    if (url.trim() && !generatedRef.current) {
+      generatedRef.current = true;
+      trackUse({ action_type: 'generate', success: true });
+    }
+    if (!url.trim()) {
+      generatedRef.current = false;
+    }
+  }, [url, trackUse]);
 
   const downloadQRCode = () => {
     const canvas = qrRef.current?.querySelector('canvas');
@@ -33,6 +46,8 @@ export default function QrGenerator({ lng }: UrlQrGeneratorProps) {
       document.body.appendChild(downloadLink);
       downloadLink.click();
       document.body.removeChild(downloadLink);
+      trackUse({ action_type: 'download', success: true });
+      trackShare({ channel: 'download' });
     }
   };
 
@@ -50,12 +65,14 @@ export default function QrGenerator({ lng }: UrlQrGeneratorProps) {
             text: url,
             files: [file],
           });
+          trackShare({ channel: 'native' });
         } else if (navigator.share) {
           await navigator.share({
             title: t('title'),
             text: url,
             url,
           });
+          trackShare({ channel: 'native' });
         }
       } catch (error) {
         // Fallback for browsers that don't support file sharing
@@ -86,7 +103,10 @@ export default function QrGenerator({ lng }: UrlQrGeneratorProps) {
           className="font-mono"
           placeholder={t('placeholder')}
           value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          onChange={(e) => {
+            trackInputStarted();
+            setUrl(e.target.value);
+          }}
         />
         <p className="text-sm text-fg-5">{t('helper')}</p>
       </div>

--- a/src/app/[lng]/(mobile)/roman-converter/components/RomanConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/roman-converter/components/RomanConverterClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Clipboard, ClipboardCheck, RotateCcw } from 'lucide-react';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
@@ -12,6 +12,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 type RomanConverterClientProps = {
   lng: Language;
@@ -92,6 +93,12 @@ function fromRoman(raw: string) {
 
 export default function RomanConverterClient({ lng }: RomanConverterClientProps) {
   const { t } = useTranslation(lng, 'roman-converter');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking(
+    'roman-converter',
+    'converter',
+  );
+  const hasNumberResultRef = useRef(false);
+  const hasRomanResultRef = useRef(false);
   const [numberInput, setNumberInput] = useState('');
   const [romanInput, setRomanInput] = useState('');
 
@@ -142,17 +149,32 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
 
   useEffect(() => {
     setCopiedNumber(false);
-  }, [romanOutput]);
+    const has = Boolean(romanOutput);
+    if (has && !hasNumberResultRef.current) {
+      trackUse({ action_type: 'number-to-roman', success: true });
+    }
+    hasNumberResultRef.current = has;
+  }, [romanOutput, trackUse]);
 
   useEffect(() => {
     setCopiedRoman(false);
-  }, [parsedRoman.value]);
+    const has = parsedRoman.value !== null;
+    if (has && !hasRomanResultRef.current) {
+      trackUse({ action_type: 'roman-to-number', success: true });
+    }
+    hasRomanResultRef.current = has;
+  }, [parsedRoman.value, trackUse]);
 
-  const handleCopy = async (value: string, onCopied: (copied: boolean) => void) => {
+  const handleCopy = async (
+    value: string,
+    onCopied: (copied: boolean) => void,
+    format?: string,
+  ) => {
     if (!value) return;
     try {
       await navigator.clipboard.writeText(value);
       onCopied(true);
+      trackCopy({ result_format: format });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy:', error);
@@ -184,7 +206,7 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
           <h3 className="text-sm font-medium text-fg-3">{t('section.numberToRoman')}</h3>
           <Button
             type="button"
-            onClick={() => handleCopy(romanOutput, setCopiedNumber)}
+            onClick={() => handleCopy(romanOutput, setCopiedNumber, 'roman')}
             className="flex items-center gap-2 px-3 py-2 text-xs"
             disabled={!romanOutput}
           >
@@ -202,7 +224,10 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
           className="font-mono"
           placeholder={t('placeholder.number')}
           value={numberInput}
-          onChange={(event) => setNumberInput(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setNumberInput(event.target.value);
+          }}
         />
         {parsedNumber.error ? (
           <p className="text-xs text-danger-1 dark:text-danger-3">{parsedNumber.error}</p>
@@ -226,7 +251,11 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
           <Button
             type="button"
             onClick={() =>
-              handleCopy(parsedRoman.value ? String(parsedRoman.value) : '', setCopiedRoman)
+              handleCopy(
+                parsedRoman.value ? String(parsedRoman.value) : '',
+                setCopiedRoman,
+                'number',
+              )
             }
             className="flex items-center gap-2 px-3 py-2 text-xs"
             disabled={!parsedRoman.value}
@@ -244,7 +273,10 @@ export default function RomanConverterClient({ lng }: RomanConverterClientProps)
           className="font-mono uppercase"
           placeholder={t('placeholder.roman')}
           value={romanInput}
-          onChange={(event) => setRomanInput(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setRomanInput(event.target.value);
+          }}
         />
 
         {parsedRoman.error ? (

--- a/src/app/[lng]/(mobile)/salary-converter/components/SalaryConverterClient.tsx
+++ b/src/app/[lng]/(mobile)/salary-converter/components/SalaryConverterClient.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { cn } from '@utils/cn';
 import {
   DEFAULT_DAYS,
@@ -31,6 +32,8 @@ const localeMap: Record<Language, string> = {
 
 export default function SalaryConverterClient({ lng }: SalaryConverterClientProps) {
   const { t } = useTranslation(lng, 'salary-converter');
+  const { trackInputStarted, trackUse } = useToolTracking('salary-converter', 'converter');
+  const hasResultRef = useRef(false);
   const [mode, setMode] = useState<SalaryMode>('annual');
   const [monthlySalary, setMonthlySalary] = useState('');
   const [hourlyWage, setHourlyWage] = useState('');
@@ -57,6 +60,14 @@ export default function SalaryConverterClient({ lng }: SalaryConverterClientProp
       weeksPerMonth,
     });
   }, [mode, monthlySalary, hourlyWage, annualSalary, daysPerWeek, hoursPerDay, weeksPerMonth]);
+
+  useEffect(() => {
+    const has = Boolean(annualSalary || monthlySalary || hourlyWage) && values.annual > 0;
+    if (has && !hasResultRef.current) {
+      trackUse({ action_type: 'calculate', success: true, mode });
+    }
+    hasResultRef.current = has;
+  }, [annualSalary, monthlySalary, hourlyWage, values.annual, mode, trackUse]);
 
   const reset = () => {
     setMonthlySalary('');
@@ -133,7 +144,10 @@ export default function SalaryConverterClient({ lng }: SalaryConverterClientProp
             inputMode="numeric"
             placeholder={primaryInput.placeholder}
             value={primaryInput.value}
-            onChange={(event) => primaryInput.onChange(normalizeCurrencyInput(event.target.value))}
+            onChange={(event) => {
+              trackInputStarted();
+              primaryInput.onChange(normalizeCurrencyInput(event.target.value));
+            }}
             className="min-h-11 px-3 text-base"
           />
         </div>

--- a/src/app/[lng]/(mobile)/sales-tax-calculator/components/SalesTaxCalculatorClient.tsx
+++ b/src/app/[lng]/(mobile)/sales-tax-calculator/components/SalesTaxCalculatorClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Input } from '@components/basic/Input';
 import { Button } from '@components/basic/Button';
 import { useTranslation } from '~/app/i18n/client';
@@ -11,6 +11,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface SalesTaxCalculatorClientProps {
   lng: Language;
@@ -24,6 +25,8 @@ const parseNumber = (value: string) => {
 
 export default function SalesTaxCalculatorClient({ lng }: SalesTaxCalculatorClientProps) {
   const { t } = useTranslation(lng, 'sales-tax-calculator');
+  const { trackInputStarted, trackUse } = useToolTracking('sales-tax-calculator', 'converter');
+  const hasResultRef = useRef(false);
   const [price, setPrice] = useState('');
   const [taxRate, setTaxRate] = useState('10');
   const [quantity, setQuantity] = useState('1');
@@ -45,6 +48,14 @@ export default function SalesTaxCalculatorClient({ lng }: SalesTaxCalculatorClie
     };
   }, [price, quantity, taxRate]);
 
+  useEffect(() => {
+    const has = subtotal > 0;
+    if (has && !hasResultRef.current) {
+      trackUse({ action_type: 'calculate', success: true });
+    }
+    hasResultRef.current = has;
+  }, [subtotal, trackUse]);
+
   const handleReset = () => {
     setPrice('');
     setTaxRate('10');
@@ -63,7 +74,10 @@ export default function SalesTaxCalculatorClient({ lng }: SalesTaxCalculatorClie
             inputMode="decimal"
             placeholder={t('inputs.price.placeholder')}
             value={price}
-            onChange={(event) => setPrice(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setPrice(event.target.value);
+            }}
           />
           <p className="text-xs text-fg-5">{t('inputs.price.helper')}</p>
         </div>

--- a/src/app/[lng]/(mobile)/server-clock/components/Clock.tsx
+++ b/src/app/[lng]/(mobile)/server-clock/components/Clock.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { sendGAEvent } from '@libs/client/gtag';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { Language } from '~/app/i18n/settings';
 import { useTranslation } from '~/app/i18n/client';
 import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
@@ -26,10 +28,31 @@ export default function Clock({ lng }: ClockProps) {
   const [customServerUrl, setCustomServerUrl] = useState<string>('');
   const [inputCustomUrl, setInputCustomUrl] = useState<string>('');
   const [showMilliseconds, setShowMilliseconds] = useState(true);
+  const { trackInputStarted, trackUse } = useToolTracking('server-clock', 'utility');
 
   const { serverTime, isLoading, error, setTimeOffset, setServerTime, setError, setIsLoading } =
     useServerTime(lng, selectedSite, customServerUrl);
   const urgentStyle = useUrgentStyle(serverTime);
+
+  // 세션 추적: 컴포넌트 마운트 시 시작, 언마운트 시 종료
+  const sessionStartRef = useRef<number | null>(null);
+  useEffect(() => {
+    sessionStartRef.current = Date.now();
+    sendGAEvent('tool_session_start', 'server-clock', {
+      tool_id: 'server-clock',
+      tool_category: 'utility',
+    });
+    return () => {
+      const startedAt = sessionStartRef.current;
+      if (startedAt) {
+        sendGAEvent('tool_session_end', 'server-clock', {
+          tool_id: 'server-clock',
+          tool_category: 'utility',
+          duration_sec: Math.floor((Date.now() - startedAt) / 1000),
+        });
+      }
+    };
+  }, []);
 
   const handleSiteSelection = (site: string) => {
     if (selectedSite === site && site !== 'custom') return;
@@ -40,6 +63,7 @@ export default function Clock({ lng }: ClockProps) {
     setTimeOffset(0);
 
     setSelectedSite(site);
+    trackUse({ action_type: 'select_site', success: true });
 
     if (site === 'custom') {
       setCustomServerUrl('');
@@ -52,7 +76,13 @@ export default function Clock({ lng }: ClockProps) {
       // URL에서 프로토콜을 제거하고 저장
       const cleanUrl = inputCustomUrl.replace(/^https?:\/\//, '');
       setCustomServerUrl(`https://${cleanUrl}`);
+      trackUse({ action_type: 'fetch_custom_url', success: true });
     }
+  };
+
+  const wrappedSetInputCustomUrl = (url: string) => {
+    trackInputStarted();
+    setInputCustomUrl(url);
   };
 
   return (
@@ -70,7 +100,7 @@ export default function Clock({ lng }: ClockProps) {
         {selectedSite === 'custom' && (
           <CustomUrlInput
             inputCustomUrl={inputCustomUrl}
-            setInputCustomUrl={setInputCustomUrl}
+            setInputCustomUrl={wrappedSetInputCustomUrl}
             isLoading={isLoading}
             handleCustomUrlFetch={handleCustomUrlFetch}
             t={t}

--- a/src/app/[lng]/(mobile)/slug-generator/components/SlugGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/slug-generator/components/SlugGeneratorClient.tsx
@@ -13,6 +13,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface SlugGeneratorClientProps {
   lng: Language;
@@ -22,6 +23,8 @@ export default function SlugGeneratorClient({ lng }: SlugGeneratorClientProps) {
   const { t } = useTranslation(lng, 'slug-generator');
   const [value, setValue] = useState('');
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('slug-generator', 'generator');
+  const convertedRef = React.useRef(false);
 
   const slug = useMemo(() => {
     if (!value) return '';
@@ -31,13 +34,21 @@ export default function SlugGeneratorClient({ lng }: SlugGeneratorClientProps) {
 
   useEffect(() => {
     setCopied(false);
-  }, [slug]);
+    if (slug && !convertedRef.current) {
+      convertedRef.current = true;
+      trackUse({ action_type: 'convert', success: true });
+    }
+    if (!slug) {
+      convertedRef.current = false;
+    }
+  }, [slug, trackUse]);
 
   const handleCopy = async () => {
     if (!slug) return;
     try {
       await navigator.clipboard.writeText(slug);
       setCopied(true);
+      trackCopy({ result_format: 'text' });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy slug:', error);
@@ -55,7 +66,10 @@ export default function SlugGeneratorClient({ lng }: SlugGeneratorClientProps) {
           className="font-mono"
           placeholder={t('placeholder')}
           value={value}
-          onChange={(event) => setValue(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setValue(event.target.value);
+          }}
         />
         <p className="text-xs text-fg-5">{t('helper')}</p>
       </div>

--- a/src/app/[lng]/(mobile)/stopwatch/components/StopwatchClient.tsx
+++ b/src/app/[lng]/(mobile)/stopwatch/components/StopwatchClient.tsx
@@ -11,6 +11,8 @@ import {
   SERVICE_CARD_INTERACTIVE,
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
+import { sendGAEvent } from '@libs/client/gtag';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 interface StopwatchClientProps {
   lng: Language;
@@ -42,6 +44,7 @@ export default function StopwatchClient({ lng }: StopwatchClientProps) {
   const [baseElapsed, setBaseElapsed] = useState(0);
   const [laps, setLaps] = useState<LapEntry[]>([]);
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('stopwatch', 'utility');
 
   useEffect(() => {
     if (!isRunning || startAt === null) {
@@ -68,6 +71,15 @@ export default function StopwatchClient({ lng }: StopwatchClientProps) {
 
   const handleStart = () => {
     if (isRunning) return;
+    // 처음 시작(이전 누적 0)에서만 세션 시작 이벤트
+    if (elapsedMs === 0) {
+      trackInputStarted();
+      sendGAEvent('tool_session_start', 'stopwatch', {
+        tool_id: 'stopwatch',
+        tool_category: 'utility',
+      });
+    }
+    trackUse({ action_type: 'start', success: true });
     setStartAt(Date.now());
     setIsRunning(true);
   };
@@ -80,6 +92,13 @@ export default function StopwatchClient({ lng }: StopwatchClientProps) {
   };
 
   const handleReset = () => {
+    if (elapsedMs > 0) {
+      sendGAEvent('tool_session_end', 'stopwatch', {
+        tool_id: 'stopwatch',
+        tool_category: 'utility',
+        duration_sec: Math.floor(elapsedMs / 1000),
+      });
+    }
     setIsRunning(false);
     setStartAt(null);
     setElapsedMs(0);
@@ -89,6 +108,7 @@ export default function StopwatchClient({ lng }: StopwatchClientProps) {
 
   const handleLap = () => {
     if (!isRunning) return;
+    trackUse({ action_type: 'lap', success: true });
 
     setLaps((prev) => {
       const lastTotal = prev.length ? prev[prev.length - 1].totalMs : 0;
@@ -118,6 +138,7 @@ export default function StopwatchClient({ lng }: StopwatchClientProps) {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
+      trackCopy();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy stopwatch text', error);

--- a/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-counter/components/TextCounterClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { Text } from '@components/basic/Text';
 import { Textarea } from '@components/basic/Textarea';
 import { Button } from '@components/basic/Button';
@@ -26,6 +27,7 @@ const toLines = (value: string) => {
 export default function TextCounterClient({ lng }: TextCounterClientProps) {
   const { t } = useTranslation(lng, 'text-counter');
   const [text, setText] = useState('');
+  const { trackInputStarted, trackUse } = useToolTracking('text-counter', 'text');
 
   const stats = useMemo(() => {
     const normalized = text.replace(/\r\n/g, '\n');
@@ -39,6 +41,14 @@ export default function TextCounterClient({ lng }: TextCounterClientProps) {
       bytes: new TextEncoder().encode(text).length,
     };
   }, [text]);
+
+  useEffect(() => {
+    if (text.length > 0) {
+      trackUse({ action_type: 'count', success: true });
+    }
+    // 결과(stats) 변경 시점에만 발화
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stats.characters, stats.words, stats.lines, stats.bytes]);
 
   const statItems = [
     { key: 'characters', label: t('label.characters'), value: stats.characters },
@@ -74,7 +84,10 @@ export default function TextCounterClient({ lng }: TextCounterClientProps) {
           className="min-h-[180px] text-sm"
           placeholder={t('placeholder')}
           value={text}
-          onChange={(event) => setText(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setText(event.target.value);
+          }}
         />
         <Text variant="c1" className="text-fg-5">
           {t('helper')}

--- a/src/app/[lng]/(mobile)/text-repeater/components/TextRepeaterClient.tsx
+++ b/src/app/[lng]/(mobile)/text-repeater/components/TextRepeaterClient.tsx
@@ -6,6 +6,7 @@ import { Input } from '@components/basic/Input';
 import { Textarea } from '@components/basic/Textarea';
 import { Button } from '@components/basic/Button';
 import { cn } from '@utils/cn';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import {
@@ -26,6 +27,7 @@ export default function TextRepeaterClient({ lng }: TextRepeaterClientProps) {
   const [countInput, setCountInput] = useState('3');
   const [separatorInput, setSeparatorInput] = useState('\\n');
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('text-repeater', 'text');
 
   const repeatCount = useMemo(() => {
     const parsed = Number.parseInt(countInput, 10);
@@ -44,6 +46,10 @@ export default function TextRepeaterClient({ lng }: TextRepeaterClientProps) {
 
   useEffect(() => {
     setCopied(false);
+    if (output) {
+      trackUse({ action_type: 'repeat', success: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [output]);
 
   const handleCopy = async () => {
@@ -51,6 +57,7 @@ export default function TextRepeaterClient({ lng }: TextRepeaterClientProps) {
     try {
       await navigator.clipboard.writeText(output);
       setCopied(true);
+      trackCopy();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy repeated text:', error);
@@ -69,7 +76,10 @@ export default function TextRepeaterClient({ lng }: TextRepeaterClientProps) {
             className="min-h-[120px]"
             placeholder={t('placeholder.input')}
             value={value}
-            onChange={(event) => setValue(event.target.value)}
+            onChange={(event) => {
+              trackInputStarted();
+              setValue(event.target.value);
+            }}
           />
         </div>
 

--- a/src/app/[lng]/(mobile)/text-reverser/components/TextReverserClient.tsx
+++ b/src/app/[lng]/(mobile)/text-reverser/components/TextReverserClient.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@components/basic/Select';
 import { cn } from '@utils/cn';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import {
@@ -31,6 +32,7 @@ export default function TextReverserClient({ lng }: TextReverserClientProps) {
   const [value, setValue] = useState('');
   const [mode, setMode] = useState<ReverseMode>('characters');
   const [copied, setCopied] = useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('text-reverser', 'text');
 
   const reversed = useMemo(() => {
     if (!value) return '';
@@ -50,6 +52,10 @@ export default function TextReverserClient({ lng }: TextReverserClientProps) {
 
   useEffect(() => {
     setCopied(false);
+    if (reversed) {
+      trackUse({ action_type: 'reverse', success: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reversed]);
 
   const handleCopy = async () => {
@@ -57,6 +63,7 @@ export default function TextReverserClient({ lng }: TextReverserClientProps) {
     try {
       await navigator.clipboard.writeText(reversed);
       setCopied(true);
+      trackCopy();
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy reversed text:', error);
@@ -91,7 +98,10 @@ export default function TextReverserClient({ lng }: TextReverserClientProps) {
           className="h-32 resize-none"
           placeholder={t('placeholder')}
           value={value}
-          onChange={(event) => setValue(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setValue(event.target.value);
+          }}
         />
       </section>
 

--- a/src/app/[lng]/(mobile)/todo/components/ToDoCard.tsx
+++ b/src/app/[lng]/(mobile)/todo/components/ToDoCard.tsx
@@ -6,6 +6,7 @@ import useStore from '@hooks/useStore';
 import { Todo } from '@stores/TodoStore/type';
 import { cn } from '@utils/cn';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { sendGAEvent } from '@libs/client/gtag';
 
 type ToDoCardType = {
   todo: Todo;
@@ -22,7 +23,16 @@ function ToDoCard({ todo }: ToDoCardType) {
     >
       <button
         type="button"
-        onClick={() => toggleTodoCheck(todo.id)}
+        onClick={() => {
+          // 미완료 → 완료로 전환 시점에만 todo_complete 발화
+          if (!todo.isChecked) {
+            sendGAEvent('todo_complete', 'todo', {
+              tool_id: 'todo',
+              tool_category: 'utility',
+            });
+          }
+          toggleTodoCheck(todo.id);
+        }}
         className="t-d-1 t-basic-1 cursor-pointer"
         aria-pressed={todo.isChecked}
       >
@@ -32,7 +42,13 @@ function ToDoCard({ todo }: ToDoCardType) {
       <button
         type="button"
         className="t-d-1 t-basic-1 cursor-pointer"
-        onClick={() => removeTodo(todo.id)}
+        onClick={() => {
+          sendGAEvent('todo_delete', 'todo', {
+            tool_id: 'todo',
+            tool_category: 'utility',
+          });
+          removeTodo(todo.id);
+        }}
         aria-label="remove todo"
       >
         <Trash2 />

--- a/src/app/[lng]/(mobile)/todo/page.tsx
+++ b/src/app/[lng]/(mobile)/todo/page.tsx
@@ -14,6 +14,8 @@ import { Button } from '@components/basic/Button';
 import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import { getServiceCategoryBadge } from '@assets/datas/serviceCategories';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { sendGAEvent } from '@libs/client/gtag';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const ToDoCard = dynamic(() => import('~/app/[lng]/(mobile)/todo/components/ToDoCard'), {
   ssr: false,
@@ -27,13 +29,25 @@ function TodoPage({ params }: LanguageParams) {
   const badge = getServiceCategoryBadge(language, '/todo');
   const { onChange, value, reset } = useInput('');
   const isClient = useIsClient();
+  const { trackInputStarted, trackUse } = useToolTracking('todo', 'utility');
 
   const handleSubmitTodo = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!value) return;
 
     addTodo(value);
+    const newCount = todos.length + 1;
+    trackUse({ action_type: 'add', success: true });
+    sendGAEvent('todo_add', 'todo', {
+      tool_id: 'todo',
+      count: newCount,
+    });
     reset();
+  };
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    trackInputStarted();
+    onChange(e);
   };
 
   return (
@@ -51,7 +65,7 @@ function TodoPage({ params }: LanguageParams) {
           className="w-full"
           placeholder={t('inputPlaceholder')}
           value={value}
-          onChange={onChange}
+          onChange={handleInputChange}
         />
         <Button type="submit" className="w-20">
           {t('add')}

--- a/src/app/[lng]/(mobile)/url-parser/components/UrlParserClient.tsx
+++ b/src/app/[lng]/(mobile)/url-parser/components/UrlParserClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Clipboard, ClipboardCheck, Eraser, Sparkles } from 'lucide-react';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
@@ -22,6 +22,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 type UrlParserClientProps = {
   lng: Language;
@@ -56,6 +57,8 @@ const SAMPLE_URL =
 
 export default function UrlParserClient({ lng }: UrlParserClientProps) {
   const { t } = useTranslation(lng, 'url-parser');
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('url-parser', 'converter');
+  const lastParseStateRef = useRef<'none' | 'ok' | 'error'>('none');
   const [value, setValue] = useState('');
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
@@ -80,11 +83,27 @@ export default function UrlParserClient({ lng }: UrlParserClientProps) {
     setCopiedKey(null);
   }, [value]);
 
+  useEffect(() => {
+    let next: 'none' | 'ok' | 'error' = 'none';
+    if (parsed.url) next = 'ok';
+    else if (parsed.error) next = 'error';
+
+    if (next !== 'none' && next !== lastParseStateRef.current) {
+      trackUse({
+        action_type: 'parse',
+        success: next === 'ok',
+        ...(next === 'error' ? { error_code: 'invalid_url' } : {}),
+      });
+    }
+    lastParseStateRef.current = next;
+  }, [parsed, trackUse]);
+
   const handleCopy = async (text: string, key: string) => {
     if (!text) return;
     try {
       await navigator.clipboard.writeText(text);
       setCopiedKey(key);
+      trackCopy({ result_format: key === 'all' ? 'json' : key });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy URL field:', error);
@@ -161,7 +180,10 @@ export default function UrlParserClient({ lng }: UrlParserClientProps) {
           className="font-mono"
           placeholder="https://example.com/path?utm_source=app"
           value={value}
-          onChange={(event) => setValue(event.target.value)}
+          onChange={(event) => {
+            trackInputStarted();
+            setValue(event.target.value);
+          }}
         />
         <Text variant="c1" color="basic-5">
           {t('helper')}

--- a/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
+++ b/src/app/[lng]/(mobile)/uuid-generator/components/UuidGeneratorClient.tsx
@@ -22,6 +22,7 @@ import {
   SERVICE_PANEL_SOFT,
 } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 
 const MAX_COUNT = 20;
 const MIN_COUNT = 1;
@@ -62,12 +63,14 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
   const [format, setFormat] = React.useState<FormatOption>('standard');
   const [uuids, setUuids] = React.useState<string[]>(() => buildUuidList(5, 'standard'));
   const [copied, setCopied] = React.useState(false);
+  const { trackInputStarted, trackUse, trackCopy } = useToolTracking('uuid-generator', 'generator');
 
   const handleGenerate = () => {
     const safeCount = clampCount(count);
     setCount(safeCount);
     setUuids(buildUuidList(safeCount, format));
     setCopied(false);
+    trackUse({ action_type: 'generate', success: true });
   };
 
   const handleCopy = async () => {
@@ -76,6 +79,7 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
       await navigator.clipboard.writeText(uuids.join('\n'));
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
+      trackCopy({ result_format: 'text' });
     } catch {
       setCopied(false);
     }
@@ -94,7 +98,10 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
               min={MIN_COUNT}
               max={MAX_COUNT}
               value={count}
-              onChange={(event) => setCount(Number(event.target.value))}
+              onChange={(event) => {
+                trackInputStarted();
+                setCount(Number(event.target.value));
+              }}
             />
             <Text className="t-basic-1/60" variant="c1">
               {t('helper.count', { max: MAX_COUNT })}
@@ -105,7 +112,13 @@ export default function UuidGeneratorClient({ lng }: { lng: Language }) {
             <Text className="t-basic-1" variant="t3">
               {t('label.format')}
             </Text>
-            <Select value={format} onValueChange={(value) => setFormat(value as FormatOption)}>
+            <Select
+              value={format}
+              onValueChange={(value) => {
+                trackInputStarted();
+                setFormat(value as FormatOption);
+              }}
+            >
               <SelectTrigger>
                 <SelectValue placeholder={t('placeholder.format')} />
               </SelectTrigger>

--- a/src/app/[lng]/(mobile)/water-intake/components/WaterIntakeClient.tsx
+++ b/src/app/[lng]/(mobile)/water-intake/components/WaterIntakeClient.tsx
@@ -13,6 +13,7 @@ import {
 import { SERVICE_PANEL, SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
 import GoogleAd from '@components/google/GoogleAd';
 import { cn } from '@utils/cn';
+import { useToolTracking } from '@hooks/analytics/useToolTracking';
 import type { Language } from '~/app/i18n/settings';
 
 const localeMap: Record<Language, string> = {
@@ -45,9 +46,11 @@ type Props = {
 
 export default function WaterIntakeClient({ lng }: Props) {
   const { t } = useTranslation(lng, 'water-intake');
+  const { trackInputStarted, trackUse } = useToolTracking('water-intake', 'calculator');
   const [weight, setWeight] = React.useState('');
   const [activity, setActivity] = React.useState<ActivityLevel>('medium');
   const [climate, setClimate] = React.useState<ClimateLevel>('normal');
+  const lastTrackedKeyRef = React.useRef<string | null>(null);
 
   const weightValue = toNumber(weight);
 
@@ -73,6 +76,20 @@ export default function WaterIntakeClient({ lng }: Props) {
     return { totalMl, liters, cups, bottles };
   }, [weightValue, activity, climate]);
 
+  React.useEffect(() => {
+    if (result) {
+      const key = `${weightValue}|${activity}|${climate}`;
+      if (lastTrackedKeyRef.current !== key) {
+        lastTrackedKeyRef.current = key;
+        trackUse({
+          action_type: 'calculate',
+          success: true,
+          total_ml: result.totalMl,
+        });
+      }
+    }
+  }, [result, weightValue, activity, climate, trackUse]);
+
   const tips = t('tips.items', { returnObjects: true }) as string[];
 
   return (
@@ -87,11 +104,20 @@ export default function WaterIntakeClient({ lng }: Props) {
             type="number"
             inputMode="decimal"
             value={weight}
-            onChange={(e) => setWeight(e.target.value)}
+            onChange={(e) => {
+              trackInputStarted();
+              setWeight(e.target.value);
+            }}
             placeholder={t('inputs.weightPlaceholder')}
             className="text-sm"
           />
-          <Select value={activity} onValueChange={(value) => setActivity(value as ActivityLevel)}>
+          <Select
+            value={activity}
+            onValueChange={(value) => {
+              trackInputStarted();
+              setActivity(value as ActivityLevel);
+            }}
+          >
             <SelectTrigger className="text-sm">
               <SelectValue placeholder={t('inputs.activity')} />
             </SelectTrigger>
@@ -101,7 +127,13 @@ export default function WaterIntakeClient({ lng }: Props) {
               <SelectItem value="high">{t('activity.high')}</SelectItem>
             </SelectContent>
           </Select>
-          <Select value={climate} onValueChange={(value) => setClimate(value as ClimateLevel)}>
+          <Select
+            value={climate}
+            onValueChange={(value) => {
+              trackInputStarted();
+              setClimate(value as ClimateLevel);
+            }}
+          >
             <SelectTrigger className="text-sm">
               <SelectValue placeholder={t('inputs.climate')} />
             </SelectTrigger>

--- a/src/app/[lng]/global-error.tsx
+++ b/src/app/[lng]/global-error.tsx
@@ -2,6 +2,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 import { useEffect } from 'react';
+import { sendGAEvent } from '@libs/client/gtag';
 
 const STALE_RELOAD_KEY = 'sentry_stale_action_reloaded';
 
@@ -24,6 +25,7 @@ export default function GlobalError({
       return;
     }
     Sentry.captureException(error);
+    sendGAEvent('exception', error.message?.slice(0, 200) ?? 'unknown', { fatal: true });
   }, [error, isStaleDeployment]);
 
   if (isStaleDeployment) {

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Script from 'next/script';
 import { Analytics } from '@vercel/analytics/react';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -10,9 +11,28 @@ import Footer from '@components/complex/Layout/Footer';
 import { ReactQueryProvider } from '@components/complex/Layout/QueryClient';
 import GoogleAdsense from '@components/google/GoogleAdsense';
 import AgentWebMcp from '@components/agent/AgentWebMcp';
+import ConsentBanner from '@components/complex/Consent/ConsentBanner';
+import WebVitalsReporter from '@components/analytics/WebVitalsReporter';
+import ScrollDepthTracker from '@components/analytics/ScrollDepthTracker';
+import OutboundLinkTracker from '@components/analytics/OutboundLinkTracker';
 import '~/styles/globals.css';
 import { Language, languages } from '~/app/i18n/settings';
 import { StoreProvider } from './provider';
+
+// GA gtag.js 보다 먼저 실행되어야 하는 Consent Mode 기본값 스크립트
+const CONSENT_DEFAULT_SCRIPT = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  analytics_storage: 'denied',
+  functionality_storage: 'granted',
+  security_storage: 'granted',
+  wait_for_update: 500,
+});
+`;
 
 export type LanguageParams = { params: Promise<{ lng: string }> };
 
@@ -45,6 +65,15 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
 
   return (
     <html lang={language} dir={dir(language)}>
+      <head>
+        {enableThirdPartyTracking && (
+          <Script
+            id="gtag-consent"
+            strategy="beforeInteractive"
+            dangerouslySetInnerHTML={{ __html: CONSENT_DEFAULT_SCRIPT }}
+          />
+        )}
+      </head>
       <body>
         <StoreProvider>
           <ReactQueryProvider>
@@ -57,6 +86,10 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
                 <SpeedInsights />
                 {gaTrackingId && <GoogleAnalytics gaId={gaTrackingId} />}
                 {googleAdsenseClientId && <GoogleAdsense pid={googleAdsenseClientId} />}
+                <ConsentBanner />
+                <WebVitalsReporter />
+                <ScrollDepthTracker />
+                <OutboundLinkTracker />
               </>
             )}
           </ReactQueryProvider>

--- a/src/app/[lng]/multi-live/[[...slug]]/layout.tsx
+++ b/src/app/[lng]/multi-live/[[...slug]]/layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import MultiLiveTracker from '@components/analytics/MultiLiveTracker';
 import { ChildrenProps } from '~/app/[lng]/layout';
 import { Language } from '~/app/i18n/settings';
 
@@ -11,6 +12,7 @@ export type MultiLiveProps = SlugParams;
 export default function MultiLiveLayout({ children, popup }: LayoutProps) {
   return (
     <>
+      <MultiLiveTracker />
       {children}
       {popup}
     </>

--- a/src/app/[lng]/provider.tsx
+++ b/src/app/[lng]/provider.tsx
@@ -4,7 +4,13 @@ import React, { ReactNode } from 'react';
 
 import stores from '@stores';
 import { StoreContext } from '@context/storeContext';
+import RouteChangeTracker from '@components/analytics/RouteChangeTracker';
 
 export function StoreProvider({ children }: { children: ReactNode }) {
-  return <StoreContext.Provider value={stores}>{children}</StoreContext.Provider>;
+  return (
+    <StoreContext.Provider value={stores}>
+      <RouteChangeTracker />
+      {children}
+    </StoreContext.Provider>
+  );
 }

--- a/src/components/analytics/MultiLiveTracker.tsx
+++ b/src/components/analytics/MultiLiveTracker.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { sendGAEvent } from '@libs/client/gtag';
+
+export default function MultiLiveTracker(): null {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname) return;
+    // /ko/multi-live/youtube:xxx/twitch:yyy 형태에서 slug 파싱
+    const segments = pathname.split('/');
+    // [empty, lng, 'multi-live', ...slugParts]
+    const slugParts = segments.slice(3).filter(Boolean);
+    if (slugParts.length === 0) return; // 진입 화면 (slug 없음) — 이벤트 없음
+
+    const platforms = slugParts.map((s) => decodeURIComponent(s).split(':')[0]).join(',');
+    sendGAEvent('live_view', pathname, {
+      stream_count: slugParts.length,
+      platforms,
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/analytics/OutboundLinkTracker.tsx
+++ b/src/components/analytics/OutboundLinkTracker.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { sendGAEvent } from '@libs/client/gtag';
+
+/**
+ * 문서 단일 delegated click listener 로 외부 링크 클릭을 감지하고
+ * GA `outbound_click` 이벤트를 발화한다.
+ */
+export default function OutboundLinkTracker(): null {
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      const { target } = event;
+      if (!(target instanceof Element)) return;
+
+      const anchor = target.closest('a');
+      if (!anchor) return;
+
+      const href = anchor.getAttribute('href');
+      if (!href) return;
+      if (!/^https?:\/\//i.test(href)) return;
+
+      let url: URL;
+      try {
+        url = new URL(href);
+      } catch {
+        return;
+      }
+
+      if (url.hostname === window.location.hostname) return;
+
+      const anchorText = (
+        anchor.textContent?.trim() ||
+        anchor.getAttribute('aria-label') ||
+        ''
+      ).slice(0, 50);
+
+      sendGAEvent('outbound_click', url.toString(), {
+        link_url: url.toString(),
+        link_domain: url.hostname,
+        link_text: anchorText,
+      });
+    };
+
+    document.addEventListener('click', onClick, true);
+    return () => document.removeEventListener('click', onClick, true);
+  }, []);
+
+  return null;
+}

--- a/src/components/analytics/RouteChangeTracker.tsx
+++ b/src/components/analytics/RouteChangeTracker.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React, { Suspense, useEffect, useRef } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { sendGAEvent } from '@libs/client/gtag';
+
+// useSearchParams는 Next.js 15 App Router에서 Suspense 경계 안에서만 사용 가능
+function RouteChangeTrackerInner() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const lastTrackedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!pathname) return;
+    const search = searchParams?.toString() ?? '';
+    const key = search ? `${pathname}?${search}` : pathname;
+
+    // 동일 URL 중복 발화 방지 (StrictMode 등)
+    if (lastTrackedRef.current === key) return;
+    lastTrackedRef.current = key;
+
+    sendGAEvent('page_view', pathname);
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export default function RouteChangeTracker() {
+  return (
+    <Suspense fallback={null}>
+      <RouteChangeTrackerInner />
+    </Suspense>
+  );
+}

--- a/src/components/analytics/ScrollDepthTracker.tsx
+++ b/src/components/analytics/ScrollDepthTracker.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useScrollDepthTracker } from '@hooks/analytics/useScrollDepthTracker';
+
+export default function ScrollDepthTracker(): null {
+  useScrollDepthTracker();
+  return null;
+}

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useReportWebVitals } from 'next/web-vitals';
+import { sendGAEvent } from '@libs/client/gtag';
+
+// =============================================================================
+// Core Web Vitals 임계값 (Phase 1 명세 기준)
+// =============================================================================
+type MetricRating = 'good' | 'ni' | 'poor';
+
+const THRESHOLDS: Record<string, { good: number; ni: number }> = {
+  LCP: { good: 2500, ni: 4000 },
+  CLS: { good: 0.1, ni: 0.25 },
+  INP: { good: 200, ni: 500 },
+  FCP: { good: 1800, ni: 3000 },
+  TTFB: { good: 800, ni: 1800 },
+};
+
+function rate(name: string, value: number): MetricRating {
+  const t = THRESHOLDS[name];
+  if (!t) return 'good';
+  if (value < t.good) return 'good';
+  if (value < t.ni) return 'ni';
+  return 'poor';
+}
+
+// next/web-vitals 훅을 사용해 Core Web Vitals를 GA4로 전송
+export default function WebVitalsReporter(): null {
+  useReportWebVitals((metric) => {
+    const { name, value } = metric;
+    if (!THRESHOLDS[name]) return; // LCP/CLS/INP/FCP/TTFB만 보고
+    const metricRating = rate(name, value);
+
+    sendGAEvent('web_vitals', name, {
+      metric_name: name,
+      metric_id: metric.id,
+      metric_value: value,
+      metric_delta: metric.delta,
+      metric_rating: metricRating,
+      metric_navigation_type: (metric as { navigationType?: string }).navigationType ?? 'unknown',
+    });
+  });
+
+  return null;
+}

--- a/src/components/basic/Button/Button.tsx
+++ b/src/components/basic/Button/Button.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable react/require-default-props */
+
+'use client';
+
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from '@radix-ui/react-slot';
 import { cn } from '@utils/cn';
+import { useElementTracking } from '@hooks/analytics/useElementTracking';
 
 const buttonVariants = cva(
   'flex items-center justify-center min-h-[32px] rounded-md bg-point-2 hover:bg-point-1 p-1 text-lg font-normal text-white transition-colors disabled:pointer-events-none disabled:opacity-50',
@@ -16,12 +20,68 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  /** GA4 추적 키. 지정 시 ui_button_click 이벤트가 발화됩니다. */
+  analyticsKey?: string;
+  /** GA4 이벤트에 동봉할 추가 파라미터 */
+  analyticsParams?: Record<string, string | number | boolean>;
+  /** true 시 dwell hover 추적(라우트당 1회) */
+  trackHover?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, asChild = false, ...props }, ref) => {
+  (
+    {
+      className,
+      asChild = false,
+      analyticsKey,
+      analyticsParams,
+      trackHover,
+      onClick,
+      onMouseEnter,
+      onMouseLeave,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : 'button';
-    return <Comp className={cn(buttonVariants({ className }))} ref={ref} {...props} />;
+
+    // asChild=true일 때는 Slot에 핸들러 합성을 위해 추적을 비활성화 (props 안전성)
+    const tracking = useElementTracking({
+      analyticsKey: asChild ? undefined : analyticsKey,
+      analyticsParams,
+      trackHover,
+      component: 'button',
+      extra: { disabled: props.disabled ?? false },
+    });
+
+    const composedClick = tracking.handleClick(onClick);
+
+    const composedMouseEnter = React.useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        onMouseEnter?.(event);
+        tracking.handleMouseEnter();
+      },
+      [onMouseEnter, tracking],
+    );
+
+    const composedMouseLeave = React.useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        onMouseLeave?.(event);
+        tracking.handleMouseLeave();
+      },
+      [onMouseLeave, tracking],
+    );
+
+    return (
+      <Comp
+        className={cn(buttonVariants({ className }))}
+        ref={ref}
+        onClick={composedClick}
+        onMouseEnter={composedMouseEnter}
+        onMouseLeave={composedMouseLeave}
+        {...props}
+      />
+    );
   },
 );
 Button.displayName = 'Button';

--- a/src/components/basic/Link/index.tsx
+++ b/src/components/basic/Link/index.tsx
@@ -1,12 +1,22 @@
 /* eslint-disable react/require-default-props */
+
+'use client';
+
 import React from 'react';
 import NextLink from 'next/link';
+import { useElementTracking } from '@hooks/analytics/useElementTracking';
 
 type LinkType = {
   children: React.ReactNode;
   href: string;
   hasTargetBlank?: boolean;
   className?: string;
+  /** GA4 추적 키. 지정 시 ui_link_click 이벤트가 발화됩니다. */
+  analyticsKey?: string;
+  /** GA4 이벤트에 동봉할 추가 파라미터 */
+  analyticsParams?: Record<string, string | number | boolean>;
+  /** true 시 dwell hover 추적(라우트당 1회) */
+  trackHover?: boolean;
   [key: string]: any;
 };
 
@@ -15,14 +25,53 @@ export default function Link({
   href,
   hasTargetBlank = false,
   className = '',
+  analyticsKey,
+  analyticsParams,
+  trackHover,
   ...rest
 }: LinkType) {
+  const { onClick, onMouseEnter, onMouseLeave, ...passthrough } = rest as {
+    onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+    onMouseEnter?: React.MouseEventHandler<HTMLAnchorElement>;
+    onMouseLeave?: React.MouseEventHandler<HTMLAnchorElement>;
+    [key: string]: any;
+  };
+
+  const tracking = useElementTracking({
+    analyticsKey,
+    analyticsParams,
+    trackHover,
+    component: 'link',
+    extra: { href, is_external: hasTargetBlank },
+  });
+
+  const composedClick = tracking.handleClick(onClick);
+
+  const composedMouseEnter = React.useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      onMouseEnter?.(event);
+      tracking.handleMouseEnter();
+    },
+    [onMouseEnter, tracking],
+  );
+
+  const composedMouseLeave = React.useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      onMouseLeave?.(event);
+      tracking.handleMouseLeave();
+    },
+    [onMouseLeave, tracking],
+  );
+
   return (
     <NextLink
       href={href}
-      {...rest}
+      {...passthrough}
       target={hasTargetBlank ? '_blank' : '_self'}
       className={className}
+      onClick={composedClick}
+      onMouseEnter={composedMouseEnter}
+      onMouseLeave={composedMouseLeave}
     >
       {children}
     </NextLink>

--- a/src/components/blog/BlogCard/index.tsx
+++ b/src/components/blog/BlogCard/index.tsx
@@ -13,6 +13,16 @@ const BlogCard: BlogCardFC = function BlogCard({ blog, isAdmin = false, type = '
   return (
     <Link
       href={link}
+      analyticsKey={isAdmin ? undefined : 'blog_card_click'}
+      analyticsParams={
+        isAdmin
+          ? undefined
+          : {
+              post_slug: blog.urlSlug ?? '',
+              post_title: (blog.title ?? '').slice(0, 100),
+              category: (blog.category ?? '').slice(0, 100),
+            }
+      }
       className={`${BLOG_CARD_INTERACTIVE} block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-point-2`}
     >
       {

--- a/src/components/blog/BlogDetail/index.tsx
+++ b/src/components/blog/BlogDetail/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import BlogHeader from 'components/blog/BlogDetail/BlogHeader';
 import { BlogComponent } from 'components/blog/BlogDetail/type';
@@ -23,8 +23,45 @@ const BlogDetail: BlogComponent = function BlogDetail({ blog, isPreview = false,
   const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
-    sendGAEvent('page_view', blog.title);
-  }, [blog.title]);
+    sendGAEvent('blog_view', blog.urlSlug ?? blog.title, {
+      post_title: blog.title,
+      post_slug: blog.urlSlug ?? '',
+      category: (blog.categoryChain ?? []).join(' > '),
+      tag_list: (blog.tags ?? []).join(','),
+    });
+  }, [blog.urlSlug, blog.title, blog.categoryChain, blog.tags]);
+
+  // blog_read_complete: 90% 스크롤 + 30초 이상 체류
+  const readStartRef = useRef<number>(0);
+  const completedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    readStartRef.current = Date.now();
+    completedRef.current = false;
+  }, [blog.urlSlug]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const check = () => {
+      if (completedRef.current) return;
+      const doc = document.documentElement;
+      const scrollableHeight = doc.scrollHeight - window.innerHeight;
+      if (scrollableHeight <= 0) return;
+      const scrolled = (window.scrollY / scrollableHeight) * 100;
+      if (scrolled < 90) return;
+      const elapsed = Math.floor((Date.now() - readStartRef.current) / 1000);
+      if (elapsed < 30) return;
+      completedRef.current = true;
+      sendGAEvent('blog_read_complete', blog.urlSlug ?? '', {
+        post_slug: blog.urlSlug ?? '',
+        time_on_page_sec: elapsed,
+      });
+    };
+
+    window.addEventListener('scroll', check, { passive: true });
+    return () => window.removeEventListener('scroll', check);
+  }, [blog.urlSlug]);
 
   return (
     <BlogDetailProvider blog={blog} lng={lng}>

--- a/src/components/blog/BlogSearchBar.tsx
+++ b/src/components/blog/BlogSearchBar.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { observer } from 'mobx-react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Filter, LayoutGrid, List, Search } from 'lucide-react';
 import useStore from '@hooks/useStore';
 import { cn } from '@utils/cn';
 import { motion, useReducedMotion } from 'framer-motion';
 import { BlogOrderByEnum } from '@api/Blog';
+import { sendGAEvent } from '@libs/client/gtag';
 import {
   Select,
   SelectContent,
@@ -33,10 +34,20 @@ function BlogSearchBar({ toggleDrawer, lng }: BlogSearchBarProps) {
     (value: string) => {
       if (value === BlogOrderByEnum.Resent || value === BlogOrderByEnum.Title) {
         setOrderBy(value as (typeof BlogOrderByEnum)[keyof typeof BlogOrderByEnum]);
+        sendGAEvent('blog_sort_change', value, { sort_value: value });
       }
     },
     [setOrderBy],
   );
+
+  useEffect(() => {
+    if (!title?.trim()) return undefined;
+    const keyword = title.trim().slice(0, 50);
+    const timer = setTimeout(() => {
+      sendGAEvent('blog_search', keyword, { search_keyword: keyword });
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [title]);
 
   return (
     <motion.div

--- a/src/components/blog/BlogSearchListClient.tsx
+++ b/src/components/blog/BlogSearchListClient.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { observer } from 'mobx-react';
 import useBlogSearchClient from '@hooks/blog/useBlogSearchClient';
 import useStore from '@hooks/useStore';
 import { cn } from '@utils/cn';
+import { sendGAEvent } from '@libs/client/gtag';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 import { BlogCategory } from '~/spec/api/Blog';
@@ -26,6 +27,31 @@ const BlogSearchListClient = function BlogSearchListClient({
   useBlogSearchClient(category, tags);
   const { blogs, count, viewType, status } = useStore('blogSearchStore');
   const { t } = useTranslation(lng, 'blog/index');
+
+  // blog_load_more: status가 success로 전환되고, 이전보다 항목이 늘어난 경우 추가 로드로 간주
+  const prevLengthRef = useRef<number>(0);
+  const pageIndexRef = useRef<number>(0);
+  const prevStatusRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const length = blogs?.length ?? 0;
+    if (status === 'success' && prevStatusRef.current === 'loading') {
+      if (length > prevLengthRef.current && prevLengthRef.current > 0) {
+        pageIndexRef.current += 1;
+        sendGAEvent('blog_load_more', String(pageIndexRef.current), {
+          page_index: pageIndexRef.current,
+          total_loaded: length,
+        });
+      }
+      prevLengthRef.current = length;
+    }
+    // 검색 조건 변경으로 리셋된 경우(길이가 줄거나 0이 됨) 페이지 인덱스 초기화
+    if (length < prevLengthRef.current) {
+      pageIndexRef.current = 0;
+      prevLengthRef.current = length;
+    }
+    prevStatusRef.current = status;
+  }, [blogs, status]);
 
   return (
     <section className="mt-2">

--- a/src/components/complex/CommandPalette/CommandPalette.tsx
+++ b/src/components/complex/CommandPalette/CommandPalette.tsx
@@ -9,6 +9,7 @@ import { UserRoleEnum } from '@api/User';
 import { Input } from '@components/basic/Input';
 import { cn } from '@utils/cn';
 import { OPEN_COMMAND_PALETTE_EVENT } from '@utils/commandPalette';
+import { sendGAEvent } from '@libs/client/gtag';
 import useStore from '@hooks/useStore';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
@@ -36,6 +37,7 @@ function CommandPalette() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<string>('unknown');
 
   // 페이지 데이터 로드
   useEffect(() => {
@@ -54,6 +56,7 @@ function CommandPalette() {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault();
+        triggerRef.current = 'keyboard';
         setOpen((prev) => !prev);
       }
     };
@@ -63,7 +66,10 @@ function CommandPalette() {
   }, []);
 
   useEffect(() => {
-    const handleOpen = () => setOpen(true);
+    const handleOpen = () => {
+      triggerRef.current = 'event';
+      setOpen(true);
+    };
 
     window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, handleOpen);
     return () => window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, handleOpen);
@@ -75,6 +81,13 @@ function CommandPalette() {
       setQuery('');
       setSelectedIndex(0);
     }
+  }, [open]);
+
+  // GA: command_palette_open (open false → true 전환 시 1회)
+  useEffect(() => {
+    if (!open) return;
+    const trigger = triggerRef.current || 'unknown';
+    sendGAEvent('command_palette_open', trigger, { trigger });
   }, [open]);
 
   const getPageTitle = useCallback(
@@ -96,13 +109,18 @@ function CommandPalette() {
 
   const navigateTo = useCallback(
     (page: PageEntry) => {
+      sendGAEvent('command_palette_select', page.path, {
+        item_path: page.path,
+        item_type: page.access,
+        query_at_select: query.trim().slice(0, 50),
+      });
       setOpen(false);
       const targetPath = `/${lng}${page.path === '/' ? '' : page.path}`;
       if (pathname !== targetPath) {
         router.push(targetPath);
       }
     },
-    [lng, pathname, router],
+    [lng, pathname, router, query],
   );
 
   // 권한 필터링 + 검색 필터링
@@ -133,6 +151,21 @@ function CommandPalette() {
   useEffect(() => {
     setSelectedIndex(0);
   }, [query]);
+
+  // GA: command_palette_search (300ms debounce)
+  useEffect(() => {
+    if (!open) return undefined;
+    const trimmed = query.trim();
+    if (!trimmed) return undefined;
+
+    const timer = setTimeout(() => {
+      sendGAEvent('command_palette_search', trimmed.slice(0, 50), {
+        query: trimmed.slice(0, 50),
+        results_count: filteredPages.length,
+      });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [query, open, filteredPages.length]);
 
   // 키보드 네비게이션
   const handleKeyDown = useCallback(

--- a/src/components/complex/Consent/ConsentBanner.tsx
+++ b/src/components/complex/Consent/ConsentBanner.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as React from 'react';
+import Link from '@components/basic/Link';
+import { Button } from '@components/basic/Button/Button';
+import { setConsentUpdate, sendGAEvent } from '@libs/client/gtag';
+
+const STORAGE_KEY = 'consent_v1';
+// 13개월(395일) — GA4 동의 보관 가이드 기준
+const CONSENT_TTL_MS = 395 * 24 * 60 * 60 * 1000;
+
+type StoredConsent = {
+  granted: boolean;
+  granted_at: number;
+};
+
+function readStoredConsent(): StoredConsent | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredConsent;
+    if (typeof parsed?.granted !== 'boolean' || typeof parsed?.granted_at !== 'number') {
+      return null;
+    }
+    // TTL 만료 체크
+    if (Date.now() - parsed.granted_at > CONSENT_TTL_MS) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredConsent(granted: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload: StoredConsent = { granted, granted_at: Date.now() };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage 사용 불가 환경 — 무시
+  }
+}
+
+export default function ConsentBanner() {
+  const [mounted, setMounted] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+    const stored = readStoredConsent();
+    if (stored?.granted === true) {
+      // 기존 동의 복원
+      setConsentUpdate(true);
+      setVisible(false);
+      return;
+    }
+    if (stored?.granted === false) {
+      // 거부 상태도 보관 — 배너 미노출
+      setVisible(false);
+      return;
+    }
+    setVisible(true);
+  }, []);
+
+  const handleAccept = React.useCallback(() => {
+    writeStoredConsent(true);
+    setConsentUpdate(true);
+    sendGAEvent('consent_update', 'granted', { analytics: 'granted', ad: 'denied' });
+    setVisible(false);
+  }, []);
+
+  const handleDeny = React.useCallback(() => {
+    writeStoredConsent(false);
+    setConsentUpdate(false);
+    sendGAEvent('consent_update', 'denied', { analytics: 'denied', ad: 'denied' });
+    setVisible(false);
+  }, []);
+
+  if (!mounted || !visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="쿠키 사용 동의"
+      aria-describedby="consent-banner-desc"
+      aria-live="polite"
+      className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-4 sm:pb-6"
+    >
+      <div className="w-full max-w-lg rounded-2xl border border-basic-3 bg-basic-0 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.18)] sm:p-5">
+        <p id="consent-banner-desc" className="text-sm leading-relaxed text-fg-1 sm:text-base">
+          이 사이트는 사용자 경험 개선과 서비스 분석을 위해 쿠키를 사용합니다. 자세한 내용은{' '}
+          <Link href="./privacy" className="underline underline-offset-2 hover:text-point-1">
+            개인정보처리방침
+          </Link>
+          에서 확인하세요.
+        </p>
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            onClick={handleDeny}
+            className="bg-basic-2 text-fg-1 hover:bg-basic-3"
+            aria-label="쿠키 사용 거부"
+          >
+            거부
+          </Button>
+          <Button type="button" onClick={handleAccept} aria-label="쿠키 사용 동의">
+            동의
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/complex/Nav/LocalesNav.tsx
+++ b/src/components/complex/Nav/LocalesNav.tsx
@@ -34,10 +34,13 @@ function LocalesNav() {
     (newLang: string) => {
       if (!pathname) return;
       const newPathname = pathname.replace(/^\/([^/]+)/, `/${newLang}`);
-      sendGAEvent('link_click', `change_language_to_${newLang}`);
+      sendGAEvent('language_change', newLang, {
+        from_lng: currentLang,
+        to_lng: newLang,
+      });
       window.location.href = `${newPathname}${window.location.search}${window.location.hash}`;
     },
-    [pathname],
+    [pathname, currentLang],
   );
 
   if (!pathname) return null;

--- a/src/components/complex/Nav/index.tsx
+++ b/src/components/complex/Nav/index.tsx
@@ -68,7 +68,12 @@ function Nav() {
             <li key={navItem.name} className="min-w-0">
               <Link
                 href={navItem.link}
-                onClick={() => sendGAEvent('link_click', navItem.name)}
+                onClick={() =>
+                  sendGAEvent('nav_click', navItem.name, {
+                    nav_item: navItem.name,
+                    nav_position: 'bottom',
+                  })
+                }
                 prefetch
                 className={cn(
                   'group relative flex h-12 w-full flex-col items-center justify-center rounded-2xl text-center transition-colors lg:h-12',

--- a/src/hooks/analytics/useElementTracking.ts
+++ b/src/hooks/analytics/useElementTracking.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import * as React from 'react';
+import { usePathname } from 'next/navigation';
+import { sendGAEvent } from '@libs/client/gtag';
+
+const HOVER_DWELL_MS = 150;
+
+type Component = 'button' | 'link';
+
+type UseElementTrackingOptions = {
+  analyticsKey: string | undefined;
+  analyticsParams?: Record<string, string | number | boolean>;
+  trackHover?: boolean;
+  component: Component;
+  extra?: Record<string, unknown>;
+};
+
+type UseElementTrackingReturn = {
+  handleClick: <E extends React.MouseEvent<any>>(
+    originalHandler?: (event: E) => void,
+  ) => (event: E) => void;
+  handleMouseEnter: () => void;
+  handleMouseLeave: () => void;
+};
+
+const NOOP = () => {};
+
+export function useElementTracking(options: UseElementTrackingOptions): UseElementTrackingReturn {
+  const { analyticsKey, analyticsParams, trackHover, component, extra } = options;
+  const pathname = usePathname();
+
+  const dwellTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedHoverRef = React.useRef<Set<string>>(new Set());
+
+  // 라우트 바뀔 때 hover dedupe set 리셋
+  React.useEffect(() => {
+    firedHoverRef.current = new Set();
+    return () => {
+      if (dwellTimerRef.current) {
+        clearTimeout(dwellTimerRef.current);
+        dwellTimerRef.current = null;
+      }
+    };
+  }, [pathname]);
+
+  const enabled = typeof analyticsKey === 'string' && analyticsKey.length > 0;
+
+  const buildParams = React.useCallback(() => {
+    return {
+      analytics_key: analyticsKey,
+      component,
+      ...(analyticsParams ?? {}),
+      ...(extra ?? {}),
+    };
+  }, [analyticsKey, analyticsParams, component, extra]);
+
+  const fireClick = React.useCallback(() => {
+    if (!enabled) return;
+    const event = component === 'button' ? 'ui_button_click' : 'ui_link_click';
+    sendGAEvent(event, analyticsKey as string, buildParams());
+  }, [enabled, component, analyticsKey, buildParams]);
+
+  const fireHover = React.useCallback(() => {
+    if (!enabled) return;
+    const dedupeKey = `${pathname}::${analyticsKey}`;
+    if (firedHoverRef.current.has(dedupeKey)) return;
+    firedHoverRef.current.add(dedupeKey);
+    const event = component === 'button' ? 'ui_button_hover' : 'ui_link_hover';
+    sendGAEvent(event, analyticsKey as string, buildParams());
+  }, [enabled, component, analyticsKey, pathname, buildParams]);
+
+  const handleClick = React.useCallback(
+    <E extends React.MouseEvent<any>>(originalHandler?: (event: E) => void) => {
+      if (!enabled && !originalHandler) return NOOP as (event: E) => void;
+      return (event: E) => {
+        try {
+          originalHandler?.(event);
+        } finally {
+          fireClick();
+        }
+      };
+    },
+    [enabled, fireClick],
+  );
+
+  const handleMouseEnter = React.useCallback(() => {
+    if (!enabled || !trackHover) return;
+    if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
+    dwellTimerRef.current = setTimeout(() => {
+      fireHover();
+      dwellTimerRef.current = null;
+    }, HOVER_DWELL_MS);
+  }, [enabled, trackHover, fireHover]);
+
+  const handleMouseLeave = React.useCallback(() => {
+    if (dwellTimerRef.current) {
+      clearTimeout(dwellTimerRef.current);
+      dwellTimerRef.current = null;
+    }
+  }, []);
+
+  return { handleClick, handleMouseEnter, handleMouseLeave };
+}
+
+export default useElementTracking;

--- a/src/hooks/analytics/useScrollDepthTracker.ts
+++ b/src/hooks/analytics/useScrollDepthTracker.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { sendGAEvent } from '@libs/client/gtag';
+
+const THRESHOLDS = [25, 50, 75, 100] as const;
+
+/**
+ * 스크롤 깊이(25/50/75/100%) 도달 시 GA `scroll` 이벤트를 1회씩 발화한다.
+ * - 라우트(pathname)가 바뀌면 도달 기록을 리셋한다.
+ * - scroll 이벤트는 passive 리스너 + requestAnimationFrame 으로 throttle 한다.
+ */
+export function useScrollDepthTracker(): void {
+  const pathname = usePathname();
+  const reachedRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    // pathname 변경 시 도달 기록 초기화
+    reachedRef.current = new Set();
+
+    let rafId: number | null = null;
+    let ticking = false;
+
+    const measure = () => {
+      ticking = false;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      if (docHeight <= 0) return;
+
+      const percent = (window.scrollY / docHeight) * 100;
+
+      THRESHOLDS.forEach((threshold) => {
+        if (percent >= threshold && !reachedRef.current.has(threshold)) {
+          reachedRef.current.add(threshold);
+          sendGAEvent('scroll', String(threshold), {
+            percent_scrolled: threshold,
+            page_path: pathname,
+          });
+        }
+      });
+    };
+
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      rafId = window.requestAnimationFrame(measure);
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    // 초기 진입 시점에도 한 번 체크 (이미 페이지가 짧은 경우 100% 도달 가능)
+    measure();
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+      }
+    };
+  }, [pathname]);
+}

--- a/src/hooks/analytics/useToolTracking.ts
+++ b/src/hooks/analytics/useToolTracking.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+import { sendGAEvent } from '@libs/client/gtag';
+
+export type ToolCategory = 'generator' | 'converter' | 'calculator' | 'text' | 'utility';
+
+type TrackUseOptions = {
+  action_type: string;
+  success: boolean;
+  error_code?: string;
+  [key: string]: unknown;
+};
+
+type TrackCopyOptions = {
+  result_format?: string;
+};
+
+type TrackShareOptions = {
+  channel?: string;
+};
+
+/**
+ * 도구 페이지의 공통 GA4 이벤트(4종)를 발화하는 훅.
+ * - tool_input_started: 첫 입력 시 세션당 1회
+ * - tool_use: 핵심 액션(생성/계산/변환) 실행 시
+ * - tool_copy_result: 결과 복사 시
+ * - tool_share_result: 결과 공유 시
+ */
+export function useToolTracking(toolId: string, category: ToolCategory) {
+  const inputStartedRef = useRef(false);
+
+  const trackInputStarted = useCallback(() => {
+    if (inputStartedRef.current) return;
+    inputStartedRef.current = true;
+    sendGAEvent('tool_input_started', toolId, {
+      tool_id: toolId,
+      tool_category: category,
+    });
+  }, [toolId, category]);
+
+  const trackUse = useCallback(
+    ({ action_type, success, error_code, ...rest }: TrackUseOptions) => {
+      sendGAEvent('tool_use', toolId, {
+        tool_id: toolId,
+        tool_category: category,
+        action_type,
+        success,
+        ...(error_code ? { error_code } : {}),
+        ...rest,
+      });
+    },
+    [toolId, category],
+  );
+
+  const trackCopy = useCallback(
+    ({ result_format = 'text' }: TrackCopyOptions = {}) => {
+      sendGAEvent('tool_copy_result', toolId, {
+        tool_id: toolId,
+        tool_category: category,
+        result_format,
+      });
+    },
+    [toolId, category],
+  );
+
+  const trackShare = useCallback(
+    ({ channel = 'native' }: TrackShareOptions = {}) => {
+      sendGAEvent('tool_share_result', toolId, {
+        tool_id: toolId,
+        tool_category: category,
+        channel,
+      });
+    },
+    [toolId, category],
+  );
+
+  return { trackInputStarted, trackUse, trackCopy, trackShare };
+}

--- a/src/libs/client/gtag.ts
+++ b/src/libs/client/gtag.ts
@@ -4,35 +4,237 @@ import { sendGAEvent as sE } from '@next/third-parties/google';
 import Cookies from 'js-cookie';
 import Jwt from '@utils/jwtUtils';
 
-type Event = 'button_click' | 'link_click' | 'page_view';
+// =============================================================================
+// Event types
+// 글로벌 / 내비 / 홈 / 블로그 / 라이브 / 메뉴 / 인증 / 도구 / UI / 기타 + 호환
+// =============================================================================
+type GlobalEvent =
+  | 'page_view'
+  | 'scroll'
+  | 'web_vitals'
+  | 'exception'
+  | 'outbound_click'
+  | 'session_start_with_user';
 
+type NavEvent =
+  | 'nav_click'
+  | 'language_change'
+  | 'command_palette_open'
+  | 'command_palette_search'
+  | 'command_palette_select'
+  | 'consent_update'
+  | 'share_click';
+
+type HomeEvent =
+  | 'install_app_prompt_shown'
+  | 'install_app_click'
+  | 'pwa_install_accepted'
+  | 'pwa_install_dismissed'
+  | 'landing_section_view'
+  | 'hero_cta_click';
+
+type BlogEvent =
+  | 'blog_search'
+  | 'blog_filter_apply'
+  | 'blog_sort_change'
+  | 'blog_card_click'
+  | 'blog_load_more'
+  | 'blog_search_no_results'
+  | 'blog_view'
+  | 'blog_read_25'
+  | 'blog_read_50'
+  | 'blog_read_75'
+  | 'blog_read_90'
+  | 'blog_read_complete'
+  | 'blog_tag_click'
+  | 'blog_toc_click'
+  | 'blog_share'
+  | 'blog_copy_code'
+  | 'blog_image_zoom';
+
+type LiveEvent =
+  | 'live_view'
+  | 'live_stream_add'
+  | 'live_stream_remove'
+  | 'live_layout_change'
+  | 'live_share_url';
+
+type MenuEvent = 'tool_open' | 'menu_search' | 'user_card_click';
+
+type AuthEvent = 'login_attempt' | 'login_success' | 'login_failure' | 'logout';
+
+type ToolEvent =
+  | 'tool_input_started'
+  | 'tool_use'
+  | 'tool_copy_result'
+  | 'tool_share_result'
+  | 'todo_add'
+  | 'todo_complete'
+  | 'todo_delete'
+  | 'todo_clear_all'
+  | 'tool_session_start'
+  | 'tool_session_end';
+
+type UiEvent = 'ui_button_click' | 'ui_button_hover' | 'ui_link_click' | 'ui_link_hover';
+
+type LegacyEvent = 'button_click' | 'link_click';
+
+type MiscEvent = 'legal_section_jump';
+
+export type Event =
+  | GlobalEvent
+  | NavEvent
+  | HomeEvent
+  | BlogEvent
+  | LiveEvent
+  | MenuEvent
+  | AuthEvent
+  | ToolEvent
+  | UiEvent
+  | MiscEvent
+  | LegacyEvent;
+
+// =============================================================================
+// Page group
+// =============================================================================
+export type PageGroup =
+  | 'home'
+  | 'blog_list'
+  | 'blog_detail'
+  | 'tool'
+  | 'auth'
+  | 'legal'
+  | 'live'
+  | 'menu'
+  | 'admin'
+  | 'other';
+
+const LANG_SEGMENT = /^\/[a-z]{2}(?=\/|$)/;
+
+export function getPageGroup(pathname: string): PageGroup {
+  if (!pathname) return 'other';
+  // /{lng} 또는 /{lng}/...
+  const stripped = pathname.replace(LANG_SEGMENT, '') || '/';
+
+  if (stripped === '/') return 'home';
+  if (stripped === '/blog') return 'blog_list';
+  if (stripped.startsWith('/blog/')) return 'blog_detail';
+  if (stripped.startsWith('/auth')) return 'auth';
+  if (stripped.startsWith('/admin')) return 'admin';
+  if (stripped.startsWith('/multi-live')) return 'live';
+  if (stripped.startsWith('/menu')) return 'menu';
+  if (stripped.startsWith('/privacy') || stripped.startsWith('/terms')) return 'legal';
+  // (mobile) 그룹은 URL에 노출되지 않으므로 그 외 단일 세그먼트는 tool로 분류
+  // 단, 명시 케이스가 모두 빠진 경우 한정
+  // 예: /qr, /todo, /loan 등
+  if (/^\/[^/]+$/.test(stripped)) return 'tool';
+
+  return 'other';
+}
+
+function getLngFromPath(pathname: string): string {
+  const match = pathname.match(/^\/([a-z]{2})(?=\/|$)/);
+  return match ? match[1] : '';
+}
+
+// =============================================================================
+// GTagEvent payload
+// =============================================================================
 type GTagEvent = {
   id: string;
+  session_id: string;
   pathname: string;
+  lng: string;
+  page_group: PageGroup;
   event: Event;
   value: string;
+  [key: string]: unknown;
 };
 
-type SendGAEventType = (event: Event, value: string) => void;
+type SendGAEventType = (event: Event, value: string, extraParams?: Record<string, unknown>) => void;
 
-export const sendGAEvent: SendGAEventType = (event, value) => {
-  if (window === undefined) return;
+export const sendGAEvent: SendGAEventType = (event, value, extraParams) => {
+  if (typeof window === 'undefined') return;
+
+  const { pathname } = window.location;
+  const pageGroup = getPageGroup(pathname);
+
+  // admin 라우트는 트래킹 제외
+  if (pageGroup === 'admin') return;
+
   let id = '';
   const accessToken = Cookies.get('access_token');
 
   if (accessToken) {
-    const { id: userId } = Jwt.getPayload(accessToken) || {};
-    id = userId;
+    try {
+      const { id: userId } = Jwt.getPayload(accessToken) || {};
+      id = userId ?? '';
+    } catch {
+      id = '';
+    }
   } else {
     id = Cookies.get('SessionId') || '';
   }
 
+  const sessionId = Cookies.get('SessionId') || '';
+  const lng = getLngFromPath(pathname);
+
   const object: GTagEvent = {
     id,
-    pathname: window.location.pathname,
+    session_id: sessionId,
+    pathname,
+    lng,
+    page_group: pageGroup,
     event,
     value,
+    ...(extraParams ?? {}),
   };
 
   sE(object);
 };
+
+// =============================================================================
+// Consent Mode helpers (window.gtag 직접 호출)
+// =============================================================================
+type GtagFn = (...args: unknown[]) => void;
+
+declare global {
+  interface Window {
+    gtag?: GtagFn;
+    dataLayer?: Object[];
+  }
+}
+
+function gtagSafe(...args: unknown[]) {
+  if (typeof window === 'undefined') return;
+  if (typeof window.gtag === 'function') {
+    window.gtag(...args);
+    return;
+  }
+  // gtag.js가 아직 로드되지 않은 경우 dataLayer로 직접 push
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(args as unknown as object);
+}
+
+export function setConsentDefault() {
+  gtagSafe('consent', 'default', {
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+    analytics_storage: 'denied',
+    functionality_storage: 'granted',
+    security_storage: 'granted',
+    wait_for_update: 500,
+  });
+}
+
+export function setConsentUpdate(granted: boolean) {
+  const analyticsValue = granted ? 'granted' : 'denied';
+  gtagSafe('consent', 'update', {
+    analytics_storage: analyticsValue,
+    // 광고 목적 데이터는 동의 여부와 무관하게 항상 denied
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+  });
+}

--- a/src/stores/UserStore/index.ts
+++ b/src/stores/UserStore/index.ts
@@ -3,6 +3,7 @@ import { authApi } from '@api';
 import { User } from '@api/User';
 import Cookies from 'js-cookie';
 import UserTokenUtil from '@utils/userTokenUtil';
+import { sendGAEvent } from '@libs/client/gtag';
 import { UserStoreState } from './type';
 
 class UserStore implements UserStoreState {
@@ -32,6 +33,9 @@ class UserStore implements UserStoreState {
   };
 
   @action public logOut = () => {
+    if (typeof window !== 'undefined') {
+      sendGAEvent('logout', 'google', { from_path: window.location.pathname });
+    }
     UserTokenUtil.removeAccessToken();
     UserTokenUtil.removeRefreshToken();
     UserTokenUtil.removeUserInfo();


### PR DESCRIPTION
## Summary

- **gtag.ts** 전면 확장: 60+ 이벤트 타입, admin 라우트 가드, GA4 Consent Mode v2 helper, 공통 파라미터(lng/page_group/session_id) 자동 첨부
- **글로벌 추적 컴포넌트 신규**: RouteChangeTracker(page_view), ConsentBanner(동의 배너), WebVitalsReporter(LCP/CLS/INP), ScrollDepthTracker(25/50/75/100%), OutboundLinkTracker(외부 링크)
- **Button/Link 옵트인 추적**: `analyticsKey` prop 지정 시 click/hover 자동 추적 (`useElementTracking` 훅)
- **도메인 이벤트**: 블로그(blog_view/search/card_click/read_complete), 네비(nav_click/language_change), 커맨드팔레트, 메뉴, 인증(login_attempt/success/failure/logout), 멀티라이브(live_view)
- **도구 40개 전체** `useToolTracking` 훅 적용: generator 8, converter 9, calculator 10, text 3, utility 10

## 변경 파일 (70개)

| 영역 | 파일 수 |
|------|--------|
| Foundation (gtag, layout, provider, global-error) | 4 |
| 신규 analytics 컴포넌트/훅 | 7 |
| Button, Link 컴포넌트 | 2 |
| Nav, CommandPalette, Menu, Auth, Blog, Multi-live | 10 |
| 도구 컴포넌트 (40개 도구) | 47 |

## Test plan

- [ ] GA4 DebugView에서 page_view, tool_use, blog_view 이벤트 확인
- [ ] 쿠키 삭제 후 ConsentBanner 노출 → 동의/거부 흐름 확인
- [ ] `/ko/admin` 접속 시 GA 이벤트 0건 (admin 가드)
- [ ] 아무 도구에서 입력 → tool_input_started, 버튼 클릭 → tool_use 확인
- [ ] `npx tsc --noEmit` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)