### PR TITLE
fix: 보안 취약점 의존성 업데이트 (axios·basic-ftp·form-data 등)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "author": "DOHYUK YOU <okdohyuk@gmail.com>",
   "packageManager": "yarn@4.5.0",
   "resolutions": {
-    "@rushstack/eslint-patch": "^1.16.1"
+    "@rushstack/eslint-patch": "^1.16.1",
+    "form-data": "^4.0.6",
+    "flatted": "^3.4.2",
+    "basic-ftp": "^5.3.1",
+    "shell-quote": "^1.8.4",
+    "lodash": "^4.18.1"
   },
   "scripts": {
     "generate-api": "node scripts/generateClientApi.js",
@@ -42,7 +47,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",
     "accept-language": "^3.0.20",
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "bson": "^7.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -53,7 +58,7 @@
     "i18next": "~25.0.2",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-resources-to-backend": "^1.2.1",
-    "js-cookie": "~3.0.7",
+    "js-cookie": "~3.0.8",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.18.1",
     "lucide-react": "^0.537.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6979,14 +6979,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.0":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
+"axios@npm:1.18.0":
+  version: 1.18.0
+  resolution: "axios@npm:1.18.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
+  checksum: 10c0/f88aae13fd9dd395dea3053c7299178fee62f436f20424a1d6d79ec11ffb7656ba664b4630defbadab2c387b6ea07e29afb9f28b26d8e0e49d45be766983290d
   languageName: node
   linkType: hard
 
@@ -7203,10 +7204,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.3.0
-  resolution: "basic-ftp@npm:5.3.0"
-  checksum: 10c0/307ebc0635d06e671729d348e45e6eaec5f926713f93de535b268e17ae675942cd6903a84196cece948b54e04b24591431be3df79b2824551a0d5ed150555fb2
+"basic-ftp@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10c0/03511b488cd292abfa82a8c0ea3b9573b40d12d2f1518d6f41a9461b012b3376d3e6d50679b38d9b2b4f48fd6e8e0418ac196312ee7e2da13cb801169940d1c3
   languageName: node
   linkType: hard
 
@@ -9899,10 +9900,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
+"flatted@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -9958,16 +9959,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+"form-data@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -10473,6 +10474,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -11417,10 +11427,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:~3.0.7":
-  version: 3.0.7
-  resolution: "js-cookie@npm:3.0.7"
-  checksum: 10c0/c921c43014e98bb94a1765663a1a10d693048d61444e374c1ecf459eba92320381f9c406e724df9aa44e819c4b606e6a7240f2abe2d5c54ad1e73a3002b191c2
+"js-cookie@npm:~3.0.8":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 
@@ -11958,13 +11968,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
-  languageName: node
-  linkType: hard
-
 "lodash@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
@@ -12257,7 +12260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.31":
+"mime-types@npm:^2.1.31, mime-types@npm:^2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -12956,7 +12959,7 @@ __metadata:
     "@vercel/speed-insights": "npm:^1.2.0"
     "@vitest/coverage-v8": "npm:^4.1.6"
     accept-language: "npm:^3.0.20"
-    axios: "npm:1.16.0"
+    axios: "npm:1.18.0"
     bson: "npm:^7.2.0"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
@@ -12981,7 +12984,7 @@ __metadata:
     i18next: "npm:~25.0.2"
     i18next-browser-languagedetector: "npm:^8.2.1"
     i18next-resources-to-backend: "npm:^1.2.1"
-    js-cookie: "npm:~3.0.7"
+    js-cookie: "npm:~3.0.8"
     jsdom: "npm:^29.1.1"
     jwt-decode: "npm:^4.0.0"
     lighthouse: "npm:^13.0.1"
@@ -14987,10 +14990,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 개요
`yarn npm audit`에서 보고된 보안 취약점 중 **핵심 6개 + Critical 1개**를 해결합니다. 빌드/CI가 yarn berry 기반이므로 `yarn.lock`만 갱신했습니다(`package-lock.json`은 방치된 stale 파일이라 미변경).

## 변경 사항

### 직접 의존성 업데이트
| 패키지 | 변경 | 취약점 |
|--------|------|--------|
| `axios` | 1.16.0 → **1.18.0** | SSRF / 프로토타입 오염 |
| `js-cookie` | ~3.0.7 → **~3.0.8** | 쿠키 속성 주입 |

### `resolutions`로 transitive 취약점 강제 패치
| 패키지 | → 버전 | 등급 | 출처 | 비고 |
|--------|--------|------|------|------|
| `form-data` | ^4.0.6 | High | axios 하위 | CRLF injection — axios 1.18.0도 `^4.0.5`를 요구하여 강제 필요 |
| `basic-ftp` | ^5.3.1 | High | get-uri ← pac-proxy-agent | DoS — 6.x는 `get-uri ^5.0.2`와 비호환이라 5.3.1 채택 |
| `flatted` | ^3.4.2 | High | flat-cache (eslint) | 프로토타입 오염 / 무한 재귀 DoS |
| `lodash` | ^4.18.1 | High | html-webpack-plugin (storybook) | 코드 주입 / 프로토타입 오염 |
| `shell-quote` | ^1.8.4 | **Critical** | concurrently (openapi-generator-cli) | quote() 개행 미이스케이프 |

## 검증
- ✅ `tsc --noEmit` 타입 에러 없음
- ✅ `vitest` 테스트 221개 전부 통과
- ✅ `yarn npm audit` — 대상 6개 + shell-quote 모두 해소 확인

## 남은 작업 (후속 PR 권장)
전체 audit에는 deep transitive 취약점이 다수 남아있으나, next/sentry/storybook/jsdom 핵심 의존성 하위라 빌드 회귀 위험이 있어 이번 범위에서 제외했습니다: `minimatch`·`undici`·`picomatch`·`rollup`·`postcss`·`esbuild`·`brace-expansion`·`ajv`·`js-yaml` 등. 별도 검증과 함께 단계적으로 처리하는 것을 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)