### PR TITLE
fix: 단축 URL 표시를 NEXT_PUBLIC_URL 기반으로 변경

### DIFF
--- a/src/app/[lng]/(mobile)/shortener/ShortenerForm.tsx
+++ b/src/app/[lng]/(mobile)/shortener/ShortenerForm.tsx
@@ -15,6 +15,7 @@ import { useCreateShortUrl } from '@queries/useShortUrlQueries';
 import type { ShortUrl, ShortUrlCreateRequest } from '@api/ShortUrl';
 import { ShortUrlCreateRequestExpirePresetEnum } from '@api/ShortUrl';
 import { cn } from '@utils/cn';
+import { buildShortUrl } from '@libs/shared/agentDiscovery';
 import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
 import logger from '@utils/logger';
 import { useTranslation } from '~/app/i18n/client';
@@ -70,6 +71,8 @@ export default function ShortenerForm({ lng }: ShortenerFormProps) {
   const [copied, setCopied] = React.useState(false);
   const createMutation = useCreateShortUrl();
   const result: ShortUrl | undefined = createMutation.data;
+  // 표시·복사용 단축 URL 은 백엔드 shortUrl 대신 NEXT_PUBLIC_URL 기반으로 직접 구성한다.
+  const displayShortUrl = result ? buildShortUrl(result.code) : '';
 
   const formatExpiresAt = (expiresAt: string | null | undefined) => {
     if (!expiresAt) return t('result.expiresNever');
@@ -100,9 +103,9 @@ export default function ShortenerForm({ lng }: ShortenerFormProps) {
   };
 
   const handleCopy = async () => {
-    if (!result?.shortUrl) return;
+    if (!displayShortUrl) return;
     try {
-      await navigator.clipboard.writeText(result.shortUrl);
+      await navigator.clipboard.writeText(displayShortUrl);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch (e) {
@@ -198,12 +201,12 @@ export default function ShortenerForm({ lng }: ShortenerFormProps) {
 
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <a
-              href={result.shortUrl}
+              href={displayShortUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="flex-1 break-all rounded-md border border-basic-3 bg-basic-0 px-3 py-2 text-sm text-point-fg underline-offset-2 hover:underline"
             >
-              {result.shortUrl}
+              {displayShortUrl}
             </a>
             <Button
               type="button"

--- a/src/app/[lng]/(mobile)/shortener/__tests__/ShortenerForm.test.tsx
+++ b/src/app/[lng]/(mobile)/shortener/__tests__/ShortenerForm.test.tsx
@@ -17,6 +17,12 @@ vi.mock('@queries/useShortUrlQueries', () => ({
   useCreateShortUrl: () => useCreateShortUrlMock(),
 }));
 
+// 표시·복사용 단축 URL 은 buildShortUrl(NEXT_PUBLIC_URL 기반) 로 구성된다.
+// 환경변수 로딩 여부와 무관하게 결정적으로 검증하기 위해 헬퍼를 직접 mock 한다.
+vi.mock('@libs/shared/agentDiscovery', () => ({
+  buildShortUrl: (code: string) => `https://okdohyuk.dev/l/${code}`,
+}));
+
 vi.mock('@utils/logger', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));

--- a/src/app/[lng]/(mobile)/shortener/me/MyShortUrlsTable.tsx
+++ b/src/app/[lng]/(mobile)/shortener/me/MyShortUrlsTable.tsx
@@ -14,6 +14,7 @@ import {
 import { useDeleteShortUrl, useMyShortUrls } from '@queries/useShortUrlQueries';
 import UserTokenUtil from '@utils/userTokenUtil';
 import logger from '@utils/logger';
+import { buildShortUrl } from '@libs/shared/agentDiscovery';
 import { useTranslation } from '~/app/i18n/client';
 import { Language } from '~/app/i18n/settings';
 
@@ -93,16 +94,18 @@ export default function MyShortUrlsTable({ lng }: MyShortUrlsTableProps) {
       <TableBody>
         {items.map((item) => {
           const isDeleting = deleteMutation.isPending && deleteMutation.variables === item.code;
+          // 백엔드 shortUrl 대신 NEXT_PUBLIC_URL 기반 절대 URL 로 표시한다.
+          const displayShortUrl = buildShortUrl(item.code);
           return (
             <TableRow key={item.code}>
               <TableCell className="font-mono text-xs">
                 <a
-                  href={item.shortUrl}
+                  href={displayShortUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-point-fg underline-offset-2 hover:underline break-all"
                 >
-                  {item.shortUrl}
+                  {displayShortUrl}
                 </a>
               </TableCell>
               <TableCell className="break-all text-xs text-fg-3">{item.originalUrl}</TableCell>

--- a/src/libs/shared/agentDiscovery.ts
+++ b/src/libs/shared/agentDiscovery.ts
@@ -44,6 +44,13 @@ export function absoluteUrl(pathname: string) {
   return new URL(joinPath(pathname), SITE_URL).toString();
 }
 
+// 단축 링크 경로는 항상 /l/{code} 이며, 표시·복사용 절대 URL 은 백엔드 응답의 shortUrl
+// (미설정 시 http://localhost:3000 으로 새는 문제) 대신 NEXT_PUBLIC_URL(SITE_URL) 기반으로
+// 직접 구성한다. absoluteUrl 이 new URL 로 trailing slash 를 정규화하므로 그대로 재사용한다.
+export function buildShortUrl(code: string) {
+  return absoluteUrl(`/l/${code}`);
+}
+
 export function isMarkdownRequest(acceptHeader: string | null) {
   return /(^|,|\s|;)text\/markdown(\s|;|,|$)/i.test(acceptHeader ?? '');
 }


### PR DESCRIPTION
## 배경
운영(prod)에서 생성된 단축 URL이 `localhost:3000`으로 표시되는 문제.

## 원인
프론트가 백엔드 응답의 `shortUrl` 필드를 그대로 노출했는데, 백엔드는 `app.short-url.base-url`(미설정 시 기본값 `http://localhost:3000`)로 단축 URL을 생성한다. 운영 설정에 해당 값이 누락돼 localhost로 폴백됐다.

## 변경
단축 링크 도메인은 프론트 도메인(`/l/[code]`를 Next.js가 서빙)이므로, 백엔드 `shortUrl` 대신 `NEXT_PUBLIC_URL` 기반으로 직접 구성하도록 변경.

- `libs/shared/agentDiscovery.ts` — 기존 `SITE_URL`/`absoluteUrl`을 재사용한 `buildShortUrl(code)` 헬퍼 추가 (`${NEXT_PUBLIC_URL}/l/{code}`, 미설정 시 `https://okdohyuk.dev` 폴백)
- `shortener/ShortenerForm.tsx` — 결과 표시·복사 대상을 `buildShortUrl(code)`로 교체
- `shortener/me/MyShortUrlsTable.tsx` — 목록 표시를 `buildShortUrl(item.code)`로 교체
- `shortener/__tests__/ShortenerForm.test.tsx` — 결정적 검증 위해 mock 추가

## 검증
- `tsc --noEmit` / eslint / `next build` 통과
- vitest 211 passed (pre-commit 훅 포함)
- 코드리뷰 blocker 0

## 참고
- 백엔드 `application.yml`은 gitignore 대상이라 이 PR에 포함되지 않음. 프론트가 `NEXT_PUBLIC_URL`로 직접 구성하므로 백엔드 `shortUrl` 값은 표시에 영향 없음.
- 별건으로 보고된 `/l/{code}` 접속 시 500은 현재 코드(Next 16)에서 재현되지 않음 → 운영 재배포 및 `NEXT_PUBLIC_API_URL` 점검 권장 (이 PR 범위 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)