### PR TITLE
feat: 익명 세션 백엔드 통합 및 세션 관리 구현

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,5 +7,6 @@ yarn run generate-api -- --name=User
 yarn run generate-api -- --name=Auth
 yarn run generate-api -- --name=Storage
 yarn run generate-api -- --name=BlogReply
+yarn run generate-api -- --name=Session
 yarn run build
 yarn run postbuild

--- a/src/app/[lng]/(mobile)/auth/login/page.tsx
+++ b/src/app/[lng]/(mobile)/auth/login/page.tsx
@@ -8,8 +8,10 @@ import Cookies from 'js-cookie';
 import { ShieldCheck } from 'lucide-react';
 
 import Link from '~/components/basic/Link';
-import { authApi, userApi } from '@api';
+import { authApi, sessionApi, userApi } from '@api';
 import useStore from '@hooks/useStore';
+import { clearSessionCookies } from '@hooks/useSession';
+import logger from '@utils/logger';
 import { useTranslation } from '~/app/i18n/client';
 import { LanguageParams } from '~/app/[lng]/layout';
 import UserTokenUtil from '~/utils/userTokenUtil';
@@ -49,7 +51,26 @@ export default function LoginPage({ params }: LanguageParams) {
             UserTokenUtil.setAccessToken(access_token);
             UserTokenUtil.setRefreshToken(refresh_token);
             UserTokenUtil.setUserInfo(data);
-            push(redirectUri);
+
+            // 익명 세션 기록(좋아요/조회수)을 회원 계정으로 마이그레이션.
+            // 실패해도 로그인 흐름은 중단하지 않는다.
+            const sessionId = Cookies.get('SessionId');
+            if (sessionId) {
+              sessionApi
+                .postSessionMigrate(`Bearer ${access_token}`, { session_id: sessionId })
+                .then(() => {
+                  // 마이그레이션 완료 후 세션 비활성화 → 쿠키 제거
+                  clearSessionCookies();
+                })
+                .catch((e) => {
+                  logger.error('Session migrate 실패', e);
+                })
+                .finally(() => {
+                  push(redirectUri);
+                });
+            } else {
+              push(redirectUri);
+            }
           });
         })
         .catch(() => {

--- a/src/components/blog/BlogDetail/LikeButton.tsx
+++ b/src/components/blog/BlogDetail/LikeButton.tsx
@@ -4,25 +4,21 @@ import React, { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Heart } from 'lucide-react';
 import { useCookies } from 'react-cookie';
-import { v4 as uuidv4 } from 'uuid';
 import { blogApi } from '@api';
 import { Text } from '@components/basic/Text';
+import { useSession } from '@hooks/useSession';
 import logger from '@utils/logger';
 import { useBlogDetail } from './BlogDetailProvider';
 
 function LikeButton() {
   const { blog } = useBlogDetail();
-  const [cookies, setCookie] = useCookies(['Authorization', 'SessionId']);
+  const [cookies] = useCookies(['Authorization', 'SessionId']);
+  // 백엔드 발급 세션 보장 — 쿠키 미존재 시 자동 발급/갱신.
+  useSession();
 
   const [likeCount, setLikeCount] = useState(blog.likeCount || 0);
   const [isLiked, setIsLiked] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (!cookies.SessionId) {
-      setCookie('SessionId', uuidv4(), { path: '/' });
-    }
-  }, [cookies.SessionId, setCookie]);
 
   useEffect(() => {
     const fetchLikeStatus = async () => {

--- a/src/components/blog/BlogDetail/ViewCount.tsx
+++ b/src/components/blog/BlogDetail/ViewCount.tsx
@@ -2,25 +2,20 @@
 
 import React, { useEffect, useState } from 'react';
 import { Eye } from 'lucide-react';
-import { useCookies } from 'react-cookie';
-import { v4 as uuidv4 } from 'uuid';
 import { usePostBlogView } from '@queries/useBlogQueries';
+import { useSession } from '@hooks/useSession';
 import { useBlogDetail } from './BlogDetailProvider';
 
 function ViewCount() {
   const { blog } = useBlogDetail();
-  const [cookies, setCookie] = useCookies(['Authorization', 'SessionId']);
+  // 백엔드 발급 세션을 사용 — 클라이언트가 UUID를 직접 만들지 않는다.
+  const { sessionId } = useSession();
   const [viewCount, setViewCount] = useState(blog.viewCount || 0);
 
   const postViewMutation = usePostBlogView();
 
   useEffect(() => {
-    // Ensure SessionId exists
-    let sessionId = cookies.SessionId;
-    if (!sessionId) {
-      sessionId = uuidv4();
-      setCookie('SessionId', sessionId, { path: '/' });
-    }
+    if (!sessionId) return;
 
     const incrementView = async () => {
       try {
@@ -34,7 +29,7 @@ function ViewCount() {
 
     incrementView();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blog.urlSlug, cookies.SessionId, setCookie]); // Mutation dependency omitted to run once per slug/session
+  }, [blog.urlSlug, sessionId]); // 슬러그/세션 변경 시 1회 카운트
 
   return (
     <span className="inline-flex items-center justify-center gap-1 align-middle leading-none">

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,105 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Cookies from 'js-cookie';
+import { sessionApi } from '@api';
+import logger from '@utils/logger';
+
+const SESSION_COOKIE_NAME = 'SessionId';
+const SESSION_EXPIRES_AT_COOKIE = 'SessionExpiresAt';
+const isProduction = process.env.NODE_ENV === 'production';
+
+interface UseSessionResult {
+  sessionId: string | null;
+  isLoading: boolean;
+  /** 백엔드에 세션 발급/검증 요청. 만료되었거나 없으면 새로 발급한다. */
+  refresh: () => Promise<string | null>;
+}
+
+function readStoredExpiresAt(): Date | null {
+  const raw = Cookies.get(SESSION_EXPIRES_AT_COOKIE);
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function persistSession(sessionId: string, expiresAt: string) {
+  const expires = new Date(expiresAt);
+  const cookieOptions: Cookies.CookieAttributes = {
+    path: '/',
+    sameSite: 'strict',
+    secure: isProduction,
+    expires: Number.isNaN(expires.getTime()) ? 365 : expires,
+  };
+  Cookies.set(SESSION_COOKIE_NAME, sessionId, cookieOptions);
+  Cookies.set(SESSION_EXPIRES_AT_COOKIE, expiresAt, cookieOptions);
+}
+
+export function clearSessionCookies() {
+  Cookies.remove(SESSION_COOKIE_NAME, { path: '/' });
+  Cookies.remove(SESSION_EXPIRES_AT_COOKIE, { path: '/' });
+}
+
+/**
+ * 익명 세션을 백엔드로부터 발급/갱신하고 쿠키에 보관한다.
+ *
+ * - 마운트 시 쿠키에 유효한 세션이 있으면 그대로 사용.
+ * - 만료가 임박했거나(=expires_at 이전 1일) 없으면 `POST /session` 호출.
+ * - 응답으로 받은 session_id / expires_at을 쿠키에 저장.
+ *
+ * 쿠키는 middleware에서 fetch로 1차 발급되며, 여기서는 검증/갱신을 담당한다.
+ */
+export function useSession(): UseSessionResult {
+  const [sessionId, setSessionId] = useState<string | null>(
+    () => Cookies.get(SESSION_COOKIE_NAME) ?? null,
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const inFlightRef = useRef<Promise<string | null> | null>(null);
+
+  const refresh = useCallback(async (): Promise<string | null> => {
+    if (inFlightRef.current) return inFlightRef.current;
+
+    const existing = Cookies.get(SESSION_COOKIE_NAME);
+
+    const request = (async () => {
+      setIsLoading(true);
+      try {
+        const { data } = await sessionApi.postSession(existing);
+        persistSession(data.session_id, data.expires_at);
+        setSessionId(data.session_id);
+        return data.session_id;
+      } catch (err) {
+        logger.error('useSession: 세션 발급 실패', err);
+        return existing ?? null;
+      } finally {
+        setIsLoading(false);
+        inFlightRef.current = null;
+      }
+    })();
+
+    inFlightRef.current = request;
+    return request;
+  }, []);
+
+  useEffect(() => {
+    const cookieSessionId = Cookies.get(SESSION_COOKIE_NAME);
+    const expiresAt = readStoredExpiresAt();
+
+    // 만료 1일 전이면 갱신 (= 만료 임박)
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    const shouldRefresh =
+      !cookieSessionId || !expiresAt || expiresAt.getTime() - Date.now() < oneDayMs;
+
+    if (shouldRefresh) {
+      refresh().catch(() => undefined);
+    } else if (cookieSessionId && cookieSessionId !== sessionId) {
+      setSessionId(cookieSessionId);
+    }
+    // 마운트 시 1회만 실행. refresh는 안정적 콜백.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { sessionId, isLoading, refresh };
+}
+
+export default useSession;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -100,8 +100,53 @@ export async function middleware(req: NextRequest) {
     if (lngInReferer) response.cookies.set(cookieName, lngInReferer);
   }
 
+  // 익명 세션: 백엔드(POST /session)가 발급한 session_id를 사용한다.
+  // 쿠키가 없는 경우에만 발급 시도 — 만료/갱신은 클라이언트 훅(useSession)이 담당한다.
   if (!req.cookies.has('SessionId')) {
-    response.cookies.set('SessionId', crypto.randomUUID());
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (apiUrl) {
+      try {
+        const sessionRes = await fetch(`${apiUrl.replace(/\/+$/, '')}/session`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          cache: 'no-store',
+        });
+        if (sessionRes.ok) {
+          const sessionPayload = (await sessionRes.json()) as {
+            session_id?: string;
+            expires_at?: string;
+          };
+          if (sessionPayload.session_id) {
+            const sessionExpires = sessionPayload.expires_at
+              ? new Date(sessionPayload.expires_at)
+              : undefined;
+            const hasValidExpiry = !!sessionExpires && !Number.isNaN(sessionExpires.getTime());
+            response.cookies.set({
+              name: 'SessionId',
+              value: sessionPayload.session_id,
+              path: '/',
+              sameSite: 'strict',
+              secure: isProduction,
+              ...(hasValidExpiry ? { expires: sessionExpires } : {}),
+            });
+            if (sessionPayload.expires_at) {
+              response.cookies.set({
+                name: 'SessionExpiresAt',
+                value: sessionPayload.expires_at,
+                path: '/',
+                sameSite: 'strict',
+                secure: isProduction,
+                ...(hasValidExpiry ? { expires: sessionExpires } : {}),
+              });
+            }
+          }
+        } else {
+          logger.error('Middleware: 세션 발급 실패', sessionRes.status);
+        }
+      } catch (e) {
+        logger.error('Middleware: 세션 발급 fetch 오류', e);
+      }
+    }
   }
 
   const accessToken = req.cookies.get('access_token')?.value;

--- a/src/spec/api/index.ts
+++ b/src/spec/api/index.ts
@@ -5,6 +5,7 @@ import UserTokenUtil from '@utils/userTokenUtil';
 import { AuthApi } from './Auth';
 import { BlogApi } from './Blog';
 import { BlogReplyApi } from './BlogReply';
+import { SessionApi } from './Session';
 import { StorageApi } from './Storage';
 import { UserApi } from './User';
 
@@ -76,6 +77,7 @@ const logoutAndLogin = () => {
 export const authApi = new AuthApi(undefined, API_URL, apiInstance);
 export const blogApi = new BlogApi(undefined, API_URL, apiInstance);
 export const blogReplyApi = new BlogReplyApi(undefined, API_URL, apiInstance);
+export const sessionApi = new SessionApi(undefined, API_URL, apiInstance);
 export const storageApi = new StorageApi(undefined, API_URL, apiInstance);
 export const userApi = new UserApi(undefined, API_URL, apiInstance);
 


### PR DESCRIPTION
## Summary
- 프론트엔드가 직접 `crypto.randomUUID()`로 세션 ID를 생성하던 방식을 **백엔드 발급으로 단일화**
- GA4와 백엔드 Analytics가 동일한 `session_id`를 공유

## 변경 파일

### 신규
| 파일 | 역할 |
|---|---|
| `src/spec/api/Session/` | OpenAPI generator로 자동 생성된 SessionApi 클라이언트 |
| `src/hooks/useSession.ts` | 세션 발급·갱신·쿠키 관리 훅 (중복 요청 방지, 만료 임박 시 자동 갱신) |

### 수정
| 파일 | 변경 내용 |
|---|---|
| `src/middleware.ts` | `crypto.randomUUID()` 제거 → Edge Runtime에서 `fetch POST /session` 호출 |
| `src/spec/api/index.ts` | `sessionApi` 인스턴스 export 추가 |
| `src/app/[lng]/(mobile)/auth/login/page.tsx` | 로그인 성공 후 `postSessionMigrate` 호출 + `clearSessionCookies()` |
| `src/components/blog/BlogDetail/LikeButton.tsx` | `uuidv4` 제거 → `useSession()` 사용 |
| `src/components/blog/BlogDetail/ViewCount.tsx` | `uuidv4` 제거 → `useSession()` 사용 |
| `api-spec` (submodule) | develop 브랜치로 업데이트 (Session.yaml 포함) |

## 세션 흐름
1. 최초 방문 → middleware에서 `POST /session` → 쿠키 `SessionId` + `SessionExpiresAt` 저장
2. 이후 요청 → `useSession()` 훅이 만료 임박 시 자동 갱신
3. 로그인 성공 → `POST /session/migrate` → 비회원 기록 회원에 연결 → 세션 쿠키 삭제

## Test plan
- [ ] 최초 방문 시 `SessionId` 쿠키 설정 확인 (백엔드 UUID 형식)
- [ ] 동일 세션으로 재방문 시 기존 `SessionId` 유지 확인
- [ ] 로그인 후 `SessionId` 쿠키 삭제 확인
- [ ] 비로그인 상태에서 좋아요/조회 → 로그인 후 기록 연결 확인
- [ ] `tsc --noEmit` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)