### PR TITLE
feat: ConsentBanner 다국어(ko/en/ja/zh) 적용

### DIFF
--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -52,6 +52,7 @@ import pokemonTypeCalculator from 'assets/locales/ko/pokemon-type-calculator.jso
 import ipLookup from 'assets/locales/ko/ip-lookup.json';
 import networkCalculator from 'assets/locales/ko/network-calculator.json';
 import commandPalette from 'assets/locales/ko/command-palette.json';
+import consent from 'assets/locales/ko/consent.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -110,6 +111,7 @@ declare module 'i18next' {
       'ip-lookup': typeof ipLookup;
       'network-calculator': typeof networkCalculator;
       'command-palette': typeof commandPalette;
+      consent: typeof consent;
     };
   }
 }

--- a/src/assets/locales/en/consent.json
+++ b/src/assets/locales/en/consent.json
@@ -1,0 +1,10 @@
+{
+  "description": "This site uses cookies to improve your experience and analyze our services. See our",
+  "privacyLink": "Privacy Policy",
+  "descriptionSuffix": "for more details.",
+  "deny": "Decline",
+  "accept": "Accept",
+  "ariaLabel": "Cookie consent",
+  "denyAriaLabel": "Decline cookies",
+  "acceptAriaLabel": "Accept cookies"
+}

--- a/src/assets/locales/ja/consent.json
+++ b/src/assets/locales/ja/consent.json
@@ -1,0 +1,10 @@
+{
+  "description": "このサイトはユーザー体験の向上とサービス分析のためにクッキーを使用します。詳細は",
+  "privacyLink": "プライバシーポリシー",
+  "descriptionSuffix": "をご覧ください。",
+  "deny": "拒否",
+  "accept": "同意",
+  "ariaLabel": "クッキーの使用に関する同意",
+  "denyAriaLabel": "クッキーの使用を拒否",
+  "acceptAriaLabel": "クッキーの使用に同意"
+}

--- a/src/assets/locales/ko/consent.json
+++ b/src/assets/locales/ko/consent.json
@@ -1,0 +1,10 @@
+{
+  "description": "이 사이트는 사용자 경험 개선과 서비스 분석을 위해 쿠키를 사용합니다. 자세한 내용은",
+  "privacyLink": "개인정보처리방침",
+  "descriptionSuffix": "에서 확인하세요.",
+  "deny": "거부",
+  "accept": "동의",
+  "ariaLabel": "쿠키 사용 동의",
+  "denyAriaLabel": "쿠키 사용 거부",
+  "acceptAriaLabel": "쿠키 사용 동의"
+}

--- a/src/assets/locales/zh/consent.json
+++ b/src/assets/locales/zh/consent.json
@@ -1,0 +1,10 @@
+{
+  "description": "本网站使用Cookie以改善用户体验并分析服务。详情请查看",
+  "privacyLink": "隐私政策",
+  "descriptionSuffix": "。",
+  "deny": "拒绝",
+  "accept": "同意",
+  "ariaLabel": "Cookie使用同意",
+  "denyAriaLabel": "拒绝使用Cookie",
+  "acceptAriaLabel": "同意使用Cookie"
+}

--- a/src/components/complex/Consent/ConsentBanner.tsx
+++ b/src/components/complex/Consent/ConsentBanner.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import * as React from 'react';
+import { useParams } from 'next/navigation';
 import Link from '@components/basic/Link';
 import { Button } from '@components/basic/Button/Button';
 import { setConsentUpdate, sendGAEvent } from '@libs/client/gtag';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
 
 const STORAGE_KEY = 'consent_v1';
 // 13개월(395일) — GA4 동의 보관 가이드 기준
@@ -45,6 +48,10 @@ function writeStoredConsent(granted: boolean) {
 }
 
 export default function ConsentBanner() {
+  const params = useParams<{ lng?: string }>();
+  const language = (params?.lng ?? 'ko') as Language;
+  const { t } = useTranslation(language, 'consent');
+
   const [mounted, setMounted] = React.useState(false);
   const [visible, setVisible] = React.useState(false);
 
@@ -52,13 +59,11 @@ export default function ConsentBanner() {
     setMounted(true);
     const stored = readStoredConsent();
     if (stored?.granted === true) {
-      // 기존 동의 복원
       setConsentUpdate(true);
       setVisible(false);
       return;
     }
     if (stored?.granted === false) {
-      // 거부 상태도 보관 — 배너 미노출
       setVisible(false);
       return;
     }
@@ -84,30 +89,30 @@ export default function ConsentBanner() {
   return (
     <div
       role="dialog"
-      aria-label="쿠키 사용 동의"
+      aria-label={t('ariaLabel')}
       aria-describedby="consent-banner-desc"
       aria-live="polite"
       className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-4 sm:pb-6"
     >
       <div className="w-full max-w-lg rounded-2xl border border-basic-3 bg-basic-0 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.18)] sm:p-5">
         <p id="consent-banner-desc" className="text-sm leading-relaxed text-fg-1 sm:text-base">
-          이 사이트는 사용자 경험 개선과 서비스 분석을 위해 쿠키를 사용합니다. 자세한 내용은{' '}
+          {t('description')}{' '}
           <Link href="./privacy" className="underline underline-offset-2 hover:text-point-1">
-            개인정보처리방침
+            {t('privacyLink')}
           </Link>
-          에서 확인하세요.
+          {t('descriptionSuffix')}
         </p>
         <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
           <Button
             type="button"
             onClick={handleDeny}
             className="bg-basic-2 text-fg-1 hover:bg-basic-3"
-            aria-label="쿠키 사용 거부"
+            aria-label={t('denyAriaLabel')}
           >
-            거부
+            {t('deny')}
           </Button>
-          <Button type="button" onClick={handleAccept} aria-label="쿠키 사용 동의">
-            동의
+          <Button type="button" onClick={handleAccept} aria-label={t('acceptAriaLabel')}>
+            {t('accept')}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- ConsentBanner 텍스트 하드코딩(한국어) → `useTranslation` 기반 다국어 전환
- `useParams()`로 URL의 `[lng]` 세그먼트 감지, 언어별 번역문 자동 적용
- consent 네임스페이스 locale 파일 4개 추가

## 변경 파일

| 파일 | 내용 |
|------|------|
| `ConsentBanner.tsx` | `useParams` + `useTranslation(language, 'consent')` 적용 |
| `i18next.d.ts` | `consent` 네임스페이스 타입 등록 |
| `locales/ko/consent.json` | 한국어 번역 |
| `locales/en/consent.json` | 영어 번역 |
| `locales/ja/consent.json` | 일본어 번역 |
| `locales/zh/consent.json` | 중국어 번역 |

## Test plan

- [ ] `/ko` 접속 → 배너에 "이 사이트는..." 한국어 표시
- [ ] `/en` 접속 → 배너에 "This site uses cookies..." 영어 표시
- [ ] `/ja` 접속 → 배너에 "このサイトは..." 일본어 표시
- [ ] `/zh` 접속 → 배너에 "本网站使用..." 중국어 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)