### PR TITLE
feat: Solve(문제풀이) 서비스 추가

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,5 +10,6 @@ yarn run generate-api -- --name=BlogReply
 yarn run generate-api -- --name=Session
 yarn run generate-api -- --name=ShortUrl
 yarn run generate-api -- --name=Copykiller
+yarn run generate-api -- --name=Solve
 yarn run build
 yarn run postbuild

--- a/src/app/[lng]/(mobile)/menu/components/MenuDirectoryClient.tsx
+++ b/src/app/[lng]/(mobile)/menu/components/MenuDirectoryClient.tsx
@@ -102,6 +102,10 @@ export default function MenuDirectoryClient({ lng }: MenuDirectoryClientProps) {
         title: t('group.lifestyle.title'),
         description: t('group.lifestyle.description'),
       },
+      learning: {
+        title: t('group.learning.title'),
+        description: t('group.learning.description'),
+      },
       external: {
         title: t('group.external.title'),
         description: t('group.external.description'),

--- a/src/app/[lng]/(mobile)/solve/SolveSubjectsClient.tsx
+++ b/src/app/[lng]/(mobile)/solve/SolveSubjectsClient.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { ListChecks } from 'lucide-react';
+import Skeleton from '@components/basic/Skeleton';
+import GoogleAd from '@components/google/GoogleAd';
+import { useSubjects, useSolveProgress } from '@queries/useSolveQueries';
+import UserTokenUtil from '@utils/userTokenUtil';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import { SubjectCard } from './components';
+
+type SolveSubjectsClientProps = {
+  lng: Language;
+};
+
+export default function SolveSubjectsClient({ lng }: SolveSubjectsClientProps) {
+  const { t } = useTranslation(lng, 'solve');
+  const router = useRouter();
+
+  // 진행률(/solve/progress)은 로그인 필수다. 비회원이 호출하면 401 → axios 응답 인터셉터가
+  // refresh 시도 실패 → logoutAndLogin 으로 로그인 리다이렉트되어 "목록 열람"이 깨진다.
+  // 따라서 로그인 시에만 useSolveProgress 를 활성화한다. SSR/하이드레이션 단계엔 쿠키를 읽지
+  // 않아 항상 false → enabled=false(idle). 마운트 후 user_info 쿠키로 판정한다.
+  const [isLoggedIn, setIsLoggedIn] = React.useState(false);
+  React.useEffect(() => {
+    setIsLoggedIn(!!UserTokenUtil.getUserInfo());
+  }, []);
+
+  const { data: subjects, isLoading, isError } = useSubjects();
+  const { data: progress } = useSolveProgress(isLoggedIn);
+
+  // subjectSlug → 진행률(서버 derived). 없으면 0 으로 표시.
+  const progressBySlug = React.useMemo(() => {
+    const map = new Map<string, { answered: number; correct: number; total: number }>();
+    (progress ?? []).forEach((p) => {
+      map.set(p.subjectSlug, { answered: p.answered, correct: p.correct, total: p.total });
+    });
+    return map;
+  }, [progress]);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Skeleton key={i} className="h-32 rounded-2xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-sm text-danger-1">
+        {t('subjects.error')}
+      </p>
+    );
+  }
+
+  const items = subjects ?? [];
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-sm text-fg-4">
+        {t('subjects.empty')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {items.map((subject) => {
+          const prog = progressBySlug.get(subject.slug);
+          const answered = prog?.answered ?? 0;
+          const completed = subject.totalQuestions > 0 && answered >= subject.totalQuestions;
+          return (
+            <SubjectCard
+              key={subject.slug}
+              title={subject.title}
+              totalQuestions={subject.totalQuestions}
+              unitCount={subject.units.length}
+              answeredCount={answered}
+              completed={completed}
+              color={subject.color}
+              onOpen={() => router.push(`/${lng}/solve/${subject.slug}`)}
+            />
+          );
+        })}
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => router.push(`/${lng}/solve/me`)}
+          className="inline-flex items-center gap-1 text-xs font-semibold text-fg-4 hover:text-point-fg"
+        >
+          <ListChecks className="h-4 w-4" />
+          {t('subjects.myAttempts')}
+        </button>
+      </div>
+
+      {/* in-content 광고: 과목 그리드 아래. 보기/입력과 인접하지 않아 정책상 안전. */}
+      <GoogleAd className="mt-2 w-full min-h-16" slotId="6290029027" />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/[slug]/SolveUnitsClient.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/SolveUnitsClient.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { ChevronRight, ArrowLeft } from 'lucide-react';
+import Skeleton from '@components/basic/Skeleton';
+import { Text } from '@components/basic/Text';
+import GoogleAd from '@components/google/GoogleAd';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+import {
+  SERVICE_PANEL_SOFT,
+  SERVICE_CARD_INTERACTIVE,
+} from '@components/complex/Service/interactiveStyles';
+import { useSubjectDetail } from '@queries/useSolveQueries';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+
+type SolveUnitsClientProps = {
+  lng: Language;
+  slug: string;
+};
+
+export default function SolveUnitsClient({ lng, slug }: SolveUnitsClientProps) {
+  const { t } = useTranslation(lng, 'solve');
+  const router = useRouter();
+
+  const { data: subject, isLoading, isError } = useSubjectDetail(slug);
+
+  // 전체 풀기: unitId 없이 quiz 진입. 단원별: unitId(=unitKey) 쿼리.
+  const startQuiz = (unitId?: string) => {
+    const base = `/${lng}/solve/${slug}/quiz`;
+    router.push(unitId ? `${base}?unitId=${encodeURIComponent(unitId)}` : base);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-28 rounded-3xl" />
+        <Skeleton className="h-16 rounded-2xl" />
+        <Skeleton className="h-16 rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (isError || !subject) {
+    return (
+      <div className="space-y-3">
+        <button
+          type="button"
+          onClick={() => router.push(`/${lng}/solve`)}
+          className="inline-flex items-center gap-1 text-xs font-semibold text-fg-4 hover:text-point-fg"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t('subject.back')}
+        </button>
+        <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-sm text-danger-1">
+          {isError ? t('subject.error') : t('subject.notFound')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => router.push(`/${lng}/solve`)}
+        className="inline-flex items-center gap-1 text-xs font-semibold text-fg-4 hover:text-point-fg"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t('subject.back')}
+      </button>
+
+      <ServicePageHeader title={subject.title} badge={t('subject.selectUnit')} />
+
+      {/* 전체 풀기 */}
+      <button
+        type="button"
+        onClick={() => startQuiz()}
+        className={cn(
+          SERVICE_PANEL_SOFT,
+          SERVICE_CARD_INTERACTIVE,
+          'flex w-full items-center justify-between gap-3 p-4 text-left',
+          'border-point-1 bg-point-soft',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-point-1 focus-visible:ring-offset-2 focus-visible:ring-offset-basic-0',
+        )}
+      >
+        <div className="min-w-0">
+          <Text variant="t3" color="basic-1" className="leading-tight">
+            {t('subject.solveAll')}
+          </Text>
+          <Text variant="d3" color="basic-5" className="mt-0.5 block">
+            {t('subject.solveAllDesc')}
+          </Text>
+        </div>
+        <ChevronRight className="h-5 w-5 shrink-0 text-point-fg" aria-hidden="true" />
+      </button>
+
+      {/* 단원별 풀기 */}
+      <div className="space-y-2">
+        {subject.units.map((unit) => (
+          <button
+            key={unit.unitKey}
+            type="button"
+            onClick={() => startQuiz(unit.unitKey)}
+            className={cn(
+              SERVICE_PANEL_SOFT,
+              SERVICE_CARD_INTERACTIVE,
+              'flex w-full items-center justify-between gap-3 p-4 text-left',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-point-1 focus-visible:ring-offset-2 focus-visible:ring-offset-basic-0',
+            )}
+          >
+            <div className="min-w-0">
+              <Text variant="d2" color="basic-1" className="break-keep leading-snug">
+                {unit.name}
+              </Text>
+              <Text variant="c1" color="basic-5" className="mt-0.5 block tabular-nums">
+                {t('subject.unitQuestionCount', { count: unit.questionCount })}
+              </Text>
+            </div>
+            <ChevronRight className="h-5 w-5 shrink-0 text-fg-5" aria-hidden="true" />
+          </button>
+        ))}
+      </div>
+
+      {/* in-content 광고: 단원 목록 아래. 풀이 시작 버튼과 분리된 영역이라 정책상 안전. */}
+      <GoogleAd className="mt-4 w-full min-h-16" slotId="6290029027" />
+    </>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/[slug]/page.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { getTranslations } from '~/app/i18n';
+import { Language } from '~/app/i18n/settings';
+import SolveUnitsClient from './SolveUnitsClient';
+
+type SolveSubjectParams = {
+  params: Promise<{ lng: string; slug: string }>;
+};
+
+export default async function SolveSubjectPage({ params }: SolveSubjectParams) {
+  const { lng, slug } = await params;
+  const language = lng as Language;
+  // 헤더(과목명)는 클라이언트가 useSubjectDetail 응답으로 채운다(과목 제목이 한국어 DB 원문).
+  await getTranslations(language, 'solve');
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4 px-2 pb-24 pt-3 sm:px-3 md:px-4">
+      <SolveUnitsClient lng={language} slug={slug} />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/[slug]/quiz/QuizClient.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/quiz/QuizClient.tsx
@@ -1,0 +1,494 @@
+/* eslint-disable react/require-default-props */
+
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2, ArrowLeft } from 'lucide-react';
+import { Text } from '@components/basic/Text';
+import { Button } from '@components/basic/Button';
+import Skeleton from '@components/basic/Skeleton';
+import { CodeBlock } from '@components/basic/CodeBlock';
+import { ProgressBar } from '@components/basic/ProgressBar';
+import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { cn } from '@utils/cn';
+import logger from '@utils/logger';
+import {
+  useStartAttempt,
+  useResumeAttempt,
+  useSubmitAnswer,
+  useFinishAttempt,
+  useQuestions,
+  SOLVE_QUESTIONS_PAGE_SIZE,
+} from '@queries/useSolveQueries';
+import type {
+  SolveAttemptMode,
+  SolveQuestion,
+  SolveQuizResult,
+  SolveSubmissionRequest,
+  SolveSubmissionResult,
+} from '@api/Solve';
+import { SolveQuestionType } from '@api/Solve';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+import {
+  ChoiceButton,
+  ShortAnswerInput,
+  ClozeBlock,
+  ExplanationPanel,
+  type ChoiceIndex,
+  type ClozeBlankValue,
+} from '../../components';
+import SolveResultView from './SolveResultView';
+
+type QuizClientProps = {
+  lng: Language;
+  slug: string;
+  unitId?: string;
+  mode: SolveAttemptMode;
+  sourceAttemptId?: number;
+};
+
+// 채점 후 MCQ 선택지의 시각 상태를 서버 결과로 계산(컴포넌트는 정답을 모름).
+function choiceState(
+  idx: ChoiceIndex,
+  selected: number | undefined,
+  result: SolveSubmissionResult | undefined,
+): 'default' | 'selected' | 'correct' | 'wrong' | 'dimmed' {
+  if (!result) return selected === idx ? 'selected' : 'default';
+  if (idx === result.correctChoice) return 'correct';
+  if (idx === selected) return 'wrong';
+  return 'dimmed';
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-col items-center justify-center gap-3 py-16">{children}</div>;
+}
+
+function BackButton({
+  lng,
+  slug,
+  label,
+  router,
+}: {
+  lng: Language;
+  slug: string;
+  label: string;
+  router: ReturnType<typeof useRouter>;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => router.push(`/${lng}/solve/${slug}`)}
+      className="inline-flex items-center gap-1 text-xs font-semibold text-fg-4 hover:text-point-fg"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      {label}
+    </button>
+  );
+}
+
+export default function QuizClient({ lng, slug, unitId, mode, sourceAttemptId }: QuizClientProps) {
+  const { t } = useTranslation(lng, 'solve');
+  const router = useRouter();
+
+  // 1) attempt 시작/재개 — 서버가 in_progress 를 재사용(멱등)하거나 새로 생성한다.
+  //    POST 지만 멱등이라 useQuery 로 모델링한다. (mutation 을 useEffect 에서 호출하면
+  //    StrictMode 가 클라이언트 네비게이션 시 마운트 effect 를 setup→cleanup→setup 으로
+  //    2회 호출하면서 in-flight mutation 이 고아가 돼 observer 가 영구 pending 이 되고,
+  //    attempt 가 안 잡혀 "준비 중"에서 멈추는 버그가 있었다. 전체 새로고침=hydration 은
+  //    effect 1회라 무사했지만 목록→문제 SPA 이동은 깨졌다. query 는 StrictMode/동시성에
+  //    안전하며 결과를 data/error 로 반응형 노출한다.)
+  const startAttempt = useStartAttempt({
+    subjectSlug: slug,
+    unitId: unitId ?? null,
+    mode,
+    sourceAttemptId: sourceAttemptId ?? null,
+  });
+
+  const attempt = startAttempt.data ?? null;
+  const attemptId = attempt?.id ?? null;
+  // review 모드 오답 0개면 409(SOLVE_REVIEW_NO_WRONG) → "복습할 문제 없음". 그 외는 일반 에러.
+  const startStatus = (startAttempt.error as { response?: { status?: number } } | null)?.response
+    ?.status;
+  const noReview = mode === 'review' && startStatus === 409;
+  const startError = startAttempt.isError && !noReview;
+
+  // 2) attempt detail — 이전 제출 결과 복원 + review scope 동결 id.
+  const { data: detail } = useResumeAttempt(attemptId);
+
+  // 3) 문항 로드. full=단원/과목 페이지네이션. review=scope 도출.
+  //    review scope 는 detail.scopeQuestionIds 로 동결. full 은 unitId(=unitKey) 범위.
+  const scopeIds = detail?.scopeQuestionIds ?? undefined;
+  const isReview = mode === 'review';
+
+  // 점진 페이지 로딩: 현재 페이지까지 누적. (review 는 scope 다 찾을 때까지, full 은 현재 위치 도달까지)
+  const [page, setPage] = React.useState(0);
+  const {
+    data: questionPage,
+    isLoading: questionsLoading,
+    isError: questionsError,
+  } = useQuestions(slug, unitId, page, SOLVE_QUESTIONS_PAGE_SIZE, attemptId != null);
+
+  const [loadedQuestions, setLoadedQuestions] = React.useState<SolveQuestion[]>([]);
+  const [allPagesLoaded, setAllPagesLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!questionPage) return;
+    setLoadedQuestions((prev) => {
+      const seen = new Set(prev.map((q) => q.id));
+      const merged = [...prev];
+      questionPage.results.forEach((q) => {
+        if (!seen.has(q.id)) merged.push(q);
+      });
+      return merged;
+    });
+    // 종료 조건 우선순위: isLast(서버가 명시) → 빈 페이지(서버가 더 줄 게 없음).
+    // 빈 페이지(results.length === 0 & isLast=false)는 실 백엔드엔 없는 비정상 응답이지만,
+    // 이를 종료로 처리하지 않으면 progressive 로딩이 더 늘지 않는 length 로 setPage 를
+    // 무한 증가시켜 폭주한다. 방어적으로 즉시 로딩 종료.
+    if (questionPage.isLast || questionPage.results.length === 0) {
+      setAllPagesLoaded(true);
+    } else if (isReview) {
+      // review: scope 전부 확보 전까지 다음 페이지 계속 로드.
+      setPage((p) => p + 1);
+    }
+  }, [questionPage, isReview]);
+
+  // review 면 scope 순서대로, full 이면 로드 순서대로 문항 배열 확정.
+  const questions = React.useMemo<SolveQuestion[]>(() => {
+    if (isReview && scopeIds && scopeIds.length > 0) {
+      const byId = new Map(loadedQuestions.map((q) => [q.id, q]));
+      return scopeIds.map((id) => byId.get(id)).filter((q): q is SolveQuestion => !!q);
+    }
+    return loadedQuestions;
+  }, [isReview, scopeIds, loadedQuestions]);
+
+  // 4) 진행 인덱스 — 재개 시 attempt.currentIndex 로 복원.
+  const [index, setIndex] = React.useState(0);
+  const restoredRef = React.useRef(false);
+  React.useEffect(() => {
+    if (restoredRef.current || !attempt) return;
+    restoredRef.current = true;
+    setIndex(Math.max(0, attempt.currentIndex));
+  }, [attempt]);
+
+  // 이전 제출 결과 맵(questionId → result) 복원.
+  const submittedById = React.useMemo(() => {
+    const map = new Map<number, SolveSubmissionResult>();
+    (detail?.submissions ?? []).forEach((s) => map.set(s.questionId, s));
+    return map;
+  }, [detail]);
+
+  // 시도 범위 전체 문항 수(신뢰원). attempt.total 우선, 없으면 페이지 응답 count, 최후 로드 수.
+  // review 모드는 attempt.total 이 곧 scope 크기이며 questions.length 와 일치한다.
+  const total = attempt?.total ?? questionPage?.count ?? questions.length;
+
+  // full 모드 progressive 로딩: 현재 인덱스가 로드된 페이지의 끝(마지막 문항)에 도달하면
+  // 다음 페이지를 미리 가져와 questions 배열에 누적한다. `length`(벗어남)가 아니라
+  // `length - 1`(마지막 로드 문항)을 임계로 써서, 마지막 문항에서 "다음"을 누르기 전에
+  // 다음 페이지가 채워지도록 한 칸 prefetch 한다(pilgi 1,786 같은 대량 과목 끊김 방지).
+  // 상한 가드: 로드 수가 total 에 도달하면 더 요청하지 않는다(setPage 무한 증가 방지).
+  // 정상 데이터에서는 length 가 index+1 을 넘는 순간 자연 종료되므로 동작은 동일하고,
+  // 비정상(빈/부족 페이지) 응답에서만 추가로 멈춘다.
+  React.useEffect(() => {
+    if (isReview || allPagesLoaded) return;
+    if (
+      loadedQuestions.length > 0 &&
+      loadedQuestions.length < total &&
+      index >= loadedQuestions.length - 1 &&
+      questionPage &&
+      !questionPage.isLast
+    ) {
+      setPage((p) => p + 1);
+    }
+  }, [index, loadedQuestions.length, allPagesLoaded, questionPage, isReview, total]);
+
+  const current = questions[index];
+  const currentResult = current ? submittedById.get(current.id) : undefined;
+
+  // 방금 제출한 결과(낙관적 표시). 복원 결과와 합쳐 표시.
+  const [justResult, setJustResult] = React.useState<SolveSubmissionResult | null>(null);
+  const [justSubmitted, setJustSubmitted] = React.useState<{
+    choice?: number;
+    text?: string;
+    blanks?: ClozeBlankValue[];
+  } | null>(null);
+  const displayResult = justResult ?? currentResult;
+
+  // 5) 제출
+  const submitAnswer = useSubmitAnswer(attemptId ?? 0);
+  const submit = (payload: Pick<SolveSubmissionRequest, 'choice' | 'text' | 'blanks'>) => {
+    if (!current || attemptId == null || displayResult) return;
+    setJustSubmitted({
+      choice: payload.choice ?? undefined,
+      text: payload.text ?? undefined,
+      blanks: (payload.blanks ?? undefined)?.map((b) => ({ blankId: b.blankId, value: b.value })),
+    });
+    submitAnswer.mutate(
+      { questionId: current.id, index, ...payload },
+      {
+        onSuccess: (data) => setJustResult(data),
+        onError: (err) => {
+          logger.error('solve 제출 실패', err);
+          setJustSubmitted(null);
+        },
+      },
+    );
+  };
+
+  const goNext = () => {
+    setJustResult(null);
+    setJustSubmitted(null);
+    setIndex((i) => i + 1);
+  };
+
+  // 6) finish + 결과
+  const finishAttempt = useFinishAttempt(attemptId ?? 0);
+  const [result, setResult] = React.useState<SolveQuizResult | null>(null);
+  const finish = () => {
+    if (attemptId == null) return;
+    finishAttempt.mutate(undefined, {
+      onSuccess: (data) => setResult(data),
+      onError: (err) => logger.error('solve finish 실패', err),
+    });
+  };
+
+  // "결과 보기" 노출/마지막 판정은 로드된 문항 수가 아니라 시도 전체 문항 수(total) 기준.
+  // full 모드는 페이지네이션으로 일부만 로드돼 있으므로 questions.length 로 판정하면
+  // 페이지 경계(예: pilgi index 99/total 1,786)에서 조기 종료가 발생한다.
+  // 방어: 모든 페이지를 다 로드했는데도 total 이 실제 로드 수보다 큰 비정상 케이스에서는
+  //       도달 불가능한 끝을 기다리지 않도록 실제 로드 수로 클램프한다.
+  const effectiveTotal = allPagesLoaded ? Math.min(total, questions.length) : total;
+  const isLast = index >= effectiveTotal - 1;
+  const graded = !!displayResult;
+
+  // 키보드: 1~4(MCQ 선택+제출), → (다음/결과), ← (이전)
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!current || result) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      const typing = tag === 'INPUT' || tag === 'TEXTAREA';
+      if (current.type === SolveQuestionType.Mcq && !graded && !typing) {
+        const n = Number(e.key);
+        if (n >= 1 && n <= 4 && current.choices && n <= current.choices.length) {
+          e.preventDefault();
+          submit({ choice: n });
+          return;
+        }
+      }
+      if (e.key === 'ArrowRight' && graded) {
+        e.preventDefault();
+        if (isLast) finish();
+        else goNext();
+      }
+      if (e.key === 'ArrowLeft' && index > 0 && !typing) {
+        e.preventDefault();
+        setJustResult(null);
+        setJustSubmitted(null);
+        setIndex((i) => Math.max(0, i - 1));
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // 핸들러는 현재 문항/채점/위치 변화 시 재바인딩(submit/finish/goNext 는 매 렌더 갱신).
+  }, [current, graded, isLast, index, result]);
+
+  // --- 렌더 분기 ---
+
+  if (noReview) {
+    return (
+      <Centered>
+        <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-center text-sm text-fg-3">
+          {t('quiz.noReview')}
+        </p>
+        <BackButton lng={lng} slug={slug} label={t('subject.back')} router={router} />
+      </Centered>
+    );
+  }
+
+  if (startError) {
+    return (
+      <Centered>
+        <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-center text-sm text-danger-1">
+          {t('quiz.error')}
+        </p>
+        <BackButton lng={lng} slug={slug} label={t('subject.back')} router={router} />
+      </Centered>
+    );
+  }
+
+  // 결과 화면
+  if (result && attemptId != null) {
+    return <SolveResultView lng={lng} slug={slug} result={result} attemptId={attemptId} />;
+  }
+
+  // 준비/로딩
+  if (attemptId == null || (questionsLoading && loadedQuestions.length === 0)) {
+    return (
+      <Centered>
+        <Loader2 className="h-6 w-6 animate-spin text-fg-4" />
+        <Text variant="d3" color="basic-5">
+          {t('quiz.preparing')}
+        </Text>
+      </Centered>
+    );
+  }
+
+  if (questionsError) {
+    return (
+      <Centered>
+        <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-center text-sm text-danger-1">
+          {t('quiz.error')}
+        </p>
+        <BackButton lng={lng} slug={slug} label={t('subject.back')} router={router} />
+      </Centered>
+    );
+  }
+
+  if (questions.length === 0 && allPagesLoaded) {
+    return (
+      <Centered>
+        <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-center text-sm text-fg-3">
+          {t('quiz.empty')}
+        </p>
+        <BackButton lng={lng} slug={slug} label={t('subject.back')} router={router} />
+      </Centered>
+    );
+  }
+
+  if (!current) {
+    // 현재 인덱스 문항이 아직 로드 전.
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-40 rounded-2xl" />
+        <Skeleton className="h-14 rounded-2xl" />
+      </div>
+    );
+  }
+
+  // 복원된 제출값(이전 제출 표시용). 서버 SolveSubmissionResult 는 사용자가 고른 choice 를
+  // 포함하지 않으므로, 방금 제출(justSubmitted)이 있을 때만 사용자가 고른 번호를 강조한다.
+  const restoredChoice = justSubmitted?.choice;
+  const submittedTextValue = justSubmitted?.text;
+  const submittedBlankMap = (justSubmitted?.blanks ?? []).reduce<Record<string, string>>(
+    (acc, b) => {
+      acc[b.blankId] = b.value;
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* 상단: 진행률 + 그만두기 */}
+      <div className="flex items-center gap-3">
+        <ProgressBar
+          value={total > 0 ? index / total : 0}
+          label={t('quiz.questionLabel')}
+          className="flex-1"
+        />
+        <Text variant="c1" color="basic-5" className="shrink-0 font-semibold tabular-nums">
+          {t('quiz.progress', { current: index + 1, total })}
+        </Text>
+      </div>
+
+      {/* 문항 */}
+      <div className={cn(SERVICE_PANEL_SOFT, 'space-y-4 p-5')}>
+        {current.no != null && (
+          <Text variant="c1" color="basic-5" className="block font-semibold tabular-nums">
+            Q{current.no}
+          </Text>
+        )}
+        <Text
+          variant="d1"
+          color="basic-1"
+          className="block whitespace-pre-wrap break-keep font-semibold leading-relaxed"
+        >
+          {current.question}
+        </Text>
+
+        {current.code && current.type !== SolveQuestionType.Cloze && (
+          <CodeBlock code={current.code} language={current.codeLanguage ?? undefined} />
+        )}
+
+        {/* MCQ */}
+        {current.type === SolveQuestionType.Mcq && current.choices && (
+          <div className="space-y-2.5">
+            {current.choices.map((choice, i) => {
+              const idx = (i + 1) as ChoiceIndex;
+              const selected = restoredChoice;
+              return (
+                <ChoiceButton
+                  key={`${current.id}-${idx}`}
+                  index={idx}
+                  text={choice}
+                  state={choiceState(idx, selected, displayResult)}
+                  locked={graded}
+                  onSelect={(n) => submit({ choice: n })}
+                />
+              );
+            })}
+          </div>
+        )}
+
+        {/* 단답 */}
+        {current.type === SolveQuestionType.Short && (
+          <ShortAnswerInput
+            key={current.id}
+            graded={graded}
+            isCorrect={displayResult?.isCorrect}
+            submittedText={submittedTextValue}
+            correctText={displayResult?.correctText ?? undefined}
+            onSubmit={(value) => submit({ text: value })}
+          />
+        )}
+
+        {/* 코드 빈칸 */}
+        {current.type === SolveQuestionType.Cloze && current.clozeTemplate && (
+          <ClozeBlock
+            key={current.id}
+            clozeTemplate={current.clozeTemplate}
+            codeLanguage={current.codeLanguage ?? undefined}
+            graded={graded}
+            submittedMap={submittedBlankMap}
+            blankResults={displayResult?.blankResults ?? undefined}
+            onSubmit={(blanks) => submit({ blanks })}
+          />
+        )}
+      </div>
+
+      {/* 해설 + 다음 */}
+      {displayResult && (
+        <>
+          <ExplanationPanel
+            correct={displayResult.isCorrect}
+            explanation={displayResult.explanation}
+            slides={current.slides ?? undefined}
+            trapType={current.trapType ?? undefined}
+          />
+          <Button
+            type="button"
+            onClick={() => (isLast ? finish() : goNext())}
+            disabled={finishAttempt.isPending}
+            className="min-h-[48px] w-full rounded-xl"
+          >
+            {finishAttempt.isPending && <Loader2 className="h-5 w-5 animate-spin" />}
+            {!finishAttempt.isPending && (isLast ? t('quiz.finish') : t('quiz.next'))}
+          </Button>
+        </>
+      )}
+
+      <div className="flex justify-center">
+        <button
+          type="button"
+          onClick={() => router.push(`/${lng}/solve/${slug}`)}
+          className="inline-flex items-center gap-1 py-1 text-xs font-semibold text-fg-5 hover:text-point-fg"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {t('quiz.exit')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/[slug]/quiz/SolveResultView.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/quiz/SolveResultView.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { RotateCcw, ArrowLeft } from 'lucide-react';
+import { Text } from '@components/basic/Text';
+import { Button } from '@components/basic/Button';
+import GoogleAd from '@components/google/GoogleAd';
+import { ScoreRing } from '@components/basic/ScoreRing';
+import { SERVICE_PANEL_SOFT } from '@components/complex/Service/interactiveStyles';
+import { cn } from '@utils/cn';
+import type { SolveQuizResult } from '@api/Solve';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+
+type SolveResultViewProps = {
+  lng: Language;
+  slug: string;
+  result: SolveQuizResult;
+  /** 결과를 만든 시도 PK. 오답 재풀이(review) 진입에 sourceAttemptId 로 사용. */
+  attemptId: number;
+};
+
+export default function SolveResultView({ lng, slug, result, attemptId }: SolveResultViewProps) {
+  const { t } = useTranslation(lng, 'solve');
+  const router = useRouter();
+
+  const hasWrong = result.wrongQuestionIds.length > 0;
+  const percent = Math.round(result.ratio * 100);
+
+  const retryWrong = () => {
+    router.push(
+      `/${lng}/solve/${slug}/quiz?mode=review&sourceAttemptId=${encodeURIComponent(attemptId)}`,
+    );
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className={cn(SERVICE_PANEL_SOFT, 'flex flex-col items-center gap-3 px-5 py-8')}>
+        <Text variant="t3" color="basic-1">
+          {t('result.title')}
+        </Text>
+        <ScoreRing correct={result.correct} total={result.total} />
+        <Text variant="d2" color="basic-2" className="tabular-nums">
+          {t('result.correctOf', { correct: result.correct, total: result.total })}
+        </Text>
+        <Text variant="d3" color="basic-5" className="tabular-nums">
+          {t('result.ratio')} {percent}%
+        </Text>
+      </div>
+
+      {result.units.length > 0 && (
+        <div className="space-y-2">
+          <Text variant="d2" color="basic-2" className="font-semibold">
+            {t('result.byUnit')}
+          </Text>
+          <ul className="space-y-2">
+            {result.units.map((unit) => (
+              <li
+                key={unit.unitKey}
+                className="flex items-center justify-between gap-3 rounded-2xl border border-basic-3 bg-basic-0 px-4 py-3"
+              >
+                <Text variant="d3" color="basic-2" className="min-w-0 break-keep">
+                  {unit.unitName}
+                </Text>
+                <Text variant="d3" color="basic-1" className="shrink-0 font-semibold tabular-nums">
+                  {unit.correct} / {unit.total}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {hasWrong ? (
+          <Button type="button" onClick={retryWrong} className="min-h-[48px] rounded-xl">
+            <RotateCcw className="mr-2 h-4 w-4" />
+            {t('result.retryWrong')}
+          </Button>
+        ) : (
+          <p className="rounded-2xl border border-success-2 bg-success-4 px-4 py-3 text-center text-sm font-semibold text-success-1">
+            {t('result.noWrong')}
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={() => router.push(`/${lng}/solve`)}
+          className="inline-flex items-center justify-center gap-1 py-2 text-sm font-semibold text-fg-4 hover:text-point-fg"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t('result.backToSubjects')}
+        </button>
+      </div>
+
+      {/* in-content 광고: 결과 점수/액션 버튼 아래. 보기·입력과 분리돼 정책상 안전. */}
+      <GoogleAd className="mt-2 w-full min-h-16" slotId="6290029027" />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/[slug]/quiz/__tests__/QuizClient.boundary.test.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/quiz/__tests__/QuizClient.boundary.test.tsx
@@ -1,0 +1,316 @@
+/* eslint-disable react/require-default-props */
+
+/**
+ * QuizClient 다중 페이지 경계 회귀 테스트 (FE-1).
+ *
+ * full 모드는 문항을 페이지네이션(limit 100)으로 점진 로딩한다. "마지막 문항(isLast)"
+ * 판정과 "결과 보기" 노출은 *현재 로드된 문항 수*가 아니라 *시도 전체 문항 수(attempt.total)*
+ * 기준이어야 한다. 과거 회귀: pilgi(total 1,786) 1페이지(100문항)만 로드된 상태에서
+ * index 99 가 곧 "결과 보기"로 오판정 → 100번째에서 시도가 조기 종료됐다.
+ *
+ * 테스트 데이터는 현실적 pilgi 페이지 구조를 따른다:
+ *   - 총 1786문항 = page 0~16 각 100문항(isLast=false) + page 17 86문항(isLast=true).
+ *   - 어떤 mock 페이지도 results.length===0 & isLast=false 조합을 주지 않는다(무한루프 원인).
+ *
+ * 비동기 누적 로딩: progressive effect 가 page+1 을 요청하며 loadedQuestions 가 점진 누적되고
+ * 그때마다 리렌더가 발생한다. 따라서 동기 act+즉시 단언이 아니라 findBy / waitFor 로 누적
+ * 로딩·리렌더가 끝나길 기다린 뒤 단언한다.
+ *
+ * 검증:
+ *  - (a) total(1786) > 1페이지(100)면 index 99(100번째)에서 finish 가 아니라 next.
+ *  - (b) 페이지 끝(index 99)에 도달하면 다음 page(page+1)가 useQuestions 로 progressive 요청.
+ *  - (c) 전체를 끝까지 진행해 실제 마지막 인덱스(1785)에 도달했을 때만 finish.
+ *  - (d) 단일 페이지(total == 로드 수)에서 마지막 문항 finish / 비마지막 next 정상.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+
+import { SolveQuestionType } from '@api/Solve';
+
+import QuizClient from '../QuizClient';
+
+// --- i18n: 키 그대로 반환(버튼 텍스트로 next/finish 분기 검증) ---
+vi.mock('~/app/i18n/client', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${key}:${JSON.stringify(vars)}` : key,
+    i18n: { language: 'ko' },
+  }),
+}));
+
+// --- next/navigation ---
+// usePathname 은 Button → useElementTracking 경로에서 호출되므로 함께 mock 한다.
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/ko/solve/jeongbocheorigisa_pilgi/quiz',
+}));
+
+vi.mock('@utils/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// --- solve 도메인 표현 컴포넌트 stub: 클릭 시 onSelect 로 제출 트리거 ---
+// 컴포넌트 분리 이동 후 QuizClient 의 import 경로가 둘로 나뉘었다:
+//  - solve 종속(ChoiceButton·ShortAnswerInput·ClozeBlock·ExplanationPanel): 로컬 ../../components
+//    (QuizClient 기준). 이 test 파일(__tests__/)에서 동일 모듈을 가리키려면 ../../../components.
+//  - 공통(CodeBlock·ProgressBar): @components/basic/* 로 이동 → 각각 별도 mock.
+vi.mock('../../../components', () => ({
+  ChoiceButton: ({ index, onSelect }: { index: number; onSelect?: (n: number) => void }) => (
+    <button type="button" data-testid={`choice-${index}`} onClick={() => onSelect?.(index)}>
+      choice {index}
+    </button>
+  ),
+  ShortAnswerInput: () => <div data-testid="short-input" />,
+  ClozeBlock: () => <div data-testid="cloze-block" />,
+  ExplanationPanel: () => <div data-testid="explanation" />,
+}));
+
+vi.mock('@components/basic/CodeBlock', () => ({
+  CodeBlock: () => <div data-testid="code-block" />,
+}));
+
+vi.mock('@components/basic/ProgressBar', () => ({
+  ProgressBar: ({ value }: { value: number }) => (
+    <div data-testid="progress-bar" data-value={value} />
+  ),
+}));
+
+vi.mock('../SolveResultView', () => ({
+  default: () => <div data-testid="result-view" />,
+}));
+
+// --- solve 훅 mock ---
+// useStartAttempt 는 이제 query → { data } 로 attempt 를 노출한다(mutation 아님).
+const startState: { data: unknown; isError: boolean; error: unknown } = {
+  data: undefined,
+  isError: false,
+  error: null,
+};
+const submitMutate = vi.fn();
+const finishMutate = vi.fn();
+
+// page 인자별 응답을 제어하기 위해 호출 인자를 기록한다.
+const useQuestionsMock = vi.fn();
+
+vi.mock('@queries/useSolveQueries', () => ({
+  SOLVE_QUESTIONS_PAGE_SIZE: 100,
+  useStartAttempt: () => startState,
+  useResumeAttempt: () => ({ data: undefined }),
+  useQuestions: (...args: unknown[]) => useQuestionsMock(...args),
+  useSubmitAnswer: () => ({ mutate: submitMutate }),
+  useFinishAttempt: () => ({ mutate: finishMutate, isPending: false }),
+}));
+
+const LIMIT = 100;
+const TOTAL = 1786; // page 0~16 각 100 + page 17 86 = 1786
+const LAST_PAGE = 17;
+
+/** 현실적 pilgi 페이지: page<17 → 100문항(isLast=false), page 17 → 86문항(isLast=true). */
+function makePilgiPage(page: number) {
+  const start = page * LIMIT;
+  const count = page < LAST_PAGE ? LIMIT : TOTAL - LAST_PAGE * LIMIT; // 17페이지=86
+  const results = Array.from({ length: count }, (_, i) => ({
+    id: start + i + 1, // 1-based 전역 id
+    no: start + i + 1,
+    type: SolveQuestionType.Mcq,
+    question: `Q${start + i + 1}`,
+    choices: ['a', 'b', 'c', 'd'],
+  }));
+  return { count: TOTAL, results, isFirst: page === 0, isLast: page >= LAST_PAGE };
+}
+
+/**
+ * startAttempt.mutate 가 즉시 onSuccess(attempt) 를 부르도록 설정.
+ * useQuestions 는 인자의 page 값에 따라 해당 페이지를 반환한다.
+ */
+function setup(opts: {
+  total: number;
+  pages: (page: number) => { count: number; results: unknown[]; isFirst: boolean; isLast: boolean };
+  currentIndex?: number;
+  unitId?: string;
+}) {
+  const attempt = {
+    id: 7,
+    subjectSlug: 'jeongbocheorigisa_pilgi',
+    unitKey: opts.unitId ?? null,
+    mode: 'full',
+    status: 'in_progress',
+    currentIndex: opts.currentIndex ?? 0,
+    total: opts.total,
+    correctCount: 0,
+    startedAt: '2026-06-22T00:00:00Z',
+  };
+
+  // query mock: attempt 를 data 로 즉시 노출.
+  startState.data = attempt;
+  startState.isError = false;
+  startState.error = null;
+
+  // 실제 React Query 는 동일 queryKey(=동일 page)에 대해 안정적 객체 참조를 반환한다.
+  // mock 도 page 별 응답을 캐싱해 참조 안정성을 보장해야 컴포넌트의 useEffect deps([questionPage])
+  // 가 매 렌더 변하지 않아 무한 리렌더(누적 effect ↔ 리렌더)가 발생하지 않는다.
+  const pageCache = new Map<number, ReturnType<typeof opts.pages>>();
+  const getPage = (page: number) => {
+    if (!pageCache.has(page)) pageCache.set(page, opts.pages(page));
+    return pageCache.get(page)!;
+  };
+  const resultCache = new Map<number, { data: unknown; isLoading: boolean; isError: boolean }>();
+  const getResult = (page: number) => {
+    if (!resultCache.has(page)) {
+      resultCache.set(page, { data: getPage(page), isLoading: false, isError: false });
+    }
+    return resultCache.get(page)!;
+  };
+
+  // useQuestions(slug, unitId, page, limit, enabled) — page 는 3번째 인자.
+  useQuestionsMock.mockImplementation((...args: unknown[]) => {
+    const page = (args[2] as number) ?? 0;
+    return getResult(page);
+  });
+
+  return { attempt };
+}
+
+beforeEach(() => {
+  startState.data = undefined;
+  startState.isError = false;
+  startState.error = null;
+  submitMutate.mockReset();
+  finishMutate.mockReset();
+  useQuestionsMock.mockReset();
+  pushMock.mockReset();
+});
+
+function renderQuiz(unitId?: string) {
+  return render(
+    <QuizClient
+      lng={'ko' as never}
+      slug="jeongbocheorigisa_pilgi"
+      unitId={unitId}
+      mode={'full' as never}
+    />,
+  );
+}
+
+/**
+ * 현재 문항의 1번 보기를 클릭해 제출 → onSuccess 로 결과 주입(채점 표시 → next/finish 노출).
+ * current 문항이 로드되기 전엔 choice-1 이 없으므로 findByTestId 로 대기한 뒤 클릭한다.
+ */
+async function submitCurrent() {
+  submitMutate.mockImplementationOnce((_payload, callbacks) => {
+    callbacks?.onSuccess?.({ isCorrect: true, correctChoice: 1, explanation: 'x' });
+  });
+  const choice = await screen.findByTestId('choice-1');
+  act(() => {
+    choice.click();
+  });
+}
+
+describe('QuizClient — 다중 페이지 경계 (FE-1)', () => {
+  it('total(1786) > 1페이지(100)면 100번째(index 99)에서 finish 가 아니라 next 를 노출한다', async () => {
+    // page>=1 도 현실적으로 100문항을 반환(빈 페이지 금지). index 99 로 복원.
+    setup({
+      total: TOTAL,
+      currentIndex: 99,
+      pages: makePilgiPage,
+    });
+    renderQuiz();
+
+    // index 99 문항 채점(current 로드 대기 후 제출) → 버튼 확인.
+    await submitCurrent();
+
+    // 회귀 방지: index 99 / total 1786 → "다음" 이어야 한다.
+    expect(await screen.findByRole('button', { name: 'quiz.next' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'quiz.finish' })).not.toBeInTheDocument();
+    expect(finishMutate).not.toHaveBeenCalled();
+  });
+
+  it('페이지 끝(index 99)에 도달하면 다음 page(=1)를 useQuestions 로 progressive 요청한다', async () => {
+    setup({
+      total: TOTAL,
+      currentIndex: 99,
+      pages: makePilgiPage,
+    });
+    renderQuiz();
+
+    // current(index 99) 로드 대기 — 이 시점이면 progressive effect 가 page+1 을 요청한 뒤다.
+    await screen.findByTestId('choice-1');
+
+    // 마지막 로드 문항(index 99)에 있으면 progressive effect 가 page 1 을 요청해야 한다.
+    await waitFor(() => {
+      const requestedPages = useQuestionsMock.mock.calls.map((c) => c[2] as number);
+      expect(requestedPages).toContain(1);
+    });
+  });
+
+  it('전체를 끝까지 진행해 실제 마지막 인덱스(1785)에 도달했을 때만 finish 를 노출한다', async () => {
+    // 진입 인덱스를 1785(=total-1)로 복원. progressive effect 가 page 0→17 까지 누적 로드한다.
+    setup({
+      total: TOTAL,
+      currentIndex: 1785,
+      pages: makePilgiPage,
+    });
+    renderQuiz();
+
+    // 18페이지 누적 로딩(0~17)이 끝나 index 1785 문항이 로드될 때까지 대기 후 제출.
+    await submitCurrent();
+
+    // index 1785 == total-1 → finish 노출.
+    expect(await screen.findByRole('button', { name: 'quiz.finish' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'quiz.next' })).not.toBeInTheDocument();
+  });
+
+  it('단일 페이지(total == 로드 수)면 마지막 문항에서 finish 를 정상 노출한다 (회귀)', async () => {
+    const SMALL_TOTAL = 5;
+    setup({
+      total: SMALL_TOTAL,
+      currentIndex: 4,
+      pages: (page) => ({
+        count: SMALL_TOTAL,
+        results: Array.from({ length: SMALL_TOTAL }, (_, i) => ({
+          id: i + 1,
+          no: i + 1,
+          type: SolveQuestionType.Mcq,
+          question: `Q${i + 1}`,
+          choices: ['a', 'b', 'c', 'd'],
+        })),
+        isFirst: page === 0,
+        isLast: true,
+      }),
+    });
+    renderQuiz('001');
+
+    await submitCurrent();
+
+    expect(await screen.findByRole('button', { name: 'quiz.finish' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'quiz.next' })).not.toBeInTheDocument();
+  });
+
+  it('단일 페이지에서 마지막이 아닌 문항(index 0)은 next 를 노출한다 (회귀)', async () => {
+    const SMALL_TOTAL = 5;
+    setup({
+      total: SMALL_TOTAL,
+      currentIndex: 0,
+      pages: (page) => ({
+        count: SMALL_TOTAL,
+        results: Array.from({ length: SMALL_TOTAL }, (_, i) => ({
+          id: i + 1,
+          no: i + 1,
+          type: SolveQuestionType.Mcq,
+          question: `Q${i + 1}`,
+          choices: ['a', 'b', 'c', 'd'],
+        })),
+        isFirst: page === 0,
+        isLast: true,
+      }),
+    });
+    renderQuiz('001');
+
+    await submitCurrent();
+
+    expect(await screen.findByRole('button', { name: 'quiz.next' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'quiz.finish' })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/[lng]/(mobile)/solve/[slug]/quiz/page.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/quiz/page.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { buildLoginUrl } from '@utils/loginRedirect';
+import { Language } from '~/app/i18n/settings';
+import { SolveAttemptMode } from '@api/Solve';
+import QuizClient from './QuizClient';
+
+export const dynamic = 'force-dynamic';
+
+type SolveQuizParams = {
+  params: Promise<{ lng: string; slug: string }>;
+  searchParams: Promise<{ unitId?: string; mode?: string; sourceAttemptId?: string }>;
+};
+
+// 풀이 진입 시점에 로그인을 강제한다(목록은 공개, 풀이/시도는 보호).
+// refresh_token + user_info 중 하나라도 없으면 로그인으로 보낸다(access_token 은 미들웨어가
+// 갱신할 수 있어 단독 기준 X). 로그인 후 원래 풀던 페이지로 정확히 복귀하도록 returnPath 에
+// unitId/mode/sourceAttemptId 쿼리까지 모두 포함한다. SPA 네비게이션에서도 server component
+// redirect 가 동작한다.
+function buildQuizReturnPath(
+  lng: string,
+  slug: string,
+  searchParams: { unitId?: string; mode?: string; sourceAttemptId?: string },
+): string {
+  const query = new URLSearchParams();
+  if (searchParams.unitId) query.set('unitId', searchParams.unitId);
+  if (searchParams.mode) query.set('mode', searchParams.mode);
+  if (searchParams.sourceAttemptId) query.set('sourceAttemptId', searchParams.sourceAttemptId);
+  const qs = query.toString();
+  const base = `/${lng}/solve/${slug}/quiz`;
+  return qs ? `${base}?${qs}` : base;
+}
+
+export default async function SolveQuizPage({ params, searchParams }: SolveQuizParams) {
+  const { lng, slug } = await params;
+  const resolvedSearchParams = await searchParams;
+  const { unitId, mode, sourceAttemptId } = resolvedSearchParams;
+  const language = lng as Language;
+
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refresh_token')?.value;
+  const userInfo = cookieStore.get('user_info')?.value;
+  if (!refreshToken || !userInfo) {
+    redirect(
+      buildLoginUrl(
+        `/${language}/auth/login`,
+        buildQuizReturnPath(language, slug, resolvedSearchParams),
+      ),
+    );
+  }
+
+  // review 모드는 sourceAttemptId 가 있어야 의미 있음. 그 외는 full.
+  const resolvedMode: SolveAttemptMode = mode === 'review' && sourceAttemptId ? 'review' : 'full';
+  const parsedSourceId =
+    resolvedMode === 'review' && sourceAttemptId ? Number(sourceAttemptId) : undefined;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-2 pb-24 pt-3 sm:px-3 md:px-4">
+      <QuizClient
+        lng={language}
+        slug={slug}
+        unitId={unitId}
+        mode={resolvedMode}
+        sourceAttemptId={Number.isFinite(parsedSourceId) ? parsedSourceId : undefined}
+      />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/components/ChoiceButton.stories.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ChoiceButton.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ChoiceButton } from './ChoiceButton';
+
+const meta: Meta<typeof ChoiceButton> = {
+  title: 'Solve/ChoiceButton',
+  component: ChoiceButton,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    index: 1,
+    text: '운영체제는 컴퓨터 시스템의 자원을 관리한다.',
+    state: 'default',
+    locked: false,
+  },
+  argTypes: {
+    state: { control: 'select', options: ['default', 'selected', 'correct', 'wrong', 'dimmed'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Selected: Story = { args: { state: 'selected' } };
+export const Correct: Story = { args: { state: 'correct', locked: true } };
+export const Wrong: Story = { args: { state: 'wrong', locked: true } };
+export const Dimmed: Story = { args: { state: 'dimmed', locked: true } };
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex max-w-md flex-col gap-3.5">
+      <ChoiceButton index={1} text="채점 후 정답 선택지" state="correct" locked />
+      <ChoiceButton index={2} text="사용자가 고른 오답" state="wrong" locked />
+      <ChoiceButton index={3} text="채점 후 나머지(dimmed)" state="dimmed" locked />
+      <ChoiceButton index={4} text="기본 상태(hover 가능)" state="default" />
+    </div>
+  ),
+};

--- a/src/app/[lng]/(mobile)/solve/components/ChoiceButton.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ChoiceButton.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/ChoiceButton.tsx — MCQ 선택지 버튼 (oksolve ChoiceButton 마이그레이션).
+ *
+ * 순수 표현 컴포넌트: 채점은 백엔드가 하므로 정답 인덱스를 받지 않는다.
+ * 부모(QuizClient)가 서버 결과(SolveSubmissionResult)를 토대로 각 선택지의 `state`를
+ * 계산해 내려주고, 이 컴포넌트는 상태에 맞는 cva variant만 렌더한다.
+ *
+ * 상태(cva variant):
+ *  - default  : 채점 전, 미선택
+ *  - selected : 채점 전, 사용자가 막 누른 선택지
+ *  - correct  : 채점 후 정답 선택지 (success 토큰)
+ *  - wrong    : 채점 후 사용자가 고른 오답 (danger 토큰)
+ *  - dimmed   : 채점 후 나머지 (채도/투명도 절감)
+ * `locked`(채점 완료로 포인터 차단)는 boolean prop으로 별도 처리.
+ *
+ * 키보드 1~4 단축키는 부모(QuizClient)가 담당. 여기선 onSelect 콜백만 노출.
+ */
+
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@utils/cn';
+import { Text } from '@components/basic/Text';
+import type { ChoiceIndex } from './types';
+
+const INDEX_BADGE: Record<ChoiceIndex, string> = {
+  1: '①',
+  2: '②',
+  3: '③',
+  4: '④',
+};
+
+const choiceVariants = cva(
+  cn(
+    'group relative flex w-full items-center gap-3.5 rounded-2xl border p-4 text-left',
+    'min-h-[60px] shadow-sm transition-all duration-200',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-point-1 focus-visible:ring-offset-2 focus-visible:ring-offset-basic-0',
+  ),
+  {
+    variants: {
+      state: {
+        default:
+          'border-basic-3 bg-basic-0 text-fg-1 hover:-translate-y-0.5 hover:border-point-4 hover:shadow-md',
+        selected: 'border-point-1 bg-point-soft text-point-1',
+        correct: 'border-success-2 bg-success-4 text-fg-1',
+        wrong: 'border-danger-2 bg-danger-4 text-fg-1',
+        dimmed: 'border-basic-3 bg-basic-0 text-fg-1 opacity-45 saturate-50 shadow-none',
+      },
+      locked: {
+        true: 'pointer-events-none cursor-default',
+        false: 'cursor-pointer active:translate-y-px',
+      },
+    },
+    defaultVariants: {
+      state: 'default',
+      locked: false,
+    },
+  },
+);
+
+const badgeVariants = cva(
+  cn(
+    'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border',
+    'text-sm font-semibold leading-none tabular-nums transition-colors',
+  ),
+  {
+    variants: {
+      state: {
+        default: 'border-basic-3 bg-basic-2 text-fg-4',
+        selected: 'border-transparent bg-point-2 text-white',
+        correct: 'border-transparent bg-success-2 text-white',
+        wrong: 'border-transparent bg-danger-2 text-white',
+        dimmed: 'border-basic-3 bg-basic-2 text-fg-4',
+      },
+    },
+    defaultVariants: { state: 'default' },
+  },
+);
+
+export type ChoiceState = NonNullable<VariantProps<typeof choiceVariants>['state']>;
+
+export interface ChoiceButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'onSelect'
+> {
+  /** 선택지 번호(1-based). */
+  index: ChoiceIndex;
+  /** 선택지 본문. */
+  text: string;
+  /** 시각 상태. 부모가 서버 채점 결과로 계산해 전달. */
+  state?: ChoiceState;
+  /** 채점 완료로 더 누를 수 없는 상태. */
+  locked?: boolean;
+  /** 선택 콜백. locked면 호출되지 않음. */
+  onSelect?: (index: ChoiceIndex) => void;
+}
+
+const ChoiceButton = React.forwardRef<HTMLButtonElement, ChoiceButtonProps>(
+  ({ index, text, state = 'default', locked = false, onSelect, className, ...props }, ref) => {
+    const isSelected = state === 'selected' || state === 'wrong' || state === 'correct';
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(choiceVariants({ state, locked }), className)}
+        aria-disabled={locked || undefined}
+        aria-pressed={isSelected}
+        aria-label={`${index}번 보기. ${text}`}
+        onClick={() => {
+          if (locked) return;
+          onSelect?.(index);
+        }}
+        {...props}
+      >
+        <span className={badgeVariants({ state })} aria-hidden="true">
+          {INDEX_BADGE[index]}
+        </span>
+        <Text variant="d2" color="basic-1" className="min-w-0 flex-1 break-keep leading-snug">
+          {text}
+        </Text>
+      </button>
+    );
+  },
+);
+ChoiceButton.displayName = 'ChoiceButton';
+
+export { ChoiceButton, choiceVariants };

--- a/src/app/[lng]/(mobile)/solve/components/ClozeBlock.stories.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ClozeBlock.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ClozeBlock } from './ClozeBlock';
+
+const meta: Meta<typeof ClozeBlock> = {
+  title: 'Solve/ClozeBlock',
+  component: ClozeBlock,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const CODE_TEMPLATE = 'for (int i = 0; i < {{n}}; i{{op}}) {\n  sum += arr[i];\n}';
+const TEXT_TEMPLATE = '객체지향의 4대 특징은 추상화, {{a}}, 상속, {{b}} 이다.';
+
+export const CodePristine: Story = {
+  args: { clozeTemplate: CODE_TEMPLATE, codeLanguage: 'java', graded: false },
+};
+
+export const TextPristine: Story = {
+  args: { clozeTemplate: TEXT_TEMPLATE, graded: false },
+};
+
+export const CodeGraded: Story = {
+  args: {
+    clozeTemplate: CODE_TEMPLATE,
+    codeLanguage: 'java',
+    graded: true,
+    submittedMap: { n: 'len', op: '--' },
+    blankResults: [
+      { blankId: 'n', correct: true, correctText: 'len' },
+      { blankId: 'op', correct: false, correctText: '++' },
+    ],
+  },
+};
+
+export const TextGraded: Story = {
+  args: {
+    clozeTemplate: TEXT_TEMPLATE,
+    graded: true,
+    submittedMap: { a: '캡슐화', b: '다형성' },
+    blankResults: [
+      { blankId: 'a', correct: true, correctText: '캡슐화' },
+      { blankId: 'b', correct: true, correctText: '다형성' },
+    ],
+  },
+};

--- a/src/app/[lng]/(mobile)/solve/components/ClozeBlock.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ClozeBlock.tsx
@@ -1,0 +1,165 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/ClozeBlock.tsx — 빈칸 채우기(다중·인라인) (oksolve ClozeBlock 마이그레이션).
+ *
+ * clozeTemplate을 parseCloze로 분해해 빈칸 위치에 인라인 <input>을 렌더한다.
+ *  - codeLanguage 있으면 코드 빈칸(monospace CodeBlock 톤), 없으면 지문 빈칸.
+ *  - 미채점: 로컬 state에 입력 보관 → 제출 시 blanks 배열로 onSubmit.
+ *  - 채점 후: 서버가 준 blankResults로 빈칸별 정/오 토큰 + "n/m 빈칸 정답" 요약 +
+ *    오답 칸 정답 노출(전부 맞춰야 정답). 색만으로 구분하지 않도록 ✕ 기호 병기.
+ *
+ * 채점은 서버가 하므로 정답을 들고 있지 않다. 부모(QuizClient)가 SolveSubmissionResult의
+ * blankResults를 내려준다. 문항 전환 시 부모 key로 리마운트되어 입력이 초기화된다.
+ *
+ * parseCloze는 `@utils/cloze`에서 import (frontend engineer가 작성 예정).
+ * 기대 시그니처는 보고서/하단 주석 참고.
+ */
+
+'use client';
+
+import * as React from 'react';
+import { cn } from '@utils/cn';
+import { Button } from '@components/basic/Button';
+import { Text } from '@components/basic/Text';
+import { parseCloze } from '@utils/cloze';
+import type { BlankResult } from './types';
+
+/** 제출 시 부모로 전달하는 빈칸 입력값. spec SolveSubmissionRequest.blanks와 동일 형태. */
+export interface ClozeBlankValue {
+  blankId: string;
+  value: string;
+}
+
+export interface ClozeBlockProps {
+  /** 빈칸 마커({{blankId}})를 포함한 템플릿. spec SolveQuestion.clozeTemplate. */
+  clozeTemplate: string;
+  /** 코드 빈칸이면 언어, 지문 빈칸이면 undefined. spec SolveQuestion.codeLanguage. */
+  codeLanguage?: string;
+  /** 채점 완료 여부. */
+  graded?: boolean;
+  /** 채점 후 사용자가 제출한 값(복원 표시용). blankId → value. */
+  submittedMap?: Record<string, string>;
+  /** 채점 후 빈칸별 결과(서버 제공). graded일 때 필수. */
+  blankResults?: BlankResult[];
+  /** 제출 콜백. */
+  onSubmit?: (blanks: ClozeBlankValue[]) => void;
+}
+
+// 빈칸 폭: 입력 길이에 맞춰(최소 4ch, 최대 24ch). 미채점은 정답 길이를 노출하지 않도록 입력 길이만 본다.
+function inputSize(text: string): number {
+  return Math.max(4, Math.min(text.length + 1, 24));
+}
+
+function ClozeBlock({
+  clozeTemplate,
+  codeLanguage,
+  graded = false,
+  submittedMap,
+  blankResults,
+  onSubmit,
+}: ClozeBlockProps) {
+  const segments = React.useMemo(() => parseCloze(clozeTemplate), [clozeTemplate]);
+  const [inputs, setInputs] = React.useState<Record<string, string>>({});
+  const isCode = !!codeLanguage;
+  const answered = submittedMap ?? {};
+
+  const resultById = React.useMemo(
+    () => new Map((blankResults ?? []).map((b) => [b.blankId, b])),
+    [blankResults],
+  );
+
+  const segNodes = segments.map((seg, i) => {
+    if (seg.kind === 'text') {
+      // eslint-disable-next-line react/no-array-index-key
+      return <span key={`t-${i}`}>{seg.value}</span>;
+    }
+    const value = (graded ? answered[seg.blankId] : inputs[seg.blankId]) ?? '';
+    const result = resultById.get(seg.blankId);
+    const ok = result?.correct;
+    let gradedSuffix = '';
+    if (graded) gradedSuffix = ok ? ' 정답' : ' 오답';
+    return (
+      <input
+        key={`b-${seg.blankId}`}
+        className={cn(
+          'mx-0.5 inline-block min-w-[4ch] rounded-md border px-1.5 py-px align-baseline font-mono text-[inherit] leading-snug',
+          'bg-basic-0 text-fg-1',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-point-1',
+          !graded && 'border-point-1',
+          graded && ok && 'border-success-2 bg-success-4',
+          graded && ok === false && 'border-danger-2 bg-danger-4',
+        )}
+        value={value}
+        size={inputSize(value)}
+        readOnly={graded}
+        onChange={
+          graded ? undefined : (e) => setInputs((m) => ({ ...m, [seg.blankId]: e.target.value }))
+        }
+        aria-label={`빈칸 ${seg.blankId}${gradedSuffix}`}
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
+      />
+    );
+  });
+
+  const body = isCode ? (
+    <div className="relative overflow-hidden rounded-2xl border border-basic-3 bg-basic-2 shadow-sm">
+      <span className="block border-b border-basic-3 px-3.5 py-1.5 text-sm font-semibold lowercase text-fg-5">
+        {codeLanguage}
+      </span>
+      <pre className="m-0 overflow-x-auto whitespace-pre px-4 py-4 font-mono text-sm leading-loose text-fg-1">
+        <code>{segNodes}</code>
+      </pre>
+    </div>
+  ) : (
+    <p className="whitespace-pre-wrap break-keep text-base leading-loose text-fg-1">{segNodes}</p>
+  );
+
+  if (graded) {
+    const total = blankResults?.length ?? 0;
+    const correctCount = (blankResults ?? []).filter((b) => b.correct).length;
+    const wrongBlanks = (blankResults ?? []).filter((b) => !b.correct);
+    return (
+      <div className="animate-solve-enter">
+        {body}
+        <Text variant="d2" className="mt-3 block font-semibold text-fg-2">
+          {correctCount} / {total} 빈칸 정답
+        </Text>
+        {wrongBlanks.length > 0 && (
+          <ul className="mt-2 flex list-none flex-col gap-1 pl-0 font-mono text-sm text-success-1">
+            {wrongBlanks.map((b) => (
+              <li key={b.blankId}>
+                <span aria-hidden="true">✕ </span>
+                {b.blankId}: {b.correctText}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  const filledCount = Object.values(inputs).filter((v) => v.trim()).length;
+  return (
+    <div className="animate-solve-enter">
+      {body}
+      <div className="mt-4 flex justify-end">
+        <Button
+          type="button"
+          disabled={filledCount === 0}
+          aria-disabled={filledCount === 0 || undefined}
+          onClick={() =>
+            onSubmit?.(Object.entries(inputs).map(([blankId, value]) => ({ blankId, value })))
+          }
+          className="min-w-[120px] rounded-xl px-6"
+        >
+          제출
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export { ClozeBlock };

--- a/src/app/[lng]/(mobile)/solve/components/ExplanationPanel.stories.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ExplanationPanel.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ExplanationPanel } from './ExplanationPanel';
+
+const meta: Meta<typeof ExplanationPanel> = {
+  title: 'Solve/ExplanationPanel',
+  component: ExplanationPanel,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    explanation:
+      '캡슐화는 데이터와 그 데이터를 처리하는 메서드를 하나로 묶고, 외부에서 직접 접근하지 못하도록 은닉하는 것이다.',
+    slides: '12',
+    trapType: '용어 혼동',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Correct: Story = { args: { correct: true } };
+export const Wrong: Story = { args: { correct: false } };
+export const NoMeta: Story = { args: { correct: true, slides: undefined, trapType: undefined } };

--- a/src/app/[lng]/(mobile)/solve/components/ExplanationPanel.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ExplanationPanel.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/ExplanationPanel.tsx — 채점 후 해설 패널 (oksolve ExplanationPanel 마이그레이션).
+ *
+ * 서버가 준 explanation/slides/trapType 표시. 정답→success 토큰, 오답→danger 토큰.
+ * 색만으로 정/오를 구분하지 않도록 ✓/✕ 기호 + 텍스트 병기.
+ * framer-motion으로 200ms 슬라이드업 등장(prefers-reduced-motion 자동 존중).
+ */
+
+'use client';
+
+import * as React from 'react';
+import { m, LazyMotion, domAnimation } from 'framer-motion';
+import { cn } from '@utils/cn';
+import { Text } from '@components/basic/Text';
+
+export interface ExplanationPanelProps {
+  /** 사용자가 맞혔는지(서버 채점). */
+  correct: boolean;
+  /** 해설 본문. */
+  explanation: string;
+  /** 슬라이드 메타(선택). */
+  slides?: string;
+  /** 함정 유형 메타(선택). */
+  trapType?: string;
+  className?: string;
+}
+
+function ExplanationPanel({
+  correct,
+  explanation,
+  slides,
+  trapType,
+  className,
+}: ExplanationPanelProps) {
+  const meta = slides && trapType ? `슬라이드 ${slides} · ${trapType}` : slides || trapType;
+
+  return (
+    <LazyMotion features={domAnimation}>
+      <m.section
+        role="status"
+        aria-live="polite"
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+        className={cn('rounded-2xl border border-basic-3 bg-basic-0 p-5 shadow-sm', className)}
+      >
+        <p
+          className={cn(
+            'mb-2.5 flex items-center gap-2 text-lg font-bold',
+            correct ? 'text-success-1' : 'text-danger-1',
+          )}
+        >
+          {correct ? '✓ 정답입니다' : '✕ 오답입니다'}
+        </p>
+        <Text variant="d2" color="basic-2" className="block break-keep leading-relaxed">
+          {explanation}
+        </Text>
+        {meta && <p className="mt-3 border-t border-basic-3 pt-3 text-sm text-fg-5">{meta}</p>}
+      </m.section>
+    </LazyMotion>
+  );
+}
+
+export { ExplanationPanel };

--- a/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.stories.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShortAnswerInput } from './ShortAnswerInput';
+
+const meta: Meta<typeof ShortAnswerInput> = {
+  title: 'Solve/ShortAnswerInput',
+  component: ShortAnswerInput,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pristine: Story = {
+  args: { graded: false },
+};
+
+export const GradedCorrect: Story = {
+  args: { graded: true, isCorrect: true, submittedText: '캡슐화' },
+};
+
+export const GradedWrong: Story = {
+  args: { graded: true, isCorrect: false, submittedText: '상속', correctText: '캡슐화' },
+};

--- a/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.tsx
@@ -1,0 +1,100 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/ShortAnswerInput.tsx — 단답식 입력 (oksolve ShortAnswerInput 마이그레이션).
+ *
+ * basic/Input + basic/Button 조합. 채점은 서버가 하므로 정오 판정 로직 없음:
+ *  - 미채점: Input(빈값 비활성, Enter 제출) + 제출 Button.
+ *  - 채점 후: readOnly Input에 정/오 토큰 보더, 오답이면 서버가 준 correctText 노출
+ *    (색만으로 구분하지 않도록 ✕ 기호 + "정답:" 텍스트 병기).
+ *
+ * 입력 상태는 내부 state로 보관. 문항 전환 시 부모 key로 리마운트되어 초기화된다.
+ */
+
+'use client';
+
+import * as React from 'react';
+import { cn } from '@utils/cn';
+import { Input } from '@components/basic/Input';
+import { Button } from '@components/basic/Button';
+import { Text } from '@components/basic/Text';
+
+export interface ShortAnswerInputProps {
+  /** 채점 완료 여부(서버 응답 도착). */
+  graded?: boolean;
+  /** 채점 후 정오. graded일 때만 의미 있음. */
+  isCorrect?: boolean;
+  /** 채점 후 사용자가 제출한 답(복원 표시용). */
+  submittedText?: string;
+  /** 오답일 때 노출할 정답 텍스트(서버 제공). */
+  correctText?: string;
+  /** 제출 콜백. */
+  onSubmit?: (value: string) => void;
+}
+
+function ShortAnswerInput({
+  graded = false,
+  isCorrect = false,
+  submittedText,
+  correctText,
+  onSubmit,
+}: ShortAnswerInputProps) {
+  const [value, setValue] = React.useState('');
+
+  if (graded) {
+    const answered = submittedText ?? '';
+    return (
+      <div className="animate-solve-enter">
+        <Input
+          value={answered}
+          readOnly
+          aria-label="제출한 답"
+          className={cn(
+            'min-h-[60px] cursor-default rounded-2xl px-4 text-base shadow-sm',
+            isCorrect ? 'border-success-2 bg-success-4' : 'border-danger-2 bg-danger-4',
+          )}
+        />
+        {!isCorrect && correctText && (
+          <Text variant="d2" className="mt-3 block break-keep font-semibold text-success-1">
+            <span aria-hidden="true">✕ </span>정답: {correctText}
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  const trimmed = value.trim();
+  return (
+    <div className="animate-solve-enter">
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && trimmed) {
+            e.preventDefault();
+            onSubmit?.(value);
+          }
+        }}
+        placeholder="답을 입력하세요"
+        aria-label="단답 입력"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="min-h-[60px] rounded-2xl px-4 text-base shadow-sm"
+      />
+      <div className="mt-4 flex justify-end">
+        <Button
+          type="button"
+          disabled={!trimmed}
+          aria-disabled={!trimmed || undefined}
+          onClick={() => onSubmit?.(value)}
+          className="min-w-[120px] rounded-xl px-6"
+        >
+          제출
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export { ShortAnswerInput };

--- a/src/app/[lng]/(mobile)/solve/components/SubjectCard.stories.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/SubjectCard.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SubjectCard } from './SubjectCard';
+
+const meta: Meta<typeof SubjectCard> = {
+  title: 'Solve/SubjectCard',
+  component: SubjectCard,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    title: '정보처리기사 필기',
+    totalQuestions: 1786,
+    unitCount: 12,
+    answeredCount: 420,
+    completed: false,
+    color: '#7c3aed',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const InProgress: Story = { args: { answeredCount: 900 } };
+export const Completed: Story = { args: { answeredCount: 1786, completed: true } };
+export const NotStarted: Story = { args: { answeredCount: 0 } };
+export const NoColor: Story = { args: { color: undefined } };

--- a/src/app/[lng]/(mobile)/solve/components/SubjectCard.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/SubjectCard.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/SubjectCard.tsx — 과목 카드 + 진행 게이지 (oksolve SubjectCard 마이그레이션).
+ *
+ * 클릭 시 단원 선택 화면으로 진입하는 버튼형 카드. 공통 상수
+ * SERVICE_PANEL_SOFT(패널 톤) + SERVICE_CARD_INTERACTIVE(hover lift/보더)를 재사용한다.
+ * 진행 게이지는 공통 @components/basic/ProgressBar 재사용.
+ *
+ * color prop(과목별 hex)은 CSS 변수(--subject-accent)로 받아 좌측 액센트 바·점에만 사용한다
+ * (배경/텍스트 등 가독성에 영향 주는 곳엔 토큰만 사용 → 다크모드/대비 안전).
+ * 이어풀기(resume) 상태는 point-soft 틴트 + point-1 보더로 강조.
+ */
+
+'use client';
+
+import * as React from 'react';
+import { cn } from '@utils/cn';
+import { Text } from '@components/basic/Text';
+import {
+  SERVICE_PANEL_SOFT,
+  SERVICE_CARD_INTERACTIVE,
+} from '@components/complex/Service/interactiveStyles';
+import { ProgressBar } from '@components/basic/ProgressBar';
+
+export interface SubjectCardProps {
+  /** 과목 제목. */
+  title: string;
+  /** 전체 문항 수. */
+  totalQuestions: number;
+  /** 단원 수. */
+  unitCount: number;
+  /** 사용자가 푼 문항 수(서버 derived 진행률). */
+  answeredCount: number;
+  /** 완료 여부(completedAt != null 등). */
+  completed?: boolean;
+  /** 과목 액센트 색(hex). 좌측 바·점에만 사용. */
+  color?: string;
+  /** 카드 클릭 콜백 → 단원 선택. */
+  onOpen?: () => void;
+}
+
+function SubjectCard({
+  title,
+  totalQuestions,
+  unitCount,
+  answeredCount,
+  completed = false,
+  color,
+  onOpen,
+}: SubjectCardProps) {
+  const inProgress = answeredCount > 0 && !completed;
+  const ratio = totalQuestions > 0 ? answeredCount / totalQuestions : 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={`${title} 열기`}
+      style={color ? ({ '--subject-accent': color } as React.CSSProperties) : undefined}
+      className={cn(
+        SERVICE_PANEL_SOFT,
+        SERVICE_CARD_INTERACTIVE,
+        'relative flex w-full flex-col gap-2.5 overflow-hidden p-5 text-left',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-point-1 focus-visible:ring-offset-2 focus-visible:ring-offset-basic-0',
+        inProgress && 'border-point-1 bg-point-soft',
+      )}
+    >
+      {/* 좌측 과목 액센트 바 (color prop이 있을 때만) */}
+      {color && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-1"
+          style={{ backgroundColor: 'var(--subject-accent)' }}
+        />
+      )}
+
+      <div className="flex items-center gap-2">
+        {color && (
+          <span
+            aria-hidden="true"
+            className="h-2.5 w-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: 'var(--subject-accent)' }}
+          />
+        )}
+        <Text variant="t3" color="basic-1" className="leading-tight">
+          {title}
+        </Text>
+      </div>
+
+      <Text variant="d3" color="basic-5" className="tabular-nums">
+        {totalQuestions}문 · {unitCount}단원
+      </Text>
+
+      <div className="mt-1 flex items-center gap-2.5">
+        <ProgressBar value={ratio} label={`${title} 진행률`} className="flex-1" />
+        <Text variant="c1" color="basic-5" className="shrink-0 font-semibold tabular-nums">
+          {completed
+            ? `완료 · ${answeredCount} / ${totalQuestions}`
+            : `${answeredCount} / ${totalQuestions}`}
+        </Text>
+      </div>
+    </button>
+  );
+}
+
+export { SubjectCard };

--- a/src/app/[lng]/(mobile)/solve/components/__tests__/ChoiceButton.test.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/__tests__/ChoiceButton.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * solve/ChoiceButton 표현 컴포넌트 테스트.
+ *
+ * 컴포넌트는 정답을 모른다 — 부모가 서버 결과로 계산한 state 를 받아 시각/접근성만 반영한다.
+ * 상태→variant 클래스, locked 시 onSelect 차단/aria, 키보드 트리거(click) 를 검증한다.
+ */
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChoiceButton } from '../ChoiceButton';
+
+describe('<ChoiceButton />', () => {
+  it('번호 배지와 본문, 접근성 라벨을 렌더한다', () => {
+    render(<ChoiceButton index={1} text="첫 번째 보기" />);
+    const btn = screen.getByRole('button', { name: '1번 보기. 첫 번째 보기' });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveTextContent('①');
+    expect(btn).toHaveTextContent('첫 번째 보기');
+  });
+
+  it('미선택 default 는 aria-pressed=false', () => {
+    render(<ChoiceButton index={2} text="t" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selected/correct/wrong 상태는 aria-pressed=true', () => {
+    const { rerender } = render(<ChoiceButton index={2} text="t" state="selected" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+    rerender(<ChoiceButton index={2} text="t" state="correct" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+    rerender(<ChoiceButton index={2} text="t" state="wrong" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('state 별로 다른 variant 클래스를 적용한다(정/오 색 토큰)', () => {
+    const { rerender } = render(<ChoiceButton index={3} text="t" state="correct" />);
+    expect(screen.getByRole('button').className).toContain('bg-success-4');
+    rerender(<ChoiceButton index={3} text="t" state="wrong" />);
+    expect(screen.getByRole('button').className).toContain('bg-danger-4');
+    rerender(<ChoiceButton index={3} text="t" state="dimmed" />);
+    expect(screen.getByRole('button').className).toContain('opacity-45');
+  });
+
+  it('클릭하면 onSelect 가 자신의 index 로 호출된다', async () => {
+    const onSelect = vi.fn();
+    render(<ChoiceButton index={4} text="t" onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(4);
+  });
+
+  it('locked 면 클릭해도 onSelect 가 호출되지 않고 aria-disabled 가 붙는다', async () => {
+    const onSelect = vi.fn();
+    render(<ChoiceButton index={1} text="t" locked onSelect={onSelect} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    await userEvent.click(btn);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[lng]/(mobile)/solve/components/__tests__/ClozeBlock.test.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/__tests__/ClozeBlock.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * solve/ClozeBlock 표현 컴포넌트 테스트.
+ *
+ * 템플릿을 parseCloze 로 분해해 빈칸별 input 을 렌더하고, 입력→제출 활성화,
+ * 채점 후 blankResults 의 빈칸별 정/오 표시 + 오답 칸 정답 노출을 검증한다.
+ * 컴포넌트는 정답을 모른다 — graded 결과는 props(서버 결과)로만 들어온다.
+ */
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ClozeBlock } from '../ClozeBlock';
+
+const TEMPLATE = 'System.out.{{m}}(x); return {{v}};';
+
+describe('<ClozeBlock /> (미채점)', () => {
+  it('템플릿의 빈칸 수만큼 input 을 렌더한다', () => {
+    render(<ClozeBlock clozeTemplate={TEMPLATE} />);
+    expect(screen.getByLabelText('빈칸 m')).toBeInTheDocument();
+    expect(screen.getByLabelText('빈칸 v')).toBeInTheDocument();
+  });
+
+  it('입력이 모두 비어 있으면 제출 버튼이 비활성', () => {
+    render(<ClozeBlock clozeTemplate={TEMPLATE} />);
+    expect(screen.getByRole('button', { name: '제출' })).toBeDisabled();
+  });
+
+  it('빈칸을 채우면 제출이 활성화되고 onSubmit 이 blanks 배열로 호출된다', async () => {
+    const onSubmit = vi.fn();
+    render(<ClozeBlock clozeTemplate={TEMPLATE} onSubmit={onSubmit} />);
+    await userEvent.type(screen.getByLabelText('빈칸 m'), 'println');
+    const submit = screen.getByRole('button', { name: '제출' });
+    expect(submit).toBeEnabled();
+    await userEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith([{ blankId: 'm', value: 'println' }]);
+  });
+
+  it('코드 빈칸(codeLanguage)이면 언어 칩을 노출한다', () => {
+    render(<ClozeBlock clozeTemplate={TEMPLATE} codeLanguage="java" />);
+    expect(screen.getByText('java')).toBeInTheDocument();
+  });
+});
+
+describe('<ClozeBlock /> (채점 후)', () => {
+  const blankResults = [
+    { blankId: 'm', correct: true, correctText: 'println' },
+    { blankId: 'v', correct: false, correctText: 'value' },
+  ];
+
+  it('graded 면 input 이 readOnly 이고 빈칸 라벨에 정/오 접미사가 붙는다', () => {
+    render(
+      <ClozeBlock
+        clozeTemplate={TEMPLATE}
+        graded
+        submittedMap={{ m: 'println', v: 'wrong' }}
+        blankResults={blankResults}
+      />,
+    );
+    const correctInput = screen.getByLabelText('빈칸 m 정답');
+    const wrongInput = screen.getByLabelText('빈칸 v 오답');
+    expect(correctInput).toHaveAttribute('readonly');
+    expect(wrongInput).toHaveAttribute('readonly');
+    // 정/오 색 토큰
+    expect(correctInput.className).toContain('bg-success-4');
+    expect(wrongInput.className).toContain('bg-danger-4');
+  });
+
+  it('n/m 빈칸 정답 요약과 오답 칸의 정답을 노출한다', () => {
+    render(<ClozeBlock clozeTemplate={TEMPLATE} graded blankResults={blankResults} />);
+    expect(screen.getByText('1 / 2 빈칸 정답')).toBeInTheDocument();
+    // 오답 칸 v 의 정답 텍스트 노출 (✕ 기호 병기)
+    expect(screen.getByText(/v: value/)).toBeInTheDocument();
+  });
+
+  it('복원된 제출값(submittedMap)을 input 에 표시한다', () => {
+    render(
+      <ClozeBlock
+        clozeTemplate={TEMPLATE}
+        graded
+        submittedMap={{ m: 'myPrint', v: 'myVal' }}
+        blankResults={blankResults}
+      />,
+    );
+    expect(screen.getByLabelText('빈칸 m 정답')).toHaveValue('myPrint');
+    expect(screen.getByLabelText('빈칸 v 오답')).toHaveValue('myVal');
+  });
+});

--- a/src/app/[lng]/(mobile)/solve/components/index.ts
+++ b/src/app/[lng]/(mobile)/solve/components/index.ts
@@ -1,0 +1,12 @@
+/*
+ * solve/components/index.ts — solve 도메인 종속 표현 컴포넌트 로컬 barrel.
+ *
+ * 공통 재사용 컴포넌트(CodeBlock·ProgressBar·ScoreRing)는 @components/basic 으로
+ * 분리됐고, solve 도메인에만 쓰이는 표현 컴포넌트만 여기서 co-location 한다.
+ */
+export * from './types';
+export * from './ChoiceButton';
+export * from './ShortAnswerInput';
+export * from './ClozeBlock';
+export * from './ExplanationPanel';
+export * from './SubjectCard';

--- a/src/app/[lng]/(mobile)/solve/components/types.ts
+++ b/src/app/[lng]/(mobile)/solve/components/types.ts
@@ -1,0 +1,17 @@
+/*
+ * solve/types.ts — solve 도메인 표현 컴포넌트 공용 타입.
+ *
+ * 채점 결과 타입은 generated `@api/Solve` 모델을 단일 진실 공급원으로 삼는다.
+ * `ChoiceIndex`만 UI 표현용으로 1~4로 좁힌 별도 타입을 유지한다(①②③④ 배지 매핑).
+ */
+
+import type { SolveBlankResult, SolveQuestionType as GeneratedSolveQuestionType } from '@api/Solve';
+
+/** MCQ 선택지 인덱스(1-based). UI 표현용 narrowing. */
+export type ChoiceIndex = 1 | 2 | 3 | 4;
+
+/** 문항 유형 판별자. generated spec enum 값과 동일('mcq' | 'short' | 'cloze'). */
+export type SolveQuestionType = GeneratedSolveQuestionType;
+
+/** 채점 후 단일 빈칸 결과. generated `SolveBlankResult`와 동일 형태(별칭). */
+export type BlankResult = SolveBlankResult;

--- a/src/app/[lng]/(mobile)/solve/layout.tsx
+++ b/src/app/[lng]/(mobile)/solve/layout.tsx
@@ -1,0 +1,15 @@
+import { GenerateMetadata, translationsMetadata } from '@libs/server/customMetadata';
+import { ChildrenProps } from '~/app/[lng]/layout';
+
+export const dynamic = 'force-dynamic';
+
+export const generateMetadata: GenerateMetadata = async ({ params }) =>
+  translationsMetadata({ params, ns: 'solve' });
+
+// solve 목록(과목·단원)은 비회원도 열람 가능하다(백엔드 GET /solve/subjects, /solve/subjects/{slug}
+// 가 공개). 인증 가드는 layout 에서 제거하고, 로그인 필요한 진입점(풀이 quiz, 기록 me)에만
+// 개별 가드를 둔다. 실제 데이터 보호는 백엔드 @User 가 담당한다.
+export default async function SolveLayout({ children }: ChildrenProps) {
+  // 가드 없이 하위 트리를 그대로 렌더. (mobile) 레이아웃이 상위에서 크롬을 제공한다.
+  return children;
+}

--- a/src/app/[lng]/(mobile)/solve/me/SolveAttemptsClient.tsx
+++ b/src/app/[lng]/(mobile)/solve/me/SolveAttemptsClient.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@components/basic/Button';
+import GoogleAd from '@components/google/GoogleAd';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@components/basic/Table';
+import { useMyAttempts, SOLVE_ATTEMPTS_PAGE_SIZE } from '@queries/useSolveQueries';
+import { cn } from '@utils/cn';
+import type { SolveAttempt } from '@api/Solve';
+import { SolveAttemptStatus, SolveAttemptMode } from '@api/Solve';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+
+type SolveAttemptsClientProps = {
+  lng: Language;
+};
+
+export default function SolveAttemptsClient({ lng }: SolveAttemptsClientProps) {
+  const { t } = useTranslation(lng, 'solve');
+  const router = useRouter();
+  const [page, setPage] = React.useState(0);
+
+  const { data, isLoading, isError } = useMyAttempts(page, SOLVE_ATTEMPTS_PAGE_SIZE);
+
+  const formatDateTime = (value: string | null | undefined) => {
+    if (!value) return '-';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString(lng);
+  };
+
+  // 이어풀기/결과 보기 진입.
+  // 진행 중: quiz 로 진입(서버가 in_progress 재사용). review 면 mode=review + sourceAttemptId 동봉.
+  const openAttempt = (attempt: SolveAttempt) => {
+    const base = `/${lng}/solve/${attempt.subjectSlug}/quiz`;
+    const params = new URLSearchParams();
+    if (attempt.unitKey) params.set('unitId', attempt.unitKey);
+    if (attempt.mode === SolveAttemptMode.Review) {
+      params.set('mode', 'review');
+      // review in_progress 는 dedup 키로 재사용된다(sourceAttemptId 는 재사용 시 무시됨).
+      params.set('sourceAttemptId', String(attempt.id));
+    }
+    const qs = params.toString();
+    router.push(qs ? `${base}?${qs}` : base);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8 text-fg-4">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-sm text-danger-1">
+        {t('me.error')}
+      </p>
+    );
+  }
+
+  const items = data?.results ?? [];
+
+  if (items.length === 0) {
+    return (
+      <div className="space-y-3">
+        <p className="rounded-2xl border border-basic-3 bg-basic-0 p-4 text-sm text-fg-4">
+          {t('me.empty')}
+        </p>
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            onClick={() => router.push(`/${lng}/solve`)}
+            className="min-h-[40px] rounded-xl px-5"
+          >
+            {t('me.startSolving')}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t('me.table.subject')}</TableHead>
+            <TableHead>{t('me.table.unit')}</TableHead>
+            <TableHead className="w-[80px]">{t('me.table.mode')}</TableHead>
+            <TableHead className="w-[90px]">{t('me.table.status')}</TableHead>
+            <TableHead className="w-[90px] text-right">{t('me.table.score')}</TableHead>
+            <TableHead className="w-[160px]">{t('me.table.startedAt')}</TableHead>
+            <TableHead className="w-[110px]">{t('me.table.actions')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((attempt) => {
+            const inProgress = attempt.status === SolveAttemptStatus.InProgress;
+            return (
+              <TableRow key={attempt.id}>
+                <TableCell className="text-xs text-fg-2">{attempt.subjectSlug}</TableCell>
+                <TableCell className="text-xs text-fg-4">
+                  {attempt.unitKey ?? t('me.allUnits')}
+                </TableCell>
+                <TableCell className="text-xs text-fg-4">
+                  {attempt.mode === SolveAttemptMode.Review
+                    ? t('me.mode.review')
+                    : t('me.mode.full')}
+                </TableCell>
+                <TableCell>
+                  <span
+                    className={cn(
+                      'inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold',
+                      inProgress ? 'bg-point-soft text-point-1' : 'bg-success-4 text-success-1',
+                    )}
+                  >
+                    {inProgress ? t('me.status.in_progress') : t('me.status.completed')}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right text-xs tabular-nums text-fg-3">
+                  {attempt.correctCount} / {attempt.total}
+                </TableCell>
+                <TableCell className="text-xs text-fg-4">
+                  {formatDateTime(attempt.startedAt)}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    type="button"
+                    onClick={() => openAttempt(attempt)}
+                    className="min-h-[28px] rounded-md px-2 text-xs"
+                  >
+                    {inProgress ? t('me.resume') : t('me.viewResult')}
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {/* 페이지네이션 */}
+      {data && (data.count > items.length || page > 0) && (
+        <div className="flex items-center justify-center gap-3">
+          <button
+            type="button"
+            disabled={data.isFirst}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-fg-4 disabled:opacity-40 hover:text-point-fg"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="text-xs tabular-nums text-fg-5">{page + 1}</span>
+          <button
+            type="button"
+            disabled={data.isLast}
+            onClick={() => setPage((p) => p + 1)}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-fg-4 disabled:opacity-40 hover:text-point-fg"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* in-content 광고: 기록 목록 아래. 액션 버튼과 분리돼 정책상 안전. */}
+      <GoogleAd className="mt-2 w-full min-h-16" slotId="6290029027" />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/me/page.tsx
+++ b/src/app/[lng]/(mobile)/solve/me/page.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ListChecks } from 'lucide-react';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+import ServiceInfoNotice from '@components/complex/Service/ServiceInfoNotice';
+import { getTranslations } from '~/app/i18n';
+import { buildLoginUrl } from '@utils/loginRedirect';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language } from '~/app/i18n/settings';
+import SolveAttemptsClient from './SolveAttemptsClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SolveMyAttemptsPage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+
+  // 기록(내 시도 목록)은 로그인 필요. refresh_token + user_info 중 하나라도 없으면 로그인으로.
+  // (access_token 은 미들웨어가 갱신할 수 있어 단독 기준 X.)
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refresh_token')?.value;
+  const userInfo = cookieStore.get('user_info')?.value;
+  if (!refreshToken || !userInfo) {
+    redirect(buildLoginUrl(`/${language}/auth/login`, `/${language}/solve/me`));
+  }
+
+  const { t } = await getTranslations(language, 'solve');
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4 px-2 pb-24 pt-3 sm:px-3 md:px-4">
+      <ServicePageHeader
+        title={t('me.title')}
+        description={t('me.description')}
+        badge={t('me.headerBadge')}
+      />
+
+      <ServiceInfoNotice icon={<ListChecks className="h-5 w-5" />}>{t('intro')}</ServiceInfoNotice>
+
+      <SolveAttemptsClient lng={language} />
+    </div>
+  );
+}

--- a/src/app/[lng]/(mobile)/solve/page.tsx
+++ b/src/app/[lng]/(mobile)/solve/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { GraduationCap } from 'lucide-react';
+import ServicePageHeader from '@components/complex/Service/ServicePageHeader';
+import ServiceInfoNotice from '@components/complex/Service/ServiceInfoNotice';
+import { getTranslations } from '~/app/i18n';
+import { LanguageParams } from '~/app/[lng]/layout';
+import { Language } from '~/app/i18n/settings';
+import { getServiceCategoryBadge } from '@assets/datas/serviceCategories';
+import SolveSubjectsClient from './SolveSubjectsClient';
+
+export default async function SolvePage({ params }: LanguageParams) {
+  const { lng } = await params;
+  const language = lng as Language;
+  const { t } = await getTranslations(language, 'solve');
+  const badge = getServiceCategoryBadge(language, '/solve');
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4 px-2 pb-24 pt-3 sm:px-3 md:px-4">
+      <ServicePageHeader title={t('title')} description={t('description')} badge={badge} />
+
+      <ServiceInfoNotice icon={<GraduationCap className="h-5 w-5" />}>
+        {t('intro')}
+      </ServiceInfoNotice>
+
+      <SolveSubjectsClient lng={language} />
+    </div>
+  );
+}

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -56,6 +56,7 @@ import commandPalette from 'assets/locales/ko/command-palette.json';
 import consent from 'assets/locales/ko/consent.json';
 import shortener from 'assets/locales/ko/shortener.json';
 import copykiller from 'assets/locales/ko/copykiller.json';
+import solve from 'assets/locales/ko/solve.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -118,6 +119,7 @@ declare module 'i18next' {
       consent: typeof consent;
       shortener: typeof shortener;
       copykiller: typeof copykiller;
+      solve: typeof solve;
     };
   }
 }

--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -18,6 +18,7 @@ import {
   FileSearch,
   Fingerprint,
   Github,
+  GraduationCap,
   HardDrive,
   Hash,
   HeartPulse,
@@ -82,6 +83,16 @@ const menus: Menus = {
       },
       icon: <Link2 />,
       link: '/shortener',
+    },
+    {
+      title: {
+        ko: '문제풀이',
+        en: 'Quiz',
+        ja: '問題演習',
+        zh: '刷题',
+      },
+      icon: <GraduationCap />,
+      link: '/solve',
     },
     {
       title: {

--- a/src/assets/datas/serviceCategories.ts
+++ b/src/assets/datas/serviceCategories.ts
@@ -6,7 +6,8 @@ type ServiceSectionKey =
   | 'generator'
   | 'textData'
   | 'devUtility'
-  | 'lifestyle';
+  | 'lifestyle'
+  | 'learning';
 
 const SERVICE_SECTION_ORDER: ServiceSectionKey[] = [
   'planning',
@@ -15,6 +16,7 @@ const SERVICE_SECTION_ORDER: ServiceSectionKey[] = [
   'textData',
   'devUtility',
   'lifestyle',
+  'learning',
 ];
 
 const SERVICE_SECTION_BY_LINK: Record<string, ServiceSectionKey> = {
@@ -62,6 +64,7 @@ const SERVICE_SECTION_BY_LINK: Record<string, ServiceSectionKey> = {
   '/bpm-tapper': 'lifestyle',
   '/ppollong': 'lifestyle',
   '/pokemon-type-calculator': 'lifestyle',
+  '/solve': 'learning',
 };
 
 const SERVICE_SECTION_BADGES: Record<Language, Record<ServiceSectionKey, string>> = {
@@ -72,6 +75,7 @@ const SERVICE_SECTION_BADGES: Record<Language, Record<ServiceSectionKey, string>
     textData: '텍스트/데이터',
     devUtility: '개발/유틸리티',
     lifestyle: '라이프/기타',
+    learning: '학습/퀴즈',
   },
   en: {
     planning: 'Planning & Time',
@@ -80,6 +84,7 @@ const SERVICE_SECTION_BADGES: Record<Language, Record<ServiceSectionKey, string>
     textData: 'Text & Data',
     devUtility: 'Developer Utilities',
     lifestyle: 'Lifestyle & Misc',
+    learning: 'Learning & Quiz',
   },
   ja: {
     planning: '日程・時間',
@@ -88,6 +93,7 @@ const SERVICE_SECTION_BADGES: Record<Language, Record<ServiceSectionKey, string>
     textData: 'テキスト・データ',
     devUtility: '開発・ユーティリティ',
     lifestyle: 'ライフ・その他',
+    learning: '学習・クイズ',
   },
   zh: {
     planning: '日程与时间',
@@ -96,6 +102,7 @@ const SERVICE_SECTION_BADGES: Record<Language, Record<ServiceSectionKey, string>
     textData: '文本与数据',
     devUtility: '开发与实用',
     lifestyle: '生活与其他',
+    learning: '学习/测验',
   },
 };
 

--- a/src/assets/locales/en/menu.json
+++ b/src/assets/locales/en/menu.json
@@ -42,6 +42,10 @@
       "title": "Lifestyle & Misc",
       "description": "Health, rhythm, and lightweight utility tools"
     },
+    "learning": {
+      "title": "Learning & Quiz",
+      "description": "Study with subject-based questions and quizzes"
+    },
     "external": {
       "title": "External Links",
       "description": "Jump to profile pages and external channels"

--- a/src/assets/locales/en/solve.json
+++ b/src/assets/locales/en/solve.json
@@ -1,0 +1,96 @@
+{
+  "title": "Quiz",
+  "description": "Practice questions across subjects—from criminology and criminal law to the Engineer Information Processing (정보처리기사) written and practical exams—with instant grading and explanations.",
+  "headerBadge": "Learning & Quiz",
+  "intro": "Sign in and pick a subject to start solving. Progress history, resume, and retry-wrong are supported.",
+  "subjects": {
+    "loading": "Loading subjects…",
+    "error": "Failed to load subjects.",
+    "empty": "No subjects available yet.",
+    "unitCount": "{{count}} units",
+    "questionCount": "{{count}} questions",
+    "myAttempts": "My attempts"
+  },
+  "subject": {
+    "loading": "Loading units…",
+    "error": "Failed to load unit info.",
+    "notFound": "Subject not found.",
+    "selectUnit": "Select a unit",
+    "solveAll": "Solve all",
+    "solveAllDesc": "Solve every question in this subject.",
+    "unitQuestionCount": "{{count}} questions",
+    "back": "Subjects"
+  },
+  "quiz": {
+    "loading": "Loading questions…",
+    "preparing": "Preparing questions…",
+    "error": "Failed to load questions.",
+    "empty": "No questions to solve.",
+    "noReview": "No wrong answers to review.",
+    "progress": "{{current}} / {{total}}",
+    "submit": "Submit",
+    "next": "Next question",
+    "finish": "See result",
+    "prev": "Previous",
+    "submitting": "Submitting…",
+    "exit": "Quit",
+    "exitConfirm": "Quit solving? Your progress is saved so you can resume later.",
+    "questionLabel": "Question"
+  },
+  "result": {
+    "title": "Result",
+    "score": "Score",
+    "ratio": "Accuracy",
+    "correctOf": "{{correct}} / {{total}} correct",
+    "byUnit": "Score by unit",
+    "retryWrong": "Retry wrong answers",
+    "noWrong": "No wrong answers. Perfect!",
+    "backToSubjects": "Back to subjects",
+    "reviewMode": "Review"
+  },
+  "me": {
+    "title": "My attempts",
+    "headerBadge": "My history",
+    "description": "See the progress and score of every attempt you've made.",
+    "loading": "Loading history…",
+    "error": "Failed to load attempt history.",
+    "empty": "No attempts yet.",
+    "startSolving": "Start solving",
+    "status": {
+      "in_progress": "In progress",
+      "completed": "Completed"
+    },
+    "mode": {
+      "full": "Full",
+      "review": "Review"
+    },
+    "table": {
+      "subject": "Subject",
+      "unit": "Unit",
+      "mode": "Mode",
+      "status": "Status",
+      "score": "Score",
+      "startedAt": "Started",
+      "actions": "Resume"
+    },
+    "allUnits": "All",
+    "resume": "Resume",
+    "viewResult": "View result"
+  },
+  "openGraph": {
+    "title": "Quiz - Subject-based question practice",
+    "description": "From corrections, criminology, victimology, criminal law, and research methodology to the Engineer Information Processing (정보처리기사) written and practical exams—a free quiz service to solve multiple-choice, short-answer, and code-cloze questions by subject with instant server-side grading and detailed explanations. Supports progress history, resume, and retry-wrong for efficient study.",
+    "keywords": [
+      "quiz",
+      "practice questions",
+      "multiple choice",
+      "short answer",
+      "code cloze",
+      "exam prep",
+      "정보처리기사",
+      "정보처리기사 필기",
+      "정보처리기사 실기",
+      "information processing engineer"
+    ]
+  }
+}

--- a/src/assets/locales/ja/menu.json
+++ b/src/assets/locales/ja/menu.json
@@ -42,6 +42,10 @@
       "title": "ライフ・その他",
       "description": "健康、リズム、軽量ユーティリティや遊び向けツール"
     },
+    "learning": {
+      "title": "学習・クイズ",
+      "description": "科目別の問題演習やクイズで学習"
+    },
     "external": {
       "title": "外部リンク",
       "description": "プロフィールや外部チャンネルへ移動"

--- a/src/assets/locales/ja/solve.json
+++ b/src/assets/locales/ja/solve.json
@@ -1,0 +1,97 @@
+{
+  "title": "問題演習",
+  "description": "矯正学・犯罪学・刑事法から情報処理技士（정보처리기사）の筆記・実技まで、科目別の問題を解いて即時採点と解説を確認しましょう。",
+  "headerBadge": "学習・クイズ",
+  "intro": "ログインして科目を選ぶと問題を解けます。解答履歴・続きから・間違い直しに対応しています。",
+  "subjects": {
+    "loading": "科目を読み込み中…",
+    "error": "科目一覧を読み込めませんでした。",
+    "empty": "まだ登録された科目がありません。",
+    "unitCount": "{{count}}単元",
+    "questionCount": "{{count}}問",
+    "myAttempts": "解答履歴"
+  },
+  "subject": {
+    "loading": "単元を読み込み中…",
+    "error": "単元情報を読み込めませんでした。",
+    "notFound": "科目が見つかりません。",
+    "selectUnit": "単元を選択",
+    "solveAll": "全問を解く",
+    "solveAllDesc": "この科目のすべての問題を解きます。",
+    "unitQuestionCount": "{{count}}問",
+    "back": "科目一覧"
+  },
+  "quiz": {
+    "loading": "問題を読み込み中…",
+    "preparing": "問題を準備中…",
+    "error": "問題を読み込めませんでした。",
+    "empty": "解ける問題がありません。",
+    "noReview": "直す間違いがありません。",
+    "progress": "{{current}} / {{total}}",
+    "submit": "提出",
+    "next": "次の問題",
+    "finish": "結果を見る",
+    "prev": "前へ",
+    "submitting": "提出中…",
+    "exit": "やめる",
+    "exitConfirm": "演習をやめますか？進捗は保存され、続きから再開できます。",
+    "questionLabel": "問題"
+  },
+  "result": {
+    "title": "解答結果",
+    "score": "スコア",
+    "ratio": "正答率",
+    "correctOf": "{{correct}} / {{total}} 正解",
+    "byUnit": "単元別スコア",
+    "retryWrong": "間違いを解き直す",
+    "noWrong": "間違いはありません。完璧です！",
+    "backToSubjects": "科目一覧へ",
+    "reviewMode": "復習"
+  },
+  "me": {
+    "title": "解答履歴",
+    "headerBadge": "履歴",
+    "description": "これまでの解答の進捗とスコアを一覧で確認できます。",
+    "loading": "履歴を読み込み中…",
+    "error": "解答履歴を読み込めませんでした。",
+    "empty": "まだ解答履歴がありません。",
+    "startSolving": "問題を解きに行く",
+    "status": {
+      "in_progress": "進行中",
+      "completed": "完了"
+    },
+    "mode": {
+      "full": "全体",
+      "review": "復習"
+    },
+    "table": {
+      "subject": "科目",
+      "unit": "単元",
+      "mode": "種別",
+      "status": "状態",
+      "score": "スコア",
+      "startedAt": "開始",
+      "actions": "続きから"
+    },
+    "allUnits": "全体",
+    "resume": "続きから",
+    "viewResult": "結果を見る"
+  },
+  "openGraph": {
+    "title": "問題演習 - 科目別の過去問クイズ",
+    "description": "矯正学・犯罪学入門・被害者学・刑事法・研究方法論から情報処理技士（정보처리기사）の筆記・実技まで、科目別の選択式・記述式・コード穴埋め問題を解き、即時のサーバー採点と詳しい解説を確認できる無料の問題演習サービスです。解答履歴・続きから・間違い直しに対応し、効率的に学習できます。",
+    "keywords": [
+      "問題演習",
+      "過去問",
+      "クイズ",
+      "選択式",
+      "記述式",
+      "コード穴埋め",
+      "情報処理",
+      "情報処理技士",
+      "정보처리기사",
+      "정보처리기사 필기",
+      "정보처리기사 실기"
+    ]
+  }
+}

--- a/src/assets/locales/ko/menu.json
+++ b/src/assets/locales/ko/menu.json
@@ -42,6 +42,10 @@
       "title": "라이프/기타",
       "description": "건강, 리듬, 가벼운 유틸리티와 놀이 도구"
     },
+    "learning": {
+      "title": "학습/퀴즈",
+      "description": "과목별 문제풀이와 퀴즈로 학습"
+    },
     "external": {
       "title": "외부 링크",
       "description": "프로필과 외부 채널로 이동"

--- a/src/assets/locales/ko/solve.json
+++ b/src/assets/locales/ko/solve.json
@@ -1,0 +1,97 @@
+{
+  "title": "문제풀이",
+  "description": "교정학·범죄학·형사법부터 정보처리기사 필기·실기까지, 과목별 기출/예상 문제를 풀고 즉시 채점과 해설을 확인하세요.",
+  "headerBadge": "학습/퀴즈",
+  "intro": "로그인 후 과목을 선택해 문제를 풀 수 있어요. 풀이 기록과 이어풀기, 오답 다시 풀기를 지원합니다.",
+  "subjects": {
+    "loading": "과목을 불러오는 중…",
+    "error": "과목 목록을 불러오지 못했어요.",
+    "empty": "아직 등록된 과목이 없어요.",
+    "unitCount": "{{count}}단원",
+    "questionCount": "{{count}}문항",
+    "myAttempts": "내 풀이 기록"
+  },
+  "subject": {
+    "loading": "단원을 불러오는 중…",
+    "error": "단원 정보를 불러오지 못했어요.",
+    "notFound": "과목을 찾을 수 없어요.",
+    "selectUnit": "단원 선택",
+    "solveAll": "전체 풀기",
+    "solveAllDesc": "이 과목의 모든 문항을 풉니다.",
+    "unitQuestionCount": "{{count}}문항",
+    "back": "과목 목록"
+  },
+  "quiz": {
+    "loading": "문제를 불러오는 중…",
+    "preparing": "문제를 준비하는 중…",
+    "error": "문제를 불러오지 못했어요.",
+    "empty": "풀 수 있는 문제가 없어요.",
+    "noReview": "다시 풀 오답이 없어요.",
+    "progress": "{{current}} / {{total}}",
+    "submit": "제출",
+    "next": "다음 문제",
+    "finish": "결과 보기",
+    "prev": "이전",
+    "submitting": "제출 중…",
+    "exit": "그만두기",
+    "exitConfirm": "풀이를 그만둘까요? 진행 상황은 저장돼 이어풀 수 있어요.",
+    "questionLabel": "문항"
+  },
+  "result": {
+    "title": "풀이 결과",
+    "score": "점수",
+    "ratio": "정답률",
+    "correctOf": "{{correct}} / {{total}} 정답",
+    "byUnit": "단원별 점수",
+    "retryWrong": "오답 다시 풀기",
+    "noWrong": "오답이 없어요. 완벽해요!",
+    "backToSubjects": "과목 목록으로",
+    "reviewMode": "오답 복습"
+  },
+  "me": {
+    "title": "내 풀이 기록",
+    "headerBadge": "내 기록",
+    "description": "지금까지 푼 시도의 진행 상황과 점수를 한눈에 확인하세요.",
+    "loading": "기록을 불러오는 중…",
+    "error": "풀이 기록을 불러오지 못했어요.",
+    "empty": "아직 풀이 기록이 없어요.",
+    "startSolving": "문제 풀러 가기",
+    "status": {
+      "in_progress": "진행 중",
+      "completed": "완료"
+    },
+    "mode": {
+      "full": "전체",
+      "review": "오답 복습"
+    },
+    "table": {
+      "subject": "과목",
+      "unit": "단원",
+      "mode": "유형",
+      "status": "상태",
+      "score": "점수",
+      "startedAt": "시작",
+      "actions": "이어풀기"
+    },
+    "allUnits": "전체",
+    "resume": "이어풀기",
+    "viewResult": "결과 보기"
+  },
+  "openGraph": {
+    "title": "문제풀이 - 과목별 기출 문제 퀴즈",
+    "description": "교정학·범죄학입문·피해자학·형사법·연구방법론부터 정보처리기사 필기·실기까지, 과목별 객관식·단답·코드 빈칸 문제를 풀고 즉시 서버 채점과 상세 해설을 확인하는 무료 문제풀이 서비스입니다. 풀이 기록, 이어풀기, 오답 다시 풀기를 지원해 효율적으로 학습할 수 있습니다.",
+    "keywords": [
+      "문제풀이",
+      "기출문제",
+      "퀴즈",
+      "객관식",
+      "단답",
+      "코드 빈칸",
+      "정보처리기사",
+      "정보처리기사 필기",
+      "정보처리기사 실기",
+      "교정학",
+      "형사법"
+    ]
+  }
+}

--- a/src/assets/locales/zh/menu.json
+++ b/src/assets/locales/zh/menu.json
@@ -42,6 +42,10 @@
       "title": "生活与其他",
       "description": "健康、节奏和轻量娱乐类工具"
     },
+    "learning": {
+      "title": "学习/测验",
+      "description": "通过按科目的刷题和测验进行学习"
+    },
     "external": {
       "title": "外部链接",
       "description": "前往个人资料页和外部频道"

--- a/src/assets/locales/zh/solve.json
+++ b/src/assets/locales/zh/solve.json
@@ -1,0 +1,97 @@
+{
+  "title": "刷题",
+  "description": "从矫正学、犯罪学、刑事法到信息处理技师（정보처리기사）笔试·实操，按科目刷题，即时获得评分与解析。",
+  "headerBadge": "学习/测验",
+  "intro": "登录后选择科目即可开始刷题。支持答题记录、继续答题和错题重做。",
+  "subjects": {
+    "loading": "正在加载科目…",
+    "error": "无法加载科目列表。",
+    "empty": "尚未有可用科目。",
+    "unitCount": "{{count}} 个单元",
+    "questionCount": "{{count}} 道题",
+    "myAttempts": "我的答题记录"
+  },
+  "subject": {
+    "loading": "正在加载单元…",
+    "error": "无法加载单元信息。",
+    "notFound": "未找到该科目。",
+    "selectUnit": "选择单元",
+    "solveAll": "全部刷题",
+    "solveAllDesc": "刷该科目的所有题目。",
+    "unitQuestionCount": "{{count}} 道题",
+    "back": "科目列表"
+  },
+  "quiz": {
+    "loading": "正在加载题目…",
+    "preparing": "正在准备题目…",
+    "error": "无法加载题目。",
+    "empty": "没有可刷的题目。",
+    "noReview": "没有需要重做的错题。",
+    "progress": "{{current}} / {{total}}",
+    "submit": "提交",
+    "next": "下一题",
+    "finish": "查看结果",
+    "prev": "上一题",
+    "submitting": "正在提交…",
+    "exit": "退出",
+    "exitConfirm": "要退出刷题吗？进度将被保存，可稍后继续。",
+    "questionLabel": "题目"
+  },
+  "result": {
+    "title": "答题结果",
+    "score": "分数",
+    "ratio": "正确率",
+    "correctOf": "{{correct}} / {{total}} 正确",
+    "byUnit": "各单元得分",
+    "retryWrong": "重做错题",
+    "noWrong": "没有错题，完美！",
+    "backToSubjects": "返回科目列表",
+    "reviewMode": "复习"
+  },
+  "me": {
+    "title": "我的答题记录",
+    "headerBadge": "我的记录",
+    "description": "一目了然地查看每次答题的进度与分数。",
+    "loading": "正在加载记录…",
+    "error": "无法加载答题记录。",
+    "empty": "尚无答题记录。",
+    "startSolving": "去刷题",
+    "status": {
+      "in_progress": "进行中",
+      "completed": "已完成"
+    },
+    "mode": {
+      "full": "全部",
+      "review": "复习"
+    },
+    "table": {
+      "subject": "科目",
+      "unit": "单元",
+      "mode": "类型",
+      "status": "状态",
+      "score": "分数",
+      "startedAt": "开始",
+      "actions": "继续"
+    },
+    "allUnits": "全部",
+    "resume": "继续",
+    "viewResult": "查看结果"
+  },
+  "openGraph": {
+    "title": "刷题 - 按科目的真题测验",
+    "description": "从矫正学、犯罪学入门、被害者学、刑事法、研究方法论到信息处理技师（정보처리기사）笔试·实操，免费刷题服务，按科目刷选择题、简答题和代码填空题，即时获得服务器评分与详细解析。支持答题记录、继续答题和错题重做，助你高效学习。",
+    "keywords": [
+      "刷题",
+      "真题",
+      "测验",
+      "选择题",
+      "简答题",
+      "代码填空",
+      "备考",
+      "信息处理技师",
+      "정보처리기사",
+      "정보처리기사 필기",
+      "정보처리기사 실기"
+    ]
+  }
+}

--- a/src/components/basic/CodeBlock/CodeBlock.stories.tsx
+++ b/src/components/basic/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CodeBlock } from './CodeBlock';
+
+const meta: Meta<typeof CodeBlock> = {
+  title: 'Solve/CodeBlock',
+  component: CodeBlock,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  args: {
+    code: 'public int sum(int[] arr) {\n  int total = 0;\n  for (int v : arr) total += v;\n  return total;\n}',
+    language: 'java',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLanguage: Story = {};
+export const WithoutLanguage: Story = { args: { language: undefined } };

--- a/src/components/basic/CodeBlock/CodeBlock.tsx
+++ b/src/components/basic/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/CodeBlock.tsx — 코드/지문 표시 전용 블록 (oksolve CodeBlock 마이그레이션).
+ *
+ * 입력 없는 읽기전용 블록. 단답 문항의 code 필드 등을 monospace·줄바꿈 보존으로 표시.
+ * prism.css는 .token.* 클래스에만 적용되므로(여기선 plain <code>) 충돌 없음.
+ * 표현만 하므로 'use client' 불필요 → server component 가능.
+ */
+import * as React from 'react';
+import { cn } from '@utils/cn';
+
+export interface CodeBlockProps {
+  /** 표시할 코드/지문 텍스트. */
+  code: string;
+  /** 언어 라벨(상단 칩). 없으면 라벨 미표시. */
+  language?: string;
+  className?: string;
+}
+
+function CodeBlock({ code, language, className }: CodeBlockProps) {
+  return (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-2xl border border-basic-3 bg-basic-2 shadow-sm',
+        className,
+      )}
+    >
+      {language && (
+        <span className="block border-b border-basic-3 px-3.5 py-1.5 text-sm font-semibold lowercase text-fg-5">
+          {language}
+        </span>
+      )}
+      <pre className="m-0 overflow-x-auto px-4 py-4 font-mono text-sm leading-relaxed text-fg-1">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export { CodeBlock };

--- a/src/components/basic/CodeBlock/index.ts
+++ b/src/components/basic/CodeBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './CodeBlock';

--- a/src/components/basic/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/basic/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProgressBar } from './ProgressBar';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'Solve/ProgressBar',
+  component: ProgressBar,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  argTypes: { value: { control: { type: 'range', min: 0, max: 1, step: 0.05 } } },
+  args: { value: 0.4 },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Empty: Story = { args: { value: 0 } };
+export const Full: Story = { args: { value: 1 } };

--- a/src/components/basic/ProgressBar/ProgressBar.tsx
+++ b/src/components/basic/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/ProgressBar.tsx — 진행률 바 (oksolve ProgressBar 마이그레이션).
+ *
+ * 트랙 basic-3 + 채움 point-2 토큰. 채움 폭은 동적 값이라 인라인 width로 주입하고
+ * 200ms width transition. role=progressbar + aria-valuenow로 접근성 보장.
+ * 표현만 하므로 server component 가능.
+ */
+import * as React from 'react';
+import { cn } from '@utils/cn';
+
+export interface ProgressBarProps {
+  /** 진행률 0~1. */
+  value: number;
+  /** 접근성 라벨(기본 "진행률"). */
+  label?: string;
+  className?: string;
+}
+
+function ProgressBar({ value, label = '진행률', className }: ProgressBarProps) {
+  const clamped = Math.min(Math.max(value, 0), 1);
+  const percent = Math.round(clamped * 100);
+
+  return (
+    <div
+      className={cn('relative h-1.5 w-full overflow-hidden rounded-full bg-basic-3', className)}
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percent}
+    >
+      <div
+        className="h-full rounded-full bg-point-2 transition-[width] duration-200 ease-out"
+        style={{ width: `${clamped * 100}%` }}
+      />
+    </div>
+  );
+}
+
+export { ProgressBar };

--- a/src/components/basic/ProgressBar/index.ts
+++ b/src/components/basic/ProgressBar/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgressBar';

--- a/src/components/basic/ScoreRing/ScoreRing.stories.tsx
+++ b/src/components/basic/ScoreRing/ScoreRing.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ScoreRing } from './ScoreRing';
+
+const meta: Meta<typeof ScoreRing> = {
+  title: 'Solve/ScoreRing',
+  component: ScoreRing,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: { correct: 7, total: 10 },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Perfect: Story = { args: { correct: 10, total: 10 } };
+export const Zero: Story = { args: { correct: 0, total: 10 } };
+export const Empty: Story = { args: { correct: 0, total: 0 } };

--- a/src/components/basic/ScoreRing/ScoreRing.tsx
+++ b/src/components/basic/ScoreRing/ScoreRing.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable react/require-default-props */
+
+/*
+ * solve/ScoreRing.tsx — 총점 도넛 링 (oksolve ScoreRing 마이그레이션).
+ *
+ * conic-gradient로 정답 비율을 채우는 도넛. 채움 = point-2 토큰, 트랙 = basic-3 토큰,
+ * 가운데 구멍 = basic-0 토큰. 마운트 시 solve-ring-sweep로 0→비율 보간(@property).
+ * 중앙 숫자 = 정답 수, 캡션 = "/ 총문항".
+ *
+ * 동적 비율(--score)은 인라인 CSS 변수로 주입(plan: "--score 변수 주입 방식 유지").
+ * conic-gradient는 토큰 CSS 변수를 직접 참조 → 다크모드 자동 대응.
+ * 표현만 하므로 server component 가능.
+ */
+import * as React from 'react';
+import { cn } from '@utils/cn';
+
+export interface ScoreRingProps {
+  /** 정답 문항 수. */
+  correct: number;
+  /** 전체 문항 수. */
+  total: number;
+  className?: string;
+}
+
+function ScoreRing({ correct, total, className }: ScoreRingProps) {
+  const ratio = total > 0 ? correct / total : 0;
+  const style = {
+    '--score': ratio,
+    '--solve-fill': `calc(var(--score) * 360deg)`,
+    background: 'conic-gradient(var(--point-2) var(--solve-fill), var(--basic-3) 0)',
+  } as React.CSSProperties;
+
+  return (
+    <div
+      className={cn(
+        'solve-score-ring relative mx-auto flex aspect-square items-center justify-center rounded-full',
+        'w-[clamp(180px,56vw,232px)]',
+        // 가운데 구멍(도넛): basic-0 토큰 + shadow-sm
+        'before:absolute before:inset-3.5 before:rounded-full before:bg-basic-0 before:shadow-sm before:content-[""]',
+        'motion-safe:animate-[solve-ring-sweep_600ms_ease_both]',
+        className,
+      )}
+      style={style}
+      role="img"
+      aria-label={`총 ${total}문항 중 ${correct}문항 정답`}
+    >
+      <span className="relative z-[1] text-5xl font-black leading-none tracking-tight tabular-nums text-fg-1">
+        {correct}
+      </span>
+      <span className="absolute bottom-[clamp(34px,12vw,48px)] z-[1] text-sm font-semibold tabular-nums text-fg-5">
+        / {total}
+      </span>
+    </div>
+  );
+}
+
+export { ScoreRing };

--- a/src/components/basic/ScoreRing/index.ts
+++ b/src/components/basic/ScoreRing/index.ts
@@ -1,0 +1,1 @@
+export * from './ScoreRing';

--- a/src/generated/commandPalettePages.ts
+++ b/src/generated/commandPalettePages.ts
@@ -649,6 +649,26 @@ export const commandPalettePages = {
       }
     },
     {
+      "path": "/solve",
+      "access": "public",
+      "titles": {
+        "ko": "문제풀이 - 과목별 기출 문제 퀴즈",
+        "en": "Quiz - Subject-based question practice",
+        "ja": "問題演習 - 科目別の過去問クイズ",
+        "zh": "刷题 - 按科目的真题测验"
+      },
+      "descriptions": {
+        "ko": "교정학·범죄학입문·피해자학·형사법·연구방법론부터 정보처리기사 필기·실기까지, 과목별 객관식·단답·코드 빈칸 문제를 풀고 즉시 서버 채점과 상세 해설을 확인하는 무료 문제풀이 서비스입니다. 풀이 기록, 이어풀기, 오답 다시 풀기를 지원해 효율적으로 학습할 수 있습니다.",
+        "en": "From corrections, criminology, victimology, criminal law, and research methodology to the Engineer Information Processing (정보처리기사) written and practical exams—a free quiz service to solve multiple-choice, short-answer, and code-cloze questions by subject with instant server-side grading and detailed explanations. Supports progress history, resume, and retry-wrong for efficient study.",
+        "ja": "矯正学・犯罪学入門・被害者学・刑事法・研究方法論から情報処理技士（정보처리기사）の筆記・実技まで、科目別の選択式・記述式・コード穴埋め問題を解き、即時のサーバー採点と詳しい解説を確認できる無料の問題演習サービスです。解答履歴・続きから・間違い直しに対応し、効率的に学習できます。",
+        "zh": "从矫正学、犯罪学入门、被害者学、刑事法、研究方法论到信息处理技师（정보처리기사）笔试·实操，免费刷题服务，按科目刷选择题、简答题和代码填空题，即时获得服务器评分与详细解析。支持答题记录、继续答题和错题重做，助你高效学习。"
+      }
+    },
+    {
+      "path": "/solve/me",
+      "access": "public"
+    },
+    {
       "path": "/stopwatch",
       "access": "public",
       "titles": {

--- a/src/queries/__tests__/useSolveQueries.test.ts
+++ b/src/queries/__tests__/useSolveQueries.test.ts
@@ -1,0 +1,265 @@
+/**
+ * useSolveQueries: Solve 도메인 React Query 훅 단위 테스트.
+ *
+ * solveApi 와 UserTokenUtil 을 mock 하여 훅 동작만 검증한다(네트워크/서버 무관).
+ * 핵심: queryKey 구성, enabled 게이트, mutation 성공 시 캐시 invalidate 대상,
+ *       토큰 명시 전달(인터셉터 이중 안전과 별개로 훅이 auth() 를 명시 전달).
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import UserTokenUtil from '@utils/userTokenUtil';
+import { solveApi } from '@api';
+import {
+  SOLVE_KEYS,
+  SOLVE_QUESTIONS_PAGE_SIZE,
+  SOLVE_ATTEMPTS_PAGE_SIZE,
+  useSubjects,
+  useSubjectDetail,
+  useQuestions,
+  useResumeAttempt,
+  useStartAttempt,
+  useSubmitAnswer,
+  useFinishAttempt,
+  useMyAttempts,
+} from '../useSolveQueries';
+
+vi.mock('@api', () => ({
+  solveApi: {
+    getSolveSubjects: vi.fn(),
+    getSolveProgress: vi.fn(),
+    getSolveSubjectDetail: vi.fn(),
+    getSolveQuestions: vi.fn(),
+    postSolveAttempt: vi.fn(),
+    getSolveAttemptDetail: vi.fn(),
+    postSolveSubmission: vi.fn(),
+    postSolveAttemptFinish: vi.fn(),
+    getSolveAttemptsMe: vi.fn(),
+  },
+}));
+
+vi.mock('@utils/userTokenUtil', () => ({
+  default: { getAccessToken: vi.fn() },
+}));
+
+const m = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+const token = () => UserTokenUtil.getAccessToken as ReturnType<typeof vi.fn>;
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return { Wrapper, queryClient };
+}
+
+beforeEach(() => {
+  Object.values(solveApi).forEach((fn) => m(fn).mockReset());
+  token().mockReset();
+  token().mockReturnValue('tok-1');
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('SOLVE_KEYS', () => {
+  it('계층적 queryKey 를 안정적으로 구성한다', () => {
+    expect(SOLVE_KEYS.all).toEqual(['solve']);
+    expect(SOLVE_KEYS.subjects()).toEqual(['solve', 'subjects']);
+    expect(SOLVE_KEYS.progress()).toEqual(['solve', 'progress']);
+    expect(SOLVE_KEYS.subjectDetail('gyojeonghak')).toEqual(['solve', 'subject', 'gyojeonghak']);
+    expect(SOLVE_KEYS.questions('s', '001', 0, 100)).toEqual([
+      'solve',
+      'questions',
+      's',
+      '001',
+      0,
+      100,
+    ]);
+    // unitId 미지정 시 null 정규화
+    expect(SOLVE_KEYS.questions('s')).toEqual(['solve', 'questions', 's', null, null, null]);
+    expect(SOLVE_KEYS.attempts()).toEqual(['solve', 'attempts']);
+    expect(SOLVE_KEYS.attemptList(2, 20)).toEqual(['solve', 'attempts', 'list', 2, 20]);
+    expect(SOLVE_KEYS.attempt(7)).toEqual(['solve', 'attempts', 'detail', 7]);
+  });
+
+  it('페이지 사이즈 상수는 서버 cap 과 일치한다', () => {
+    expect(SOLVE_QUESTIONS_PAGE_SIZE).toBe(100);
+    expect(SOLVE_ATTEMPTS_PAGE_SIZE).toBe(20);
+  });
+});
+
+describe('useSubjects', () => {
+  it('로그인 시 토큰을 전달해 getSolveSubjects 를 호출하고 data 반환', async () => {
+    m(solveApi.getSolveSubjects).mockResolvedValue({ data: [{ slug: 'a' }] });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSubjects(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveSubjects).toHaveBeenCalledWith('tok-1');
+    expect(result.current.data).toEqual([{ slug: 'a' }]);
+  });
+
+  it('비회원(토큰 없음)이면 authorization 없이(undefined) 호출한다 — 공개 endpoint', async () => {
+    token().mockReturnValue('');
+    m(solveApi.getSolveSubjects).mockResolvedValue({ data: [{ slug: 'a' }] });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSubjects(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveSubjects).toHaveBeenCalledWith(undefined);
+  });
+
+  it('enabled=false 면 호출하지 않는다', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSubjects(false), { wrapper: Wrapper });
+    await new Promise((r) => {
+      setTimeout(r, 30);
+    });
+    expect(solveApi.getSolveSubjects).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useSubjectDetail', () => {
+  it('slug 가 빈 문자열이면 enabled:false (호출 안 함)', async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useSubjectDetail(''), { wrapper: Wrapper });
+    await new Promise((r) => {
+      setTimeout(r, 30);
+    });
+    expect(solveApi.getSolveSubjectDetail).not.toHaveBeenCalled();
+  });
+
+  it('로그인 시 slug 가 있으면 (slug, token) 으로 호출', async () => {
+    m(solveApi.getSolveSubjectDetail).mockResolvedValue({ data: { slug: 'x', units: [] } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSubjectDetail('x'), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveSubjectDetail).toHaveBeenCalledWith('x', 'tok-1');
+  });
+
+  it('비회원(토큰 없음)이면 (slug, undefined) 로 호출한다 — 공개 endpoint', async () => {
+    token().mockReturnValue('');
+    m(solveApi.getSolveSubjectDetail).mockResolvedValue({ data: { slug: 'x', units: [] } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSubjectDetail('x'), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveSubjectDetail).toHaveBeenCalledWith('x', undefined);
+  });
+});
+
+describe('useQuestions', () => {
+  it('(slug, token, unitId, page, limit) 순서로 호출한다', async () => {
+    m(solveApi.getSolveQuestions).mockResolvedValue({ data: { results: [] } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useQuestions('s', '001', 1, 50), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveQuestions).toHaveBeenCalledWith('s', 'tok-1', '001', 1, 50);
+  });
+
+  it('slug 없으면 호출 안 함', async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useQuestions(''), { wrapper: Wrapper });
+    await new Promise((r) => {
+      setTimeout(r, 30);
+    });
+    expect(solveApi.getSolveQuestions).not.toHaveBeenCalled();
+  });
+});
+
+describe('useResumeAttempt', () => {
+  it('id 가 null 이면 enabled:false', async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useResumeAttempt(null), { wrapper: Wrapper });
+    await new Promise((r) => {
+      setTimeout(r, 30);
+    });
+    expect(solveApi.getSolveAttemptDetail).not.toHaveBeenCalled();
+  });
+
+  it('id 가 0 이하면 enabled:false (신규 attempt 미확보)', async () => {
+    const { Wrapper } = makeWrapper();
+    renderHook(() => useResumeAttempt(0), { wrapper: Wrapper });
+    await new Promise((r) => {
+      setTimeout(r, 30);
+    });
+    expect(solveApi.getSolveAttemptDetail).not.toHaveBeenCalled();
+  });
+
+  it('유효 id 면 (id, token) 으로 상세 조회', async () => {
+    m(solveApi.getSolveAttemptDetail).mockResolvedValue({ data: { attempt: { id: 5 } } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useResumeAttempt(5), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveAttemptDetail).toHaveBeenCalledWith(5, 'tok-1');
+  });
+});
+
+describe('useStartAttempt', () => {
+  it('마운트 시 postSolveAttempt 로 시작/재개하고 결과를 data 로 노출한다 (query)', async () => {
+    m(solveApi.postSolveAttempt).mockResolvedValue({ data: { id: 1 } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useStartAttempt({ subjectSlug: 's', mode: 'full' } as never),
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.postSolveAttempt).toHaveBeenCalledWith('tok-1', {
+      subjectSlug: 's',
+      mode: 'full',
+    });
+    expect(result.current.data).toEqual({ id: 1 });
+  });
+});
+
+describe('useSubmitAnswer', () => {
+  it('성공 시 attempt + progress 캐시를 invalidate 한다', async () => {
+    m(solveApi.postSolveSubmission).mockResolvedValue({ data: { isCorrect: true } });
+    const { Wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSubmitAnswer(42), { wrapper: Wrapper });
+    act(() => {
+      result.current.mutate({ questionId: 1, index: 0, choice: 2 } as never);
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.postSolveSubmission).toHaveBeenCalledWith(42, 'tok-1', {
+      questionId: 1,
+      index: 0,
+      choice: 2,
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SOLVE_KEYS.attempt(42) });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SOLVE_KEYS.progress() });
+  });
+});
+
+describe('useFinishAttempt', () => {
+  it('성공 시 attempt + attempts + progress 를 invalidate 한다', async () => {
+    m(solveApi.postSolveAttemptFinish).mockResolvedValue({ data: { total: 5, correct: 3 } });
+    const { Wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useFinishAttempt(7), { wrapper: Wrapper });
+    act(() => {
+      result.current.mutate();
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.postSolveAttemptFinish).toHaveBeenCalledWith(7, 'tok-1');
+    expect(spy).toHaveBeenCalledWith({ queryKey: SOLVE_KEYS.attempt(7) });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SOLVE_KEYS.attempts() });
+    expect(spy).toHaveBeenCalledWith({ queryKey: SOLVE_KEYS.progress() });
+  });
+});
+
+describe('useMyAttempts', () => {
+  it('(token, page, limit) 으로 호출하고 default limit 은 20', async () => {
+    m(solveApi.getSolveAttemptsMe).mockResolvedValue({ data: { results: [] } });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useMyAttempts(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(solveApi.getSolveAttemptsMe).toHaveBeenCalledWith('tok-1', 0, SOLVE_ATTEMPTS_PAGE_SIZE);
+  });
+});

--- a/src/queries/useSolveQueries.ts
+++ b/src/queries/useSolveQueries.ts
@@ -1,0 +1,172 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { solveApi } from '@api';
+import type { SolveCreateAttemptRequest, SolveSubmissionRequest } from '@api/Solve';
+import UserTokenUtil from '@utils/userTokenUtil';
+
+/*
+ * useSolveQueries — Solve(문제풀이) 서버 상태 훅.
+ *
+ * 공개(비회원 허용): getSolveSubjects, getSolveSubjectDetail — 목록/단원 메타. 토큰 optional.
+ * 보호(로그인 필수): progress / questions / attempts 계열. authorization 인자로 토큰 전달.
+ * 어느 경우든 axios 인터셉터가 Authorization 헤더 주입 + 401 refresh 를 한 번 더 보장한다
+ * (ShortUrl/BlogReply 동일 패턴). 단, 보호 훅을 비회원이 호출하면 401→logoutAndLogin 으로
+ * 로그인 리다이렉트되므로, 호출 측에서 enabled(로그인 여부)로 게이팅해야 한다(useSolveProgress).
+ * 채점은 서버가 수행하므로 프론트는 응답(SolveSubmissionResult/SolveQuizResult)을 그대로 사용한다.
+ */
+
+export const SOLVE_KEYS = {
+  all: ['solve'] as const,
+  subjects: () => [...SOLVE_KEYS.all, 'subjects'] as const,
+  progress: () => [...SOLVE_KEYS.all, 'progress'] as const,
+  subjectDetail: (slug: string) => [...SOLVE_KEYS.all, 'subject', slug] as const,
+  questions: (slug: string, unitId?: string, page?: number, limit?: number) =>
+    [...SOLVE_KEYS.all, 'questions', slug, unitId ?? null, page ?? null, limit ?? null] as const,
+  attempts: () => [...SOLVE_KEYS.all, 'attempts'] as const,
+  attemptList: (page?: number, limit?: number) =>
+    [...SOLVE_KEYS.attempts(), 'list', page ?? null, limit ?? null] as const,
+  attempt: (id: number) => [...SOLVE_KEYS.attempts(), 'detail', id] as const,
+};
+
+// 서버 cap 과 동일(spec: questions/attempts limit max 100).
+export const SOLVE_QUESTIONS_PAGE_SIZE = 100;
+export const SOLVE_ATTEMPTS_PAGE_SIZE = 20;
+
+const auth = () => UserTokenUtil.getAccessToken();
+// 공개(비회원 허용) endpoint 용. 토큰이 없으면 빈 문자열 대신 undefined 를 넘겨
+// Authorization 헤더 자체를 보내지 않는다(빈 헤더 방지). 토큰이 있으면 그대로 동봉한다.
+const optionalAuth = () => auth() || undefined;
+
+// 과목 목록(사용자 무관 메타). 공개 endpoint — 비회원도 200(메타데이터만).
+export const useSubjects = (enabled = true) =>
+  useQuery({
+    queryKey: SOLVE_KEYS.subjects(),
+    queryFn: async () => {
+      const { data } = await solveApi.getSolveSubjects(optionalAuth());
+      return data;
+    },
+    enabled,
+  });
+
+// 호출자별 과목 진행률(서버 derived). subjects 와 분리해 메타 캐시성 유지.
+export const useSolveProgress = (enabled = true) =>
+  useQuery({
+    queryKey: SOLVE_KEYS.progress(),
+    queryFn: async () => {
+      const { data } = await solveApi.getSolveProgress(auth());
+      return data;
+    },
+    enabled,
+  });
+
+// 과목 상세(단원 + 각 단원 questionCount). 공개 endpoint — 비회원도 200.
+export const useSubjectDetail = (slug: string, enabled = true) =>
+  useQuery({
+    queryKey: SOLVE_KEYS.subjectDetail(slug),
+    queryFn: async () => {
+      const { data } = await solveApi.getSolveSubjectDetail(slug, optionalAuth());
+      return data;
+    },
+    enabled: enabled && !!slug,
+  });
+
+// 공개 문항 페이지(정답/해설 미포함). pilgi 대비 페이지네이션.
+export const useQuestions = (
+  slug: string,
+  unitId?: string,
+  page = 0,
+  limit = SOLVE_QUESTIONS_PAGE_SIZE,
+  enabled = true,
+) =>
+  useQuery({
+    queryKey: SOLVE_KEYS.questions(slug, unitId, page, limit),
+    queryFn: async () => {
+      const { data } = await solveApi.getSolveQuestions(slug, auth(), unitId, page, limit);
+      return data;
+    },
+    enabled: enabled && !!slug,
+    placeholderData: keepPreviousData,
+  });
+
+// 시도 시작/재개: in_progress 있으면 서버가 재사용(200), 없으면 생성(201). 둘 다 SolveAttempt.
+// POST 지만 멱등(서버가 동일 scope in_progress 재사용)이라 useQuery 로 모델링한다.
+// ⚠️ mutation 을 마운트 useEffect 에서 호출하면 StrictMode 가 클라이언트 네비게이션 시
+//    마운트 effect 를 setup→cleanup→setup 으로 2회 호출하면서 in-flight mutation 이 고아가 돼
+//    observer 가 영구 pending → "준비 중"에 멈추는 버그가 있었다(전체 새로고침=hydration 은
+//    effect 1회라 무사). query 는 StrictMode/동시성에 안전하다.
+//    queryKey 는 attempts() 하위가 아닌 별도 네임스페이스('start-attempt')라 제출/완료의
+//    invalidateQueries(attempts()) prefix 에 걸리지 않아 풀이 중 재-POST(중복 시도)가 없다.
+export const useStartAttempt = (params: SolveCreateAttemptRequest, enabled = true) =>
+  useQuery({
+    queryKey: [
+      ...SOLVE_KEYS.all,
+      'start-attempt',
+      params.subjectSlug,
+      params.unitId ?? null,
+      params.mode,
+      params.sourceAttemptId ?? null,
+    ],
+    queryFn: async () => {
+      const { data } = await solveApi.postSolveAttempt(auth(), params);
+      return data;
+    },
+    enabled,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+// 이어풀기: 시도 헤더 + 이전 제출 결과(복원). attemptId 가 유효할 때만.
+export const useResumeAttempt = (id: number | null, enabled = true) =>
+  useQuery({
+    queryKey: id != null ? SOLVE_KEYS.attempt(id) : SOLVE_KEYS.attempts(),
+    queryFn: async () => {
+      const { data } = await solveApi.getSolveAttemptDetail(id as number, auth());
+      return data;
+    },
+    enabled: enabled && id != null && id > 0,
+  });
+
+// 문항 제출(서버 채점). 멱등 재제출은 서버가 기존 결과 반환. 성공 시 attempt/progress 무효화.
+export const useSubmitAnswer = (attemptId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: SolveSubmissionRequest) => {
+      const { data } = await solveApi.postSolveSubmission(attemptId, auth(), payload);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SOLVE_KEYS.attempt(attemptId) });
+      queryClient.invalidateQueries({ queryKey: SOLVE_KEYS.progress() });
+    },
+  });
+};
+
+// 시도 완료 처리 + 결과 집계. 이미 완료된 시도는 서버가 현재 결과 반환(멱등).
+export const useFinishAttempt = (attemptId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await solveApi.postSolveAttemptFinish(attemptId, auth());
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SOLVE_KEYS.attempt(attemptId) });
+      queryClient.invalidateQueries({ queryKey: SOLVE_KEYS.attempts() });
+      queryClient.invalidateQueries({ queryKey: SOLVE_KEYS.progress() });
+    },
+  });
+};
+
+// 내 시도 목록(기록).
+export const useMyAttempts = (page = 0, limit = SOLVE_ATTEMPTS_PAGE_SIZE, enabled = true) =>
+  useQuery({
+    queryKey: SOLVE_KEYS.attemptList(page, limit),
+    queryFn: async () => {
+      const { data } = await solveApi.getSolveAttemptsMe(auth(), page, limit);
+      return data;
+    },
+    enabled,
+    placeholderData: keepPreviousData,
+  });

--- a/src/spec/api/index.ts
+++ b/src/spec/api/index.ts
@@ -8,6 +8,7 @@ import { BlogReplyApi } from './BlogReply';
 import { CopykillerApi } from './Copykiller';
 import { SessionApi } from './Session';
 import { ShortUrlApi } from './ShortUrl';
+import { SolveApi } from './Solve';
 import { StorageApi } from './Storage';
 import { UserApi } from './User';
 
@@ -82,6 +83,7 @@ export const blogReplyApi = new BlogReplyApi(undefined, API_URL, apiInstance);
 export const copykillerApi = new CopykillerApi(undefined, API_URL, apiInstance);
 export const sessionApi = new SessionApi(undefined, API_URL, apiInstance);
 export const shortUrlApi = new ShortUrlApi(undefined, API_URL, apiInstance);
+export const solveApi = new SolveApi(undefined, API_URL, apiInstance);
 export const storageApi = new StorageApi(undefined, API_URL, apiInstance);
 export const userApi = new UserApi(undefined, API_URL, apiInstance);
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -482,3 +482,45 @@ table {
     color: var(--status-neutral-fg);
   }
 }
+
+/* =========================================================================
+ * solve 도메인 모션 토큰 (components/solve)
+ *  - ScoreRing conic 채움 보간 + 마운트 스윕
+ *  - 문항/패널 진입 애니메이션
+ *  - prefers-reduced-motion 존중
+ * ========================================================================= */
+@property --solve-fill {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes solve-ring-sweep {
+  from {
+    --solve-fill: 0deg;
+  }
+}
+
+@keyframes solve-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-solve-enter {
+  animation: solve-enter 200ms ease both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-solve-enter {
+    animation: none;
+  }
+  .solve-score-ring {
+    animation: none !important;
+  }
+}

--- a/src/utils/__tests__/cloze.test.ts
+++ b/src/utils/__tests__/cloze.test.ts
@@ -1,0 +1,97 @@
+/**
+ * cloze.ts — parseCloze / clozeMarkerIds 단위 테스트.
+ *
+ * oksolve src/lib/cloze.ts 의 1:1 포팅본이므로 마커 규약({{blankId}})·세그먼트 분해·
+ * id 수집을 빠짐없이 검증한다. 채점 로직은 서버 담당이라 여기서 다루지 않는다.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseCloze, clozeMarkerIds } from '@utils/cloze';
+
+describe('parseCloze', () => {
+  it('마커가 없으면 단일 text 세그먼트', () => {
+    expect(parseCloze('plain text only')).toEqual([{ kind: 'text', value: 'plain text only' }]);
+  });
+
+  it('빈 문자열은 빈 배열', () => {
+    expect(parseCloze('')).toEqual([]);
+  });
+
+  it('text + blank + text 순서로 분해한다', () => {
+    expect(parseCloze('x = {{b1}};')).toEqual([
+      { kind: 'text', value: 'x = ' },
+      { kind: 'blank', blankId: 'b1' },
+      { kind: 'text', value: ';' },
+    ]);
+  });
+
+  it('선두 마커는 앞 text 세그먼트를 만들지 않는다', () => {
+    expect(parseCloze('{{b1}} rest')).toEqual([
+      { kind: 'blank', blankId: 'b1' },
+      { kind: 'text', value: ' rest' },
+    ]);
+  });
+
+  it('연속 마커 사이 빈 텍스트는 생략한다', () => {
+    expect(parseCloze('{{b1}}{{b2}}')).toEqual([
+      { kind: 'blank', blankId: 'b1' },
+      { kind: 'blank', blankId: 'b2' },
+    ]);
+  });
+
+  it('여러 빈칸이 섞인 코드 템플릿을 정확히 분해한다', () => {
+    expect(parseCloze('System.out.{{m}}(x); return {{v}};')).toEqual([
+      { kind: 'text', value: 'System.out.' },
+      { kind: 'blank', blankId: 'm' },
+      { kind: 'text', value: '(x); return ' },
+      { kind: 'blank', blankId: 'v' },
+      { kind: 'text', value: ';' },
+    ]);
+  });
+
+  it('blankId 에 언더스코어/숫자 허용', () => {
+    expect(parseCloze('{{blank_1}}')).toEqual([{ kind: 'blank', blankId: 'blank_1' }]);
+  });
+
+  it('단일 중괄호는 마커가 아니라 텍스트로 취급한다', () => {
+    // 일반 코드의 단일 { 와 충돌하지 않아야 한다.
+    expect(parseCloze('if (x) { return {{r}}; }')).toEqual([
+      { kind: 'text', value: 'if (x) { return ' },
+      { kind: 'blank', blankId: 'r' },
+      { kind: 'text', value: '; }' },
+    ]);
+  });
+
+  it('연속 호출에도 결과가 안정적이다(lastIndex 공유 방어)', () => {
+    const t = 'a {{b1}} c';
+    const first = parseCloze(t);
+    const second = parseCloze(t);
+    expect(first).toEqual(second);
+  });
+
+  it('개행을 포함한 멀티라인 템플릿을 보존한다', () => {
+    expect(parseCloze('line1\n{{b1}}\nline2')).toEqual([
+      { kind: 'text', value: 'line1\n' },
+      { kind: 'blank', blankId: 'b1' },
+      { kind: 'text', value: '\nline2' },
+    ]);
+  });
+});
+
+describe('clozeMarkerIds', () => {
+  it('템플릿의 모든 마커 id 를 순서대로 수집한다', () => {
+    expect(clozeMarkerIds('{{a}} x {{b}} y {{c}}')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('마커가 없으면 빈 배열', () => {
+    expect(clozeMarkerIds('no markers here')).toEqual([]);
+  });
+
+  it('중복 마커 id 도 등장 순서대로 모두 포함한다', () => {
+    expect(clozeMarkerIds('{{a}}{{a}}')).toEqual(['a', 'a']);
+  });
+
+  it('연속 호출에도 안정적이다', () => {
+    expect(clozeMarkerIds('{{x}}{{y}}')).toEqual(['x', 'y']);
+    expect(clozeMarkerIds('{{x}}{{y}}')).toEqual(['x', 'y']);
+  });
+});

--- a/src/utils/cloze.ts
+++ b/src/utils/cloze.ts
@@ -1,0 +1,45 @@
+/*
+ * cloze.ts — 코드/지문 빈칸 템플릿 파서 (oksolve src/lib/cloze.ts 포팅, 렌더 전용).
+ *
+ * 마커 규약: {{blankId}} (이중 중괄호). blankId는 영숫자+언더스코어만 허용.
+ * 채점은 백엔드가 하므로 grade 관련 로직은 포팅하지 않는다(렌더용 parse/markerIds만).
+ *
+ * NOTE(ui-component-designer): solve/ClozeBlock이 직접 의존하므로 컴파일·Storybook을 위해
+ * 이 파일을 생성했다. 계획서 §4.4상 이 유틸의 owner는 nextjs-frontend-engineer이며,
+ * 시그니처는 그대로 유지하면 된다(아래 export 2개).
+ */
+
+// 전역 플래그 정규식 — 호출마다 새 RegExp를 만들어 lastIndex 공유를 피한다.
+const CLOZE_MARKER = /\{\{([A-Za-z0-9_]+)\}\}/g;
+
+export type ClozeSegment = { kind: 'text'; value: string } | { kind: 'blank'; blankId: string };
+
+/** 템플릿을 텍스트/빈칸 세그먼트 배열로 분해한다. 마커 사이 빈 텍스트는 생략. */
+export function parseCloze(template: string): ClozeSegment[] {
+  const segments: ClozeSegment[] = [];
+  let lastIndex = 0;
+  const re = new RegExp(CLOZE_MARKER.source, 'g');
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = re.exec(template)) !== null) {
+    if (m.index > lastIndex) {
+      segments.push({ kind: 'text', value: template.slice(lastIndex, m.index) });
+    }
+    segments.push({ kind: 'blank', blankId: m[1] });
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < template.length) {
+    segments.push({ kind: 'text', value: template.slice(lastIndex) });
+  }
+  return segments;
+}
+
+/** 템플릿에 등장하는 마커 id 집합. blanks[].id 일치 검증에 쓴다. */
+export function clozeMarkerIds(template: string): string[] {
+  const ids: string[] = [];
+  const re = new RegExp(CLOZE_MARKER.source, 'g');
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = re.exec(template)) !== null) ids.push(m[1]);
+  return ids;
+}


### PR DESCRIPTION
## 개요
oksolve 퀴즈앱을 okdohyuk 정식 **Solve(문제풀이)** 서비스로 이식 — 프론트 계층.
선행 PR: okdohyuk-api-spec#33 · okdohyuk-api#171 (머지 후 `yarn generate-api --name=Solve`로 클라이언트 생성 — `scripts/build.sh`에 반영됨)

## 변경
- **라우트** `(mobile)/solve/`: 과목 목록 → 단원 → 풀이(QuizClient) → 결과 → 내 기록.
- **컴포넌트** `components/solve/`: ChoiceButton·ShortAnswerInput·ClozeBlock·CodeBlock·ExplanationPanel·ScoreRing·ProgressBar·SubjectCard (cva+cn+토큰).
- **훅** `useSolveQueries.ts`, 유틸 `utils/cloze.ts`.
- **인증 게이트**: 목록(subjects/units) 공개, 풀이 진입(quiz)·기록(me)은 서버 가드로 로그인. 진행률은 로그인 시에만 호출.
- **등록**: `learning` 서비스 섹션 + `/solve` 메뉴 + 4개국어 `solve.json`. `scripts/build.sh`에 Solve client 생성 추가.
- **광고**: 과목 목록·단원·결과·기록 하단에 in-content `GoogleAd`(풀이 문항 영역 제외).
- **OG/SEO**: 설명에 실제 과목(교정학·형사법·정보처리기사 필기/실기 등) 자연 삽입 + keywords 보강.

## 주요 수정
- **SPA 네비게이션 버그**: 마운트 effect의 mutation이 StrictMode 클라이언트 이동 시 고아가 돼 "준비 중"에 멈추던 문제 → 시작/재개를 `useQuery`로 모델링(멱등).
- 다중 페이지(pilgi 1,786) 경계에서 `attempt.total` 기준 progressive 로딩.

## 검증
- `tsc --noEmit` 0 · eslint 0 · vitest solve 스위트 통과 · `next build` 성공.
- 브라우저(playwright): 비회원 목록 열람(401 0건)·풀이 클릭→로그인·로그인 풀이/이어풀기·광고 노출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)