### PR TITLE
fix: 블로그 상세페이지 SSG를 4시간 ISR로 전환

### DIFF
--- a/src/app/[lng]/blog/[urlSlug]/page.tsx
+++ b/src/app/[lng]/blog/[urlSlug]/page.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import axios from 'axios';
 import { notFound } from 'next/navigation';
 import { unstable_cache as cache } from 'next/cache';
 import { blogApi } from '@api';
-import { BaseException } from '@api/Blog';
+import { Blog } from '@api/Blog';
 import BlogDetail from '@components/blog/BlogDetail';
 import { metadata } from '@libs/server/customMetadata';
 import { Language } from '~/app/i18n/settings';
@@ -12,7 +11,13 @@ type BlogDetailProps = {
   params: Promise<{ lng: Language; urlSlug: string }>;
 };
 
-export const dynamic = 'force-static';
+// 4시간(=4*60*60=14400s)마다 정적 페이지를 ISR 재생성한다.
+// Next.js 세그먼트 설정은 정적 분석 가능한 리터럴이어야 하므로 변수 참조 대신 리터럴 사용.
+export const revalidate = 14400;
+
+// 빌드 시점에 알려진 슬러그를 prerender. dynamicParams=true 이므로
+// 여기에 없던 새 글도 첫 요청 시 온디맨드로 정적 생성된다.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   try {
@@ -24,21 +29,22 @@ export async function generateStaticParams() {
   }
 }
 
+// 데이터 캐시도 페이지 ISR 정책과 동일하게 4시간으로 맞춘다.
+// notFound()는 캐시 내부에서 호출하지 않는다 — 존재하지 않는 슬러그의 404
+// 결과가 캐시에 박히면 이후 글이 추가돼도 계속 404가 노출되기 때문.
+// 대신 실패 시 null을 반환하고, 호출부(페이지/메타데이터)에서 notFound()를 호출한다.
 const getPost = cache(
-  async (urlSlug: string) => {
+  async (urlSlug: string): Promise<Blog | null> => {
     try {
       const { data } = await blogApi.getBlogUrlSlug(decodeURIComponent(urlSlug));
 
       return data;
     } catch (error) {
-      if (axios.isAxiosError<BaseException, never>(error)) {
-        return notFound();
-      }
-      return notFound();
+      return null;
     }
   },
   ['blog-post'],
-  { revalidate: 3600, tags: ['blog-post'] },
+  { revalidate: 14400, tags: ['blog-post'] },
 );
 
 export const generateMetadata = async (props: BlogDetailProps) => {
@@ -46,7 +52,13 @@ export const generateMetadata = async (props: BlogDetailProps) => {
 
   const { lng, urlSlug } = params;
 
-  const { title, contents, thumbnailImage, tags } = await getPost(urlSlug);
+  const post = await getPost(urlSlug);
+
+  if (!post) {
+    return notFound();
+  }
+
+  const { title, contents, thumbnailImage, tags } = post;
 
   return metadata({
     title,
@@ -62,5 +74,9 @@ export default async function BlogDetailPage({ params }: BlogDetailProps) {
   const { urlSlug, lng } = await params;
   const blog = await getPost(urlSlug);
 
-  return <BlogDetail blog={blog} lng={await lng} />;
+  if (!blog) {
+    return notFound();
+  }
+
+  return <BlogDetail blog={blog} lng={lng} />;
 }


### PR DESCRIPTION
## 배경
블로그 상세페이지(`/[lng]/blog/[urlSlug]`)가 SSG로 빌드되는데, **빌드 후 추가된 새 글에 접속하면 Vercel에서 404(없는 페이지)** 가 떴다.

## 원인
1. `export const dynamic = 'force-static';` 가 라우트를 완전 정적으로 고정 → `generateStaticParams`(빌드 시점 상위 100개만 prerender)에 없던 새 슬러그가 온디맨드로 생성되지 못하고 404.
2. `getPost`가 `unstable_cache` **내부에서 `notFound()` 를 호출** → 존재하지 않던 슬러그의 404 결과가 데이터 캐시에 박혀, 이후 글이 추가돼도 계속 404가 노출될 수 있음.

## 변경 (`src/app/[lng]/blog/[urlSlug]/page.tsx`)
- `dynamic = 'force-static'` **제거**
- `export const revalidate = 14400;` **추가** — 4시간(=4×60×60초)마다 정적 페이지 ISR 재생성
- `export const dynamicParams = true;` **추가** — prerender 목록에 없는 새 글도 첫 요청 시 온디맨드 정적 생성
- `getPost` 가 실패 시 `notFound()` 대신 **`null` 반환**, `notFound()` 는 호출부(페이지/메타데이터, 캐시 바깥)에서 호출 → 404가 캐시에 박히지 않음
- 데이터 캐시 `revalidate` 3600 → 14400 으로 페이지 정책과 일치
- 미사용 import 정리(`axios`, `BaseException`)

## 동작
- 기존 글: 정적(SSG) 서빙 + 4시간마다 ISR 재생성
- 새 글: 첫 접속 시 온디맨드 정적 생성(404 없음), 이후 4시간 ISR
- 글 수정: 최대 4시간 내 반영

## 검증
- `next build` 성공 — 라우트 `● /[lng]/blog/[urlSlug]` (SSG + ISR + dynamicParams)
- `tsc --noEmit` / eslint 통과
- vitest 211 passed (pre-commit 훅 포함)

## 후속 권고 (이 PR 범위 밖)
- `server-sitemap.xml`이 블로그 상위 100개만 노출 → 글 100개 초과 시 sitemap 누락(SEO). 별도 개선 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)