### PR TITLE
fix: 단축 URL 리다이렉트 시 비ASCII originalUrl로 인한 500 해결

### DIFF
--- a/src/app/l/[code]/page.tsx
+++ b/src/app/l/[code]/page.tsx
@@ -31,5 +31,18 @@ export default async function ShortLinkPage({ params }: ShortLinkPageProps) {
     notFound();
   }
 
-  redirect(originalUrl);
+  // Location 헤더에는 ASCII(latin1)만 허용된다. 원본 URL에 한글 등 비ASCII나
+  // 인코딩되지 않은 공백이 포함되면 redirect() 내부의 setHeader 가
+  // "Invalid character in header content" 로 throw → try/catch 밖이라 500 이 된다.
+  // new URL().href 로 path/query/host(punycode)를 정규화·percent-encoding 하여 헤더 안전 문자열로 만든다.
+  let redirectUrl: string;
+  try {
+    redirectUrl = new URL(originalUrl).href;
+  } catch {
+    // 정규화 불가한 비정상 URL 은 not-found 로 안내한다.
+    logger.warn('ShortLinkPage 잘못된 originalUrl', code, originalUrl);
+    notFound();
+  }
+
+  redirect(redirectUrl);
 }


### PR DESCRIPTION
## 증상
`https://okdohyuk.dev/l/{code}` 접속 시 일부 단축 링크에서 **500** 발생 (예: `/l/vDKdXF`, `/l/ij0Vgz`).

## 근본 원인 (Sentry 확인)
- Sentry 이슈 `OKDOHYUK-FRONT-1Y` / `OKDOHYUK-FRONT-1Z`: **`TypeError: Invalid character in header content ["location"]`**, transaction `/l/[code]/page`.
- 스택: `redirect(originalUrl)` → Next 내부 `setHeader('location', originalUrl)` → `node:_http_outgoing setHeader`.
- HTTP `Location` 헤더 값은 ASCII(latin1)만 허용된다. 원본 URL에 **한글 등 비ASCII나 인코딩되지 않은 공백**이 포함되면 Node `setHeader`가 throw하는데, 이 호출은 `try/catch` 밖이라 그대로 500으로 표면화됐다.

## 수정 (`src/app/l/[code]/page.tsx`)
- `redirect()` 직전에 **`new URL(originalUrl).href`로 정규화**하여 path/query는 percent-encoding, host는 punycode로 변환된 헤더 안전 문자열을 사용.
- 정규화 불가한 비정상 URL은 `notFound()`로 안내.

```
https://example.com/검색?q=한글 → https://example.com/%EA%B2%80%EC%83%89?q=%ED%95%9C%EA%B8%80
https://한글.com/path           → https://xn--bj0bj06e.com/path
```

## 검증
- `tsc --noEmit` / eslint 통과
- vitest 211 passed (pre-commit 훅 포함)
- Node로 비ASCII/공백/IDN URL 정규화 동작 확인

## ⚠️ 별도 발견 (이 PR 범위 밖, 후속 필요)
같은 부류의 헤더 인코딩 버그가 블로그에도 있음 — Sentry `OKDOHYUK-FRONT-1G`: **`Invalid character in header content ["x-next-cache-tags"]`**, culprit `/[lng]/blog/[urlSlug]/page`, **1418건**. 한글 슬러그가 Next 캐시 태그 헤더에 들어가며 발생하는 것으로 추정. 별도 이슈로 처리 권장.

Fixes OKDOHYUK-FRONT-1Y
Fixes OKDOHYUK-FRONT-1Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)