### PR TITLE
feat: 코드 정답 textarea 입력 + 풀이 화면 이전/다음 자유 이동

### DIFF
--- a/src/app/[lng]/(mobile)/solve/[slug]/quiz/QuizClient.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/quiz/QuizClient.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import { Loader2, ArrowLeft } from 'lucide-react';
+import { Loader2, ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Text } from '@components/basic/Text';
 import { Button } from '@components/basic/Button';
 import Skeleton from '@components/basic/Skeleton';
@@ -205,43 +205,53 @@ export default function QuizClient({ lng, slug, unitId, mode, sourceAttemptId }:
   }, [index, loadedQuestions.length, allPagesLoaded, questionPage, isReview, total]);
 
   const current = questions[index];
-  const currentResult = current ? submittedById.get(current.id) : undefined;
 
-  // 방금 제출한 결과(낙관적 표시). 복원 결과와 합쳐 표시.
-  const [justResult, setJustResult] = React.useState<SolveSubmissionResult | null>(null);
-  const [justSubmitted, setJustSubmitted] = React.useState<{
-    choice?: number;
-    text?: string;
-    blanks?: ClozeBlankValue[];
-  } | null>(null);
-  const displayResult = justResult ?? currentResult;
+  // 문항별 채점 결과/제출값을 로컬에 누적 → 이전/다음으로 자유 이동해도 채점 상태가 유지된다(oksolve 방식).
+  const [localResults, setLocalResults] = React.useState<Map<number, SolveSubmissionResult>>(
+    () => new Map(),
+  );
+  const [localAnswers, setLocalAnswers] = React.useState<
+    Map<number, { choice?: number; text?: string; blanks?: ClozeBlankValue[] }>
+  >(() => new Map());
+
+  // 현재 문항: 로컬 누적(방금/이전 제출) 우선, 없으면 서버 복원(detail.submissions).
+  const currentResult = current
+    ? (localResults.get(current.id) ?? submittedById.get(current.id))
+    : undefined;
+  const currentAnswer = current ? localAnswers.get(current.id) : undefined;
+  const displayResult = currentResult;
 
   // 5) 제출
   const submitAnswer = useSubmitAnswer(attemptId ?? 0);
   const submit = (payload: Pick<SolveSubmissionRequest, 'choice' | 'text' | 'blanks'>) => {
     if (!current || attemptId == null || displayResult) return;
-    setJustSubmitted({
-      choice: payload.choice ?? undefined,
-      text: payload.text ?? undefined,
-      blanks: (payload.blanks ?? undefined)?.map((b) => ({ blankId: b.blankId, value: b.value })),
-    });
+    const qid = current.id;
+    setLocalAnswers((m) =>
+      new Map(m).set(qid, {
+        choice: payload.choice ?? undefined,
+        text: payload.text ?? undefined,
+        blanks: (payload.blanks ?? undefined)?.map((b) => ({ blankId: b.blankId, value: b.value })),
+      }),
+    );
     submitAnswer.mutate(
-      { questionId: current.id, index, ...payload },
+      { questionId: qid, index, ...payload },
       {
-        onSuccess: (data) => setJustResult(data),
+        onSuccess: (data) => setLocalResults((m) => new Map(m).set(qid, data)),
         onError: (err) => {
           logger.error('solve 제출 실패', err);
-          setJustSubmitted(null);
+          setLocalAnswers((m) => {
+            const next = new Map(m);
+            next.delete(qid);
+            return next;
+          });
         },
       },
     );
   };
 
-  const goNext = () => {
-    setJustResult(null);
-    setJustSubmitted(null);
-    setIndex((i) => i + 1);
-  };
+  // 풀이 여부와 무관하게 이전/다음으로 이동(문항별 상태는 로컬 누적이라 보존된다).
+  const goNext = () => setIndex((i) => i + 1);
+  const goPrev = () => setIndex((i) => Math.max(0, i - 1));
 
   // 6) finish + 결과
   const finishAttempt = useFinishAttempt(attemptId ?? 0);
@@ -277,16 +287,14 @@ export default function QuizClient({ lng, slug, unitId, mode, sourceAttemptId }:
           return;
         }
       }
-      if (e.key === 'ArrowRight' && graded) {
+      if (e.key === 'ArrowRight' && !typing) {
         e.preventDefault();
         if (isLast) finish();
         else goNext();
       }
       if (e.key === 'ArrowLeft' && index > 0 && !typing) {
         e.preventDefault();
-        setJustResult(null);
-        setJustSubmitted(null);
-        setIndex((i) => Math.max(0, i - 1));
+        goPrev();
       }
     };
     window.addEventListener('keydown', onKey);
@@ -367,11 +375,11 @@ export default function QuizClient({ lng, slug, unitId, mode, sourceAttemptId }:
     );
   }
 
-  // 복원된 제출값(이전 제출 표시용). 서버 SolveSubmissionResult 는 사용자가 고른 choice 를
-  // 포함하지 않으므로, 방금 제출(justSubmitted)이 있을 때만 사용자가 고른 번호를 강조한다.
-  const restoredChoice = justSubmitted?.choice;
-  const submittedTextValue = justSubmitted?.text;
-  const submittedBlankMap = (justSubmitted?.blanks ?? []).reduce<Record<string, string>>(
+  // 사용자가 고른 값(선택 강조용). 서버 SolveSubmissionResult 는 고른 choice 를 포함하지 않으므로,
+  // 로컬 누적(localAnswers)에 있는 문항만 사용자가 고른 번호/입력을 강조한다.
+  const restoredChoice = currentAnswer?.choice;
+  const submittedTextValue = currentAnswer?.text;
+  const submittedBlankMap = (currentAnswer?.blanks ?? []).reduce<Record<string, string>>(
     (acc, b) => {
       acc[b.blankId] = b.value;
       return acc;
@@ -459,26 +467,43 @@ export default function QuizClient({ lng, slug, unitId, mode, sourceAttemptId }:
         )}
       </div>
 
-      {/* 해설 + 다음 */}
+      {/* 해설 (채점 후) */}
       {displayResult && (
-        <>
-          <ExplanationPanel
-            correct={displayResult.isCorrect}
-            explanation={displayResult.explanation}
-            slides={current.slides ?? undefined}
-            trapType={current.trapType ?? undefined}
-          />
-          <Button
-            type="button"
-            onClick={() => (isLast ? finish() : goNext())}
-            disabled={finishAttempt.isPending}
-            className="min-h-[48px] w-full rounded-xl"
-          >
-            {finishAttempt.isPending && <Loader2 className="h-5 w-5 animate-spin" />}
-            {!finishAttempt.isPending && (isLast ? t('quiz.finish') : t('quiz.next'))}
-          </Button>
-        </>
+        <ExplanationPanel
+          correct={displayResult.isCorrect}
+          explanation={displayResult.explanation}
+          slides={current.slides ?? undefined}
+          trapType={current.trapType ?? undefined}
+        />
       )}
+
+      {/* 하단 네비: 풀이 여부와 무관하게 이전/다음 이동 (oksolve 참고) */}
+      <nav className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={goPrev}
+          disabled={index === 0}
+          aria-label={t('quiz.prev')}
+          className="inline-flex min-h-[48px] flex-1 items-center justify-center gap-1 rounded-xl border border-basic-3 bg-basic-0 text-sm font-semibold text-fg-3 transition-colors hover:bg-basic-1 disabled:pointer-events-none disabled:opacity-40"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          {t('quiz.prev')}
+        </button>
+        <Button
+          type="button"
+          onClick={() => (isLast ? finish() : goNext())}
+          disabled={finishAttempt.isPending}
+          className="min-h-[48px] flex-1 rounded-xl"
+        >
+          {finishAttempt.isPending && <Loader2 className="h-5 w-5 animate-spin" />}
+          {!finishAttempt.isPending && (
+            <span className="inline-flex items-center gap-1">
+              {isLast ? t('quiz.finish') : t('quiz.next')}
+              {!isLast && <ChevronRight className="h-4 w-4" />}
+            </span>
+          )}
+        </Button>
+      </nav>
 
       <div className="flex justify-center">
         <button

--- a/src/app/[lng]/(mobile)/solve/[slug]/quiz/QuizClient.tsx
+++ b/src/app/[lng]/(mobile)/solve/[slug]/quiz/QuizClient.tsx
@@ -436,6 +436,7 @@ export default function QuizClient({ lng, slug, unitId, mode, sourceAttemptId }:
         {current.type === SolveQuestionType.Short && (
           <ShortAnswerInput
             key={current.id}
+            code={!!current.codeLanguage}
             graded={graded}
             isCorrect={displayResult?.isCorrect}
             submittedText={submittedTextValue}

--- a/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.stories.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.stories.tsx
@@ -22,3 +22,26 @@ export const GradedCorrect: Story = {
 export const GradedWrong: Story = {
   args: { graded: true, isCorrect: false, submittedText: '상속', correctText: '캡슐화' },
 };
+
+export const CodePristine: Story = {
+  args: { graded: false, code: true },
+};
+
+export const CodeGradedCorrect: Story = {
+  args: {
+    graded: true,
+    code: true,
+    isCorrect: true,
+    submittedText: 'for (int i = 0; i < n; i++) {\n    sum += i;\n}',
+  },
+};
+
+export const CodeGradedWrong: Story = {
+  args: {
+    graded: true,
+    code: true,
+    isCorrect: false,
+    submittedText: 'for(int i=0;i<n;i++){sum+=i;}',
+    correctText: 'for (int i = 0; i < n; i++) {\n    sum += i;\n}',
+  },
+};

--- a/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/ShortAnswerInput.tsx
@@ -3,10 +3,19 @@
 /*
  * solve/ShortAnswerInput.tsx — 단답식 입력 (oksolve ShortAnswerInput 마이그레이션).
  *
- * basic/Input + basic/Button 조합. 채점은 서버가 하므로 정오 판정 로직 없음:
- *  - 미채점: Input(빈값 비활성, Enter 제출) + 제출 Button.
- *  - 채점 후: readOnly Input에 정/오 토큰 보더, 오답이면 서버가 준 correctText 노출
+ * basic/Input(일반 단답) 또는 basic/Textarea(코드 답안) + basic/Button 조합.
+ * 채점은 서버가 하므로 정오 판정 로직 없음:
+ *  - 미채점: Input/Textarea(빈값 비활성) + 제출 Button.
+ *  - 채점 후: readOnly 표시에 정/오 토큰 보더, 오답이면 서버가 준 correctText 노출
  *    (색만으로 구분하지 않도록 ✕ 기호 + "정답:" 텍스트 병기).
+ *
+ * 코드 답안(code=true): question.codeLanguage 가 있는 short 문항.
+ *  - <input> 대신 monospace <textarea>(줄바꿈 가능). Enter 는 줄바꿈이라 제출하지 않고
+ *    제출 버튼(또는 Ctrl/Cmd+Enter)으로 제출한다. 일반 단답은 기존대로 Enter 제출.
+ *  - 백엔드 strict 채점(normalizeCode): 내부 공백·줄바꿈을 보존해 비교한다. 따라서 프론트는
+ *    사용자 입력의 내부 공백/줄바꿈을 절대 정규화/축약하지 않는다. onSubmit 에 value 원본을
+ *    그대로 전달하고(축약 금지), 빈 입력 가드용으로만 trim() 결과를 본다.
+ *  - 채점 후에도 줄바꿈을 보존해(whitespace-pre) 표시하고, correctText 도 줄바꿈을 보존한다.
  *
  * 입력 상태는 내부 state로 보관. 문항 전환 시 부모 key로 리마운트되어 초기화된다.
  */
@@ -16,6 +25,7 @@
 import * as React from 'react';
 import { cn } from '@utils/cn';
 import { Input } from '@components/basic/Input';
+import { Textarea } from '@components/basic/Textarea';
 import { Button } from '@components/basic/Button';
 import { Text } from '@components/basic/Text';
 
@@ -28,7 +38,12 @@ export interface ShortAnswerInputProps {
   submittedText?: string;
   /** 오답일 때 노출할 정답 텍스트(서버 제공). */
   correctText?: string;
-  /** 제출 콜백. */
+  /**
+   * 코드 답안 여부(question.codeLanguage 유무). true 면 monospace textarea 로 입력받고
+   * 줄바꿈·내부 공백을 보존한다. false(기본) 면 기존 단답 input.
+   */
+  code?: boolean;
+  /** 제출 콜백. value 는 사용자가 입력한 원본(내부 공백·줄바꿈 보존). */
   onSubmit?: (value: string) => void;
 }
 
@@ -37,12 +52,46 @@ function ShortAnswerInput({
   isCorrect = false,
   submittedText,
   correctText,
+  code = false,
   onSubmit,
 }: ShortAnswerInputProps) {
   const [value, setValue] = React.useState('');
 
   if (graded) {
     const answered = submittedText ?? '';
+    const gradedTokenClass = isCorrect
+      ? 'border-success-2 bg-success-4'
+      : 'border-danger-2 bg-danger-4';
+
+    if (code) {
+      // 코드 답안: 줄바꿈·내부 공백 보존(whitespace-pre)해 표시. readOnly textarea 대신
+      // pre 로 렌더해 멀티라인 답안의 간격을 그대로 보여준다.
+      return (
+        <div className="animate-solve-enter">
+          <pre
+            aria-label="제출한 답"
+            className={cn(
+              'm-0 min-h-[60px] overflow-x-auto whitespace-pre rounded-2xl border px-4 py-3',
+              'font-mono text-sm leading-relaxed text-fg-1 shadow-sm',
+              gradedTokenClass,
+            )}
+          >
+            <code>{answered}</code>
+          </pre>
+          {!isCorrect && correctText && (
+            <div className="mt-3">
+              <Text variant="d2" className="block break-keep font-semibold text-success-1">
+                <span aria-hidden="true">✕ </span>정답:
+              </Text>
+              <pre className="m-0 mt-1 overflow-x-auto whitespace-pre font-mono text-sm leading-relaxed text-success-1">
+                <code>{correctText}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      );
+    }
+
     return (
       <div className="animate-solve-enter">
         <Input
@@ -51,7 +100,7 @@ function ShortAnswerInput({
           aria-label="제출한 답"
           className={cn(
             'min-h-[60px] cursor-default rounded-2xl px-4 text-base shadow-sm',
-            isCorrect ? 'border-success-2 bg-success-4' : 'border-danger-2 bg-danger-4',
+            gradedTokenClass,
           )}
         />
         {!isCorrect && correctText && (
@@ -63,14 +112,53 @@ function ShortAnswerInput({
     );
   }
 
-  const trimmed = value.trim();
+  // 빈 입력 가드용으로만 trim 을 사용한다. 제출되는 값(value)은 절대 축약하지 않는다.
+  const isEmpty = value.trim().length === 0;
+
+  if (code) {
+    return (
+      <div className="animate-solve-enter">
+        <Textarea
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            // Enter 는 줄바꿈(기본 동작 유지). Ctrl/Cmd+Enter 보조 제출만 처리.
+            if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && !isEmpty) {
+              e.preventDefault();
+              onSubmit?.(value);
+            }
+          }}
+          rows={4}
+          placeholder="코드 답안을 입력하세요"
+          aria-label="코드 답안 입력"
+          autoComplete="off"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="min-h-[112px] resize-y whitespace-pre rounded-2xl px-4 py-3 font-mono text-sm leading-relaxed shadow-sm"
+        />
+        <div className="mt-4 flex justify-end">
+          <Button
+            type="button"
+            disabled={isEmpty}
+            aria-disabled={isEmpty || undefined}
+            onClick={() => onSubmit?.(value)}
+            className="min-w-[120px] rounded-xl px-6"
+          >
+            제출
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="animate-solve-enter">
       <Input
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && trimmed) {
+          if (e.key === 'Enter' && !isEmpty) {
             e.preventDefault();
             onSubmit?.(value);
           }
@@ -85,8 +173,8 @@ function ShortAnswerInput({
       <div className="mt-4 flex justify-end">
         <Button
           type="button"
-          disabled={!trimmed}
-          aria-disabled={!trimmed || undefined}
+          disabled={isEmpty}
+          aria-disabled={isEmpty || undefined}
           onClick={() => onSubmit?.(value)}
           className="min-w-[120px] rounded-xl px-6"
         >

--- a/src/app/[lng]/(mobile)/solve/components/__tests__/ShortAnswerInput.test.tsx
+++ b/src/app/[lng]/(mobile)/solve/components/__tests__/ShortAnswerInput.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * solve/ShortAnswerInput 표현 컴포넌트 테스트.
+ *
+ * 일반 단답(input, Enter 제출)과 코드 답안(code=true: monospace textarea, Enter=줄바꿈,
+ * Ctrl/Cmd+Enter 또는 제출 버튼으로 제출)을 각각 검증한다. 핵심은 코드 답안에서
+ * 사용자가 입력한 내부 공백·줄바꿈이 onSubmit 으로 축약 없이 그대로 전달되는 것
+ * (백엔드 strict 채점 normalizeCode 와 정합). 채점은 서버가 하므로 정오 결과는 props 로만 들어온다.
+ */
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ShortAnswerInput } from '../ShortAnswerInput';
+
+describe('<ShortAnswerInput /> (일반 단답, 미채점)', () => {
+  it('input 을 렌더하고 빈값이면 제출 버튼이 비활성', () => {
+    render(<ShortAnswerInput />);
+    expect(screen.getByLabelText('단답 입력').tagName).toBe('INPUT');
+    expect(screen.getByRole('button', { name: '제출' })).toBeDisabled();
+  });
+
+  it('입력 후 Enter 로 제출되고 onSubmit 이 값으로 호출된다', async () => {
+    const onSubmit = vi.fn();
+    render(<ShortAnswerInput onSubmit={onSubmit} />);
+    const input = screen.getByLabelText('단답 입력');
+    await userEvent.type(input, '캡슐화{Enter}');
+    expect(onSubmit).toHaveBeenCalledWith('캡슐화');
+  });
+
+  it('입력 후 제출 버튼으로도 제출된다', async () => {
+    const onSubmit = vi.fn();
+    render(<ShortAnswerInput onSubmit={onSubmit} />);
+    await userEvent.type(screen.getByLabelText('단답 입력'), '상속');
+    await userEvent.click(screen.getByRole('button', { name: '제출' }));
+    expect(onSubmit).toHaveBeenCalledWith('상속');
+  });
+});
+
+describe('<ShortAnswerInput /> (코드 답안, 미채점)', () => {
+  it('code=true 면 monospace textarea 를 렌더한다(input 아님)', () => {
+    render(<ShortAnswerInput code />);
+    const el = screen.getByLabelText('코드 답안 입력');
+    expect(el.tagName).toBe('TEXTAREA');
+    expect(el.className).toContain('font-mono');
+  });
+
+  it('Enter 는 줄바꿈으로 처리되고 제출하지 않는다', async () => {
+    const onSubmit = vi.fn();
+    render(<ShortAnswerInput code onSubmit={onSubmit} />);
+    const ta = screen.getByLabelText('코드 답안 입력') as HTMLTextAreaElement;
+    await userEvent.type(ta, 'a{Enter}b');
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(ta.value).toBe('a\nb');
+  });
+
+  it('내부 공백·줄바꿈을 축약 없이 그대로 onSubmit 으로 전달한다', async () => {
+    const onSubmit = vi.fn();
+    render(<ShortAnswerInput code onSubmit={onSubmit} />);
+    const ta = screen.getByLabelText('코드 답안 입력') as HTMLTextAreaElement;
+    // 들여쓰기(공백 4칸) + 줄바꿈 + 내부 다중 공백을 정확히 재현(userEvent 특수문자 이스케이프
+    // 우회를 위해 change 로 raw 값을 주입). 컴포넌트가 이 값을 축약하지 않고 그대로 넘겨야 한다.
+    const raw = 'for (int i = 0; i < n; i++) {\n    sum  +=  i;\n}';
+    fireEvent.change(ta, { target: { value: raw } });
+    expect(ta.value).toBe(raw);
+    await userEvent.click(screen.getByRole('button', { name: '제출' }));
+    expect(onSubmit).toHaveBeenCalledWith(raw);
+  });
+
+  it('Ctrl+Enter 로 보조 제출된다', async () => {
+    const onSubmit = vi.fn();
+    render(<ShortAnswerInput code onSubmit={onSubmit} />);
+    const ta = screen.getByLabelText('코드 답안 입력');
+    await userEvent.type(ta, 'x = 1');
+    await userEvent.keyboard('{Control>}{Enter}{/Control}');
+    expect(onSubmit).toHaveBeenCalledWith('x = 1');
+  });
+
+  it('공백만 입력하면 제출 버튼이 비활성(빈 입력 가드)', async () => {
+    render(<ShortAnswerInput code />);
+    await userEvent.type(screen.getByLabelText('코드 답안 입력'), '   ');
+    expect(screen.getByRole('button', { name: '제출' })).toBeDisabled();
+  });
+});
+
+describe('<ShortAnswerInput /> (코드 답안, 채점 후)', () => {
+  it('정답이면 제출한 답을 줄바꿈 보존(pre)으로 표시하고 success 토큰을 쓴다', () => {
+    render(<ShortAnswerInput code graded isCorrect submittedText={'line1\n    line2'} />);
+    const pre = screen.getByLabelText('제출한 답');
+    expect(pre.tagName).toBe('PRE');
+    expect(pre.className).toContain('whitespace-pre');
+    expect(pre.className).toContain('border-success-2');
+    expect(pre.textContent).toBe('line1\n    line2');
+  });
+
+  it('오답이면 danger 토큰 + 줄바꿈 보존된 correctText 를 노출한다', () => {
+    render(
+      <ShortAnswerInput
+        code
+        graded
+        isCorrect={false}
+        submittedText="wrong"
+        correctText={'a\n    b'}
+      />,
+    );
+    expect(screen.getByLabelText('제출한 답').className).toContain('border-danger-2');
+    expect(screen.getByText('정답:')).toBeInTheDocument();
+    // correctText 를 줄바꿈 보존(pre)으로 노출하는지 확인. 제출한 답 pre(='wrong') 와 구분해
+    // correctText 를 담은 pre 를 찾는다.
+    const pres = Array.from(document.querySelectorAll('pre'));
+    const correctPre = pres.find((p) => p.textContent === 'a\n    b');
+    expect(correctPre).toBeTruthy();
+    expect(correctPre?.className).toContain('whitespace-pre');
+  });
+});


### PR DESCRIPTION
## 변경 사항
### 1. 코드 정답 textarea 입력 + 줄바꿈 보존
- `ShortAnswerInput`: `code` prop 시 monospace **textarea** 입력 + 공백/줄바꿈 보존, 채점 후 `<pre>`로 정답 표시
- `QuizClient`: 코드 문항(codeLanguage)에 textarea 입력 연결
- `ShortAnswerInput.test.tsx`(신규 10 tests) + stories 업데이트

### 2. 풀이 여부와 무관한 이전/다음 자유 이동 (oksolve 참고)
- `QuizClient`: 영속 하단 네비 `[← 이전][다음 →/결과 보기]` 추가 — **안 풀어도 건너뛰며 이동**
- 문항별 채점 결과/제출값 로컬 누적(`localResults`/`localAnswers`)으로 오가도 채점·해설 유지
- 키보드 `←`/`→` 자유 이동(입력 중 비활성), i18n `prev` 키 활용

## 테스트
- `ShortAnswerInput.test.tsx` 10 tests 통과 (vitest)
- `tsc --noEmit` / ESLint 통과
- 백엔드 채점(codeMode)은 별도 PR(okdohyuk-api#173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)