### PR TITLE
fix: GoogleAd width=0 케이스 광고 노출 복구

### DIFF
--- a/src/components/google/GoogleAd.tsx
+++ b/src/components/google/GoogleAd.tsx
@@ -13,24 +13,60 @@ type GoogleAdProps = {
   className?: string;
 };
 
+const MIN_AD_WIDTH = 250;
+
 function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
   const insRef = useRef<HTMLModElement>(null);
 
   useEffect(() => {
-    if (!insRef.current || insRef.current.offsetWidth === 0) return;
-    try {
-      (window.adsbygoogle = window.adsbygoogle || []).push({});
-    } catch (_) {
-      // adsbygoogle push errors are non-fatal
+    const el = insRef.current;
+    if (!el) return undefined;
+
+    let pushed = false;
+    let ro: ResizeObserver | null = null;
+    let io: IntersectionObserver | null = null;
+
+    // 폭이 확보되고 뷰포트에 들어왔을 때 1회만 push.
+    // 기존 구현은 mount 직후 1회 측정만 했기 때문에, flex/grid 부모가 초기 폭=0이면
+    // 광고가 영구히 노출되지 않으면서 AdSense는 별도 경로로 push를 시도해 No-slot-size 에러를 던졌다.
+    const tryPush = () => {
+      if (pushed || !el.isConnected) return;
+      if (el.offsetWidth < MIN_AD_WIDTH) return;
+      pushed = true;
+      try {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      } catch {
+        // adsbygoogle.push의 동기 throw만 흡수. 비동기 TagError는 Sentry로 보내 모니터링 유지.
+      }
+      ro?.disconnect();
+      io?.disconnect();
+    };
+
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(tryPush);
+      ro.observe(el);
     }
+    if (typeof IntersectionObserver !== 'undefined') {
+      io = new IntersectionObserver((entries) => {
+        if (entries.some((e) => e.isIntersecting)) tryPush();
+      });
+      io.observe(el);
+    }
+
+    tryPush();
+
+    return () => {
+      ro?.disconnect();
+      io?.disconnect();
+    };
   }, []);
 
   return (
-    <div className={className}>
+    <div className={className} style={{ minWidth: MIN_AD_WIDTH, minHeight: 100 }}>
       <ins
         ref={insRef}
         className="adsbygoogle"
-        style={{ display: 'block' }}
+        style={{ display: 'block', minWidth: MIN_AD_WIDTH, minHeight: 100 }}
         data-ad-client={process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_CLIENT_ID}
         data-ad-slot={String(slotId)}
         data-ad-format="auto"


### PR DESCRIPTION
## Summary
- 기존 `GoogleAd`는 mount 직후 1회만 `offsetWidth`를 측정해 0이면 push를 건너뛰는 가드를 가지고 있었음 → 부모 컨테이너가 초기 폭=0인 케이스(flex/grid, 모바일 가변폭, 조건부 렌더)에서 광고가 **두 번 다시 push되지 않으면서** AdSense 스크립트가 별도 경로로 push를 시도해 `TagError: No slot size for availableWidth=0` 에러를 던지는 \"수익 0 + 에러는 그대로\" 최악 조합 발생.
- `ResizeObserver` + `IntersectionObserver`로 width ≥ 250px이 확보되고 뷰포트에 들어왔을 때 1회만 push하도록 변경. `<ins>`와 래퍼 div 모두 `minWidth: 250, minHeight: 100` 부여로 슬롯 폭과 CLS 영역 확보.

## Sentry 이슈
- [OKDOHYUK-FRONT-9](https://okdohyuk.sentry.io/issues/OKDOHYUK-FRONT-9) `TagError: adsbygoogle.push() error: No slot size for availableWidth=0` — **854 events / 553 users** (`/pokemon-type-calculator` 등)

## 변경 파일
- `src/components/google/GoogleAd.tsx`

## Test plan
- [ ] Chrome devtools 모바일 에뮬레이션(360×640) + Throttling 3G로 `/pokemon-type-calculator` 진입 → Network 탭에서 `pagead/show_ads` 호출 + DOM에 `<iframe id=\"aswift_*\">` 생성 확인
- [ ] `coin-flip`, `qr-generator`, `bmi-calculator` 등 다른 `GoogleAd` 사용 페이지에서 광고 정상 노출 회귀 없음 확인
- [ ] 실제 모바일 Safari/Chrome 진입 후 광고 노출 확인
- [ ] 배포 후 1주: Sentry `OKDOHYUK-FRONT-9` `lastSeen` 정지 + AdSense 대시보드 노출/수익 회복 곡선 모니터링