### PR TITLE
fix: 로그인 후 이전 페이지 복귀 동작 복구

### DIFF
--- a/src/app/[lng]/(mobile)/anti-copykiller/components/CopykillerClient.tsx
+++ b/src/app/[lng]/(mobile)/anti-copykiller/components/CopykillerClient.tsx
@@ -17,6 +17,7 @@ import {
   useDownloadCopykillerResult,
 } from '@queries/useCopykillerQueries';
 import useStore from '@hooks/useStore';
+import { buildLoginUrl } from '@utils/loginRedirect';
 import type { Language } from '~/app/i18n/settings';
 import type { CopykillerJob } from '@api/Copykiller';
 
@@ -188,7 +189,7 @@ function CopykillerClient({ lng }: CopykillerClientProps) {
       sponsorTitle={t('gate.sponsor.title')}
       sponsorDescription={t('gate.sponsor.description')}
       sponsorCta={t('gate.sponsor.cta')}
-      loginHref={`/${lng}/auth/login`}
+      loginHref={buildLoginUrl(`/${lng}/auth/login`, `/${lng}/anti-copykiller`)}
       sponsorHref="https://github.com/sponsors/okdohyuk?frequency=recurring"
     >
       <div className="space-y-6">

--- a/src/app/[lng]/(mobile)/auth/login/page.tsx
+++ b/src/app/[lng]/(mobile)/auth/login/page.tsx
@@ -11,6 +11,7 @@ import Link from '~/components/basic/Link';
 import { authApi, sessionApi, userApi } from '@api';
 import useStore from '@hooks/useStore';
 import { clearSessionCookies } from '@hooks/useSession';
+import { clearLoginRedirect, getLoginRedirect, rememberLoginRedirect } from '@utils/loginRedirect';
 import logger from '@utils/logger';
 import { useTranslation } from '~/app/i18n/client';
 import { LanguageParams } from '~/app/[lng]/layout';
@@ -81,7 +82,7 @@ export default function LoginPage({ params }: LanguageParams) {
           push('/auth/login');
         })
         .finally(() => {
-          Cookies.remove('redirect_uri');
+          clearLoginRedirect();
           Cookies.remove('login_state');
         });
     },
@@ -89,6 +90,11 @@ export default function LoginPage({ params }: LanguageParams) {
   );
 
   useEffect(() => {
+    // 서버 리다이렉트(인증 가드 등)가 쿼리로 넘긴 복귀 경로를 쿠키로 영속화한다.
+    // OAuth 왕복 후에는 쿼리가 유실되므로 쿠키에서 복원한다.
+    const queryRedirectUri = new URLSearchParams(window.location.search).get('redirect_uri');
+    if (queryRedirectUri) rememberLoginRedirect(queryRedirectUri);
+
     const hashFragment = window.location.hash.split('#')[1];
     if (!hashFragment) {
       setLoginButtonDisabled(false);
@@ -103,8 +109,7 @@ export default function LoginPage({ params }: LanguageParams) {
       return;
     }
 
-    const redirectUri = Cookies.get('redirect_uri');
-    login(accessToken, redirectUri || '/');
+    login(accessToken, getLoginRedirect() || '/');
   }, [login]);
 
   const handleLogin = async () => {

--- a/src/app/[lng]/(mobile)/shortener/me/page.tsx
+++ b/src/app/[lng]/(mobile)/shortener/me/page.tsx
@@ -5,6 +5,7 @@ import { ListChecks } from 'lucide-react';
 import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
 import ServiceInfoNotice from '@components/complex/Service/ServiceInfoNotice';
 import { getTranslations } from '~/app/i18n';
+import { buildLoginUrl } from '@utils/loginRedirect';
 import { LanguageParams } from '~/app/[lng]/layout';
 import { Language } from '~/app/i18n/settings';
 import MyShortUrlsTable from './MyShortUrlsTable';
@@ -20,7 +21,7 @@ export default async function MyShortUrlsPage({ params }: LanguageParams) {
   const refreshToken = cookieStore.get('refresh_token')?.value;
   const userInfo = cookieStore.get('user_info')?.value;
   if (!refreshToken || !userInfo) {
-    redirect(`/${language}/auth/login?redirect_uri=/${language}/shortener/me`);
+    redirect(buildLoginUrl(`/${language}/auth/login`, `/${language}/shortener/me`));
   }
 
   const { t } = await getTranslations(language, 'shortener');

--- a/src/app/[lng]/admin/blog/write/page.tsx
+++ b/src/app/[lng]/admin/blog/write/page.tsx
@@ -8,9 +8,9 @@ import BlogWritePageImpl from '~/app/[lng]/admin/blog/write/impl';
 import { LanguageParams } from '~/app/[lng]/layout';
 import { Language } from '~/app/i18n/settings';
 
-const getPost = async (urlSlug: string) => {
+const getPost = async (urlSlug: string, redirectPath: string) => {
   try {
-    const token = await getTokenServer();
+    const token = await getTokenServer(redirectPath);
     if (!token) return notFound();
     const { data } = await blogApi.getBlogUrlSlug(decodeURIComponent(urlSlug), token.accessToken);
     return data;
@@ -38,7 +38,9 @@ export default async function BlogWritePage({ params, searchParams }: BlogWriteP
   const { urlSlug: urlSlugs } = await searchParams;
 
   const urlSlug = typeof urlSlugs === 'string' ? urlSlugs : null;
-  const blog = urlSlug ? await getPost(urlSlug) : null;
+  const blog = urlSlug
+    ? await getPost(urlSlug, `/${language}/admin/blog/write?urlSlug=${encodeURIComponent(urlSlug)}`)
+    : null;
   const category = await getCategory();
 
   return <BlogWritePageImpl lng={language} blog={blog} category={category} />;

--- a/src/components/blog/reply/BlogReplyForm.tsx
+++ b/src/components/blog/reply/BlogReplyForm.tsx
@@ -6,6 +6,7 @@ import { BlogReply } from '@api/BlogReply';
 import { useRouter } from 'next/navigation';
 import UserTokenUtil from '@utils/userTokenUtil';
 import { getErrorMessage } from '@utils/errorHandler';
+import { rememberLoginRedirect } from '@utils/loginRedirect';
 import { Language } from '~/app/i18n/settings';
 import { useTranslation } from '../../../app/i18n/client';
 
@@ -42,6 +43,7 @@ function BlogReplyForm({
     const token = await UserTokenUtil.getAccessToken();
     if (!token) {
       if (window.confirm(t('confirm.loginRequired'))) {
+        rememberLoginRedirect(window.location.pathname);
         router.push('/auth/login');
       }
       return;

--- a/src/components/blog/reply/BlogReplyItem.tsx
+++ b/src/components/blog/reply/BlogReplyItem.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { User, UserRoleEnum } from '@api/User';
 
 import { getErrorMessage } from '@utils/errorHandler';
+import { rememberLoginRedirect } from '@utils/loginRedirect';
 import { Language } from '~/app/i18n/settings';
 import { useTranslation } from '../../../app/i18n/client';
 
@@ -46,6 +47,7 @@ export default function BlogReplyItem({
     const token = await UserTokenUtil.getAccessToken();
     if (!token) {
       if (window.confirm(t('confirm.loginRequired'))) {
+        rememberLoginRedirect(window.location.pathname);
         router.push('/auth/login');
       }
       return false;

--- a/src/components/complex/Card/UserInfoCard.tsx
+++ b/src/components/complex/Card/UserInfoCard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Image from 'next/legacy/image';
 import { observer } from 'mobx-react';
 import useStore from '@hooks/useStore';
-import Cookies from 'js-cookie';
+import { rememberLoginRedirect } from '@utils/loginRedirect';
 import { usePathname, useRouter } from 'next/navigation';
 import { Language } from '~/app/i18n/settings';
 import { useTranslation } from '~/app/i18n/client';
@@ -23,7 +23,7 @@ function UserInfoCard({ lng }: { lng: Language }) {
   const isClient = useIsClient();
 
   const handleLogin = () => {
-    if (pathname) Cookies.set('redirect_uri', pathname);
+    rememberLoginRedirect(pathname);
     push('/auth/login');
   };
 

--- a/src/components/complex/CommandPalette/CommandPalette.tsx
+++ b/src/components/complex/CommandPalette/CommandPalette.tsx
@@ -9,6 +9,7 @@ import { UserRoleEnum } from '@api/User';
 import { Input } from '@components/basic/Input';
 import { cn } from '@utils/cn';
 import { OPEN_COMMAND_PALETTE_EVENT } from '@utils/commandPalette';
+import { rememberLoginRedirect } from '@utils/loginRedirect';
 import { sendGAEvent } from '@libs/client/gtag';
 import useStore from '@hooks/useStore';
 import { useTranslation } from '~/app/i18n/client';
@@ -117,6 +118,8 @@ function CommandPalette() {
       setOpen(false);
       const targetPath = `/${lng}${page.path === '/' ? '' : page.path}`;
       if (pathname !== targetPath) {
+        // 로그인 페이지로 이동 시 현재 페이지를 기록해 로그인 후 복귀할 수 있게 한다.
+        if (page.path === '/auth/login') rememberLoginRedirect(pathname);
         router.push(targetPath);
       }
     },

--- a/src/libs/server/token.ts
+++ b/src/libs/server/token.ts
@@ -8,8 +8,12 @@ import UserTokenUtil from '@utils/userTokenUtil';
 import { AxiosError } from 'axios';
 import { authApi } from '@api';
 import logger from '@utils/logger';
+import { buildLoginUrl } from '@utils/loginRedirect';
 
-export const getTokenServer = cache(async () => {
+/**
+ * @param redirectPath 인증 실패로 로그인 페이지 이동 시, 로그인 완료 후 복귀할 경로
+ */
+export const getTokenServer = cache(async (redirectPath?: string) => {
   const cookieStore = await cookies();
   let accessToken = cookieStore.get('access_token')?.value;
   const refreshToken = cookieStore.get('refresh_token')?.value;
@@ -75,5 +79,5 @@ export const getTokenServer = cache(async () => {
   }
 
   // 3. 모든 시도 실패 시 (유효한 초기 토큰 없음, 리프레시 토큰/사용자 ID 없음, 또는 리프레시 실패)
-  return redirect('/auth/login');
+  return redirect(redirectPath ? buildLoginUrl('/auth/login', redirectPath) : '/auth/login');
 });

--- a/src/spec/api/index.ts
+++ b/src/spec/api/index.ts
@@ -1,7 +1,7 @@
-import Cookies from 'js-cookie';
 import axios, { AxiosError, AxiosHeaders, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import * as Sentry from '@sentry/nextjs';
 import UserTokenUtil from '@utils/userTokenUtil';
+import { rememberLoginRedirect } from '@utils/loginRedirect';
 import { AuthApi } from './Auth';
 import { BlogApi } from './Blog';
 import { BlogReplyApi } from './BlogReply';
@@ -70,7 +70,7 @@ const processQueue = (error: unknown, token: string | null = null) => {
 // 로그아웃 및 로그인 페이지로 이동
 const logoutAndLogin = () => {
   if (typeof window !== 'undefined') {
-    Cookies.set('redirect_uri', window.location.pathname);
+    rememberLoginRedirect(window.location.pathname);
     window.location.href = '/auth/login';
   }
 };

--- a/src/utils/__tests__/loginRedirect.test.ts
+++ b/src/utils/__tests__/loginRedirect.test.ts
@@ -1,0 +1,91 @@
+import { vi } from 'vitest';
+import Cookies from 'js-cookie';
+import {
+  sanitizeRedirectUri,
+  rememberLoginRedirect,
+  getLoginRedirect,
+  clearLoginRedirect,
+  buildLoginUrl,
+} from '../loginRedirect';
+
+// js-cookie 모의
+vi.mock('js-cookie');
+const mockedCookies = vi.mocked(Cookies, true);
+
+describe('loginRedirect', () => {
+  beforeEach(() => {
+    mockedCookies.get.mockClear();
+    mockedCookies.set.mockClear();
+    mockedCookies.remove.mockClear();
+  });
+
+  describe('sanitizeRedirectUri', () => {
+    it('내부 절대 경로는 그대로 반환해야 합니다', () => {
+      expect(sanitizeRedirectUri('/ko/shortener/me')).toBe('/ko/shortener/me');
+      expect(sanitizeRedirectUri('/ko/blog/some-post?tab=reply')).toBe(
+        '/ko/blog/some-post?tab=reply',
+      );
+    });
+
+    it('비어있거나 없는 값은 null을 반환해야 합니다', () => {
+      expect(sanitizeRedirectUri(undefined)).toBeNull();
+      expect(sanitizeRedirectUri(null)).toBeNull();
+      expect(sanitizeRedirectUri('')).toBeNull();
+    });
+
+    it('외부 URL과 프로토콜 상대 URL은 차단해야 합니다 (open redirect 방지)', () => {
+      expect(sanitizeRedirectUri('https://evil.com')).toBeNull();
+      expect(sanitizeRedirectUri('//evil.com')).toBeNull();
+      // no-script-url 룰 회피를 위해 동적으로 조립 (실제 검증 대상은 스킴 자체)
+      expect(sanitizeRedirectUri(`javascript${':'}alert(1)`)).toBeNull();
+    });
+
+    it('로그인 페이지 자신으로의 복귀는 제외해야 합니다', () => {
+      expect(sanitizeRedirectUri('/ko/auth/login')).toBeNull();
+      expect(sanitizeRedirectUri('/auth/login')).toBeNull();
+    });
+  });
+
+  describe('rememberLoginRedirect', () => {
+    it('유효한 경로면 redirect_uri 쿠키를 설정해야 합니다', () => {
+      rememberLoginRedirect('/ko/menu');
+      expect(Cookies.set).toHaveBeenCalledWith('redirect_uri', '/ko/menu');
+    });
+
+    it('유효하지 않은 경로면 쿠키를 설정하지 않아야 합니다', () => {
+      rememberLoginRedirect('https://evil.com');
+      rememberLoginRedirect(null);
+      expect(Cookies.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getLoginRedirect', () => {
+    it('쿠키에 저장된 유효한 경로를 반환해야 합니다', () => {
+      mockedCookies.get.mockReturnValue('/ko/menu' as unknown as { [key: string]: string });
+      expect(getLoginRedirect()).toBe('/ko/menu');
+    });
+
+    it('쿠키가 없거나 유효하지 않으면 null을 반환해야 합니다', () => {
+      mockedCookies.get.mockReturnValue(undefined as unknown as { [key: string]: string });
+      expect(getLoginRedirect()).toBeNull();
+
+      mockedCookies.get.mockReturnValue('//evil.com' as unknown as { [key: string]: string });
+      expect(getLoginRedirect()).toBeNull();
+    });
+  });
+
+  describe('clearLoginRedirect', () => {
+    it('redirect_uri 쿠키를 제거해야 합니다', () => {
+      clearLoginRedirect();
+      expect(Cookies.remove).toHaveBeenCalledWith('redirect_uri');
+    });
+  });
+
+  describe('buildLoginUrl', () => {
+    it('복귀 경로를 인코딩해 쿼리로 담은 로그인 URL을 만들어야 합니다', () => {
+      expect(buildLoginUrl('/ko/auth/login', '/ko/shortener/me')).toBe(
+        '/ko/auth/login?redirect_uri=%2Fko%2Fshortener%2Fme',
+      );
+    });
+  });
+});

--- a/src/utils/loginRedirect.ts
+++ b/src/utils/loginRedirect.ts
@@ -1,0 +1,43 @@
+import Cookies from 'js-cookie';
+
+/**
+ * 로그인 후 복귀 경로(redirect_uri) 기록/조회 공통 헬퍼.
+ *
+ * 로그인 페이지는 OAuth 왕복(구글 → /auth/login#...) 과정에서 쿼리 파라미터가 유실되므로
+ * 복귀 경로를 쿠키에 보관한다. 로그인으로 보내는 모든 진입점은 이 헬퍼로 경로를 기록해야
+ * 로그인 완료 후 이전 페이지로 복귀할 수 있다.
+ */
+const REDIRECT_URI_COOKIE = 'redirect_uri';
+
+/**
+ * 내부 경로만 허용해 open redirect를 방지한다.
+ * - 절대 경로(`/...`)만 허용, 프로토콜 상대 URL(`//host`) 차단
+ * - 로그인 페이지 자신으로의 복귀는 무의미하므로 제외
+ */
+export function sanitizeRedirectUri(uri: string | undefined | null): string | null {
+  if (!uri) return null;
+  if (!uri.startsWith('/') || uri.startsWith('//')) return null;
+  if (uri.includes('/auth/login')) return null;
+  return uri;
+}
+
+/** 로그인 후 복귀할 경로를 쿠키에 기록한다. 유효하지 않은 경로면 무시. */
+export function rememberLoginRedirect(path: string | undefined | null): void {
+  const sanitized = sanitizeRedirectUri(path);
+  if (sanitized) Cookies.set(REDIRECT_URI_COOKIE, sanitized);
+}
+
+/** 기록된 복귀 경로를 읽는다. 없거나 유효하지 않으면 null. */
+export function getLoginRedirect(): string | null {
+  return sanitizeRedirectUri(Cookies.get(REDIRECT_URI_COOKIE));
+}
+
+/** 기록된 복귀 경로를 제거한다. */
+export function clearLoginRedirect(): void {
+  Cookies.remove(REDIRECT_URI_COOKIE);
+}
+
+/** 복귀 경로를 쿼리로 담은 로그인 페이지 URL을 만든다. (서버 컴포넌트/링크용) */
+export function buildLoginUrl(loginPath: string, redirectUri: string): string {
+  return `${loginPath}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+}


### PR DESCRIPTION
## 문제

서비스 이용 중 로그인 페이지로 이동하면 이전 페이지를 기록해두었다가 로그인 완료 시 복귀해야 하는데, 항상 홈으로 이동함.

## 원인

로그인 복귀는 `redirect_uri` **쿠키** 기반인데, 로그인으로 보내는 진입점 7곳 중 2곳(메뉴 UserInfoCard, axios 401 인터셉터)만 쿠키를 기록하고 있었음.

| 진입점 | 기록 여부 (수정 전) |
|---|---|
| 메뉴 UserInfoCard | ✅ |
| axios 401 인터셉터 | ✅ |
| `shortener/me` 인증 가드 | ❌ `?redirect_uri=` 쿼리로 전달하지만 로그인 페이지가 쿼리를 읽지 않음 |
| 블로그 댓글 (Form/Item) | ❌ `push('/auth/login')`만 |
| 카피킬러 SponsorGate | ❌ 단순 링크 |
| CommandPalette | ❌ 단순 이동 |
| `getTokenServer` (admin) | ❌ `redirect('/auth/login')`만 |

→ 쿠키가 없어 `redirectUri || '/'` 폴백으로 홈 이동.

## 수정

- **`src/utils/loginRedirect.ts` 신설** — 기록/조회/제거/URL생성 공통 헬퍼. 내부 절대 경로만 허용해 open redirect 방지 (`//evil.com`, 외부 URL, `javascript:` 스킴, 로그인 페이지 자신 차단)
- **로그인 페이지** — 마운트 시 `?redirect_uri=` 쿼리를 쿠키로 영속화 (OAuth 왕복 후 쿼리 유실 대응), 복귀 시 sanitize된 값 사용
- **누락 진입점 5곳에 기록 추가** — 블로그 댓글 폼/아이템, 카피킬러 SponsorGate, CommandPalette, `getTokenServer`(admin)
- **기존 기록 지점 2곳도 헬퍼로 통일** — UserInfoCard, axios 인터셉터

## 검증

- `tsc --noEmit` 통과
- ESLint 통과
- Vitest 전체 221개 통과 (신규 `loginRedirect` 테스트 10개 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)