### PR TITLE
fix: AdSense availableWidth=0 노출 복구 + Sentry 노이즈 필터링

### DIFF
--- a/src/components/google/GoogleAd.tsx
+++ b/src/components/google/GoogleAd.tsx
@@ -16,22 +16,27 @@ type GoogleAdProps = {
 const MIN_AD_WIDTH = 250;
 
 function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
+  const wrapRef = useRef<HTMLDivElement>(null);
   const insRef = useRef<HTMLModElement>(null);
 
   useEffect(() => {
+    const wrap = wrapRef.current;
     const el = insRef.current;
-    if (!el) return undefined;
+    if (!wrap || !el) return undefined;
 
     let pushed = false;
     let ro: ResizeObserver | null = null;
     let io: IntersectionObserver | null = null;
 
     // 폭이 확보되고 뷰포트에 들어왔을 때 1회만 push.
-    // 기존 구현은 mount 직후 1회 측정만 했기 때문에, flex/grid 부모가 초기 폭=0이면
-    // 광고가 영구히 노출되지 않으면서 AdSense는 별도 경로로 push를 시도해 No-slot-size 에러를 던졌다.
+    // AdSense가 계산하는 availableWidth는 <ins>가 아니라 부모(래퍼)의 콘텐츠 폭이다.
+    // 과거 구현은 <ins>에 min-width를 걸고 <ins>.offsetWidth로 가드했는데,
+    // min-width는 부모 폭이 0이어도 offsetWidth를 그 값 이상으로 부풀려(overflow)
+    // 가드가 항상 통과 → 0폭 부모에서 push가 나가 No-slot-size(availableWidth=0)를 유발했다.
+    // 따라서 래퍼(실제 가용 폭)를 측정하고, <ins>는 width:100%로 래퍼를 그대로 따르게 한다.
     const tryPush = () => {
       if (pushed || !el.isConnected) return;
-      if (el.offsetWidth < MIN_AD_WIDTH) return;
+      if (wrap.offsetWidth < MIN_AD_WIDTH) return;
       pushed = true;
       try {
         (window.adsbygoogle = window.adsbygoogle || []).push({});
@@ -44,13 +49,13 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
 
     if (typeof ResizeObserver !== 'undefined') {
       ro = new ResizeObserver(tryPush);
-      ro.observe(el);
+      ro.observe(wrap);
     }
     if (typeof IntersectionObserver !== 'undefined') {
       io = new IntersectionObserver((entries) => {
         if (entries.some((e) => e.isIntersecting)) tryPush();
       });
-      io.observe(el);
+      io.observe(wrap);
     }
 
     tryPush();
@@ -62,11 +67,11 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
   }, []);
 
   return (
-    <div className={className} style={{ minWidth: MIN_AD_WIDTH, minHeight: 100 }}>
+    <div ref={wrapRef} className={className} style={{ minHeight: 100 }}>
       <ins
         ref={insRef}
         className="adsbygoogle"
-        style={{ display: 'block', minWidth: MIN_AD_WIDTH, minHeight: 100 }}
+        style={{ display: 'block', width: '100%', minHeight: 100 }}
         data-ad-client={process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_CLIENT_ID}
         data-ad-slot={String(slotId)}
         data-ad-format="auto"

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -8,6 +8,52 @@ const sentryEnabled =
 
 const replayEnabled = process.env.NEXT_PUBLIC_ENABLE_SENTRY_REPLAY === 'true';
 
+// 지속 관찰이 불필요한 노이즈 이벤트를 전송 전에 걸러낸다.
+// ⚠️ AdSense TagError(availableWidth 등)는 노출 회귀 감시를 위해 계속 수집한다(여기서 거르지 않음).
+type NoiseFrame = { function?: string };
+type NoiseEvent = {
+  exception?: { values?: Array<{ value?: string; stacktrace?: { frames?: NoiseFrame[] } }> };
+};
+
+// 인앱 WebView(번역/제스처 오버레이)가 주입한 스크립트의 함수 시그니처. 우리 코드에 존재하지 않는다.
+const INJECTED_SCRIPT_FUNCTIONS = [
+  'hit_swipe_element',
+  'check_swipe_element',
+  'hit_test',
+  'is_mark_able_element',
+];
+
+const isNoiseEvent = (event: NoiseEvent): boolean => {
+  const exception = event.exception?.values?.[0];
+  const message = exception?.value ?? '';
+  const frames = exception?.stacktrace?.frames ?? [];
+
+  // 1) 인앱 WebView 주입 스크립트 오류 (FRONT-26/27): 특정 기기 오버레이가 던지는 것으로 우리 코드 아님.
+  if (
+    frames.some((frame) => frame.function && INJECTED_SCRIPT_FUNCTIONS.includes(frame.function))
+  ) {
+    return true;
+  }
+
+  // 2) 서드파티 애널리틱스 비콘의 네트워크 실패 (FRONT-20~24): 애드블록/오프라인 등 액션 불가.
+  if (
+    /Failed to fetch|Load failed|NetworkError/i.test(message) &&
+    /(google-analytics|googletagmanager|analytics\.google|googlesyndication)\.com/i.test(message)
+  ) {
+    return true;
+  }
+
+  // 3) 기대된 4xx 응답 (FRONT-1J 404, FRONT-3 만료 단축 URL 410): 정상 흐름.
+  if (/Request failed with status code (404|410)/.test(message)) {
+    return true;
+  }
+
+  return false;
+};
+
+const beforeSend = <T extends NoiseEvent>(event: T): T | null =>
+  isNoiseEvent(event) ? null : event;
+
 let sentryModulePromise: Promise<SentryModule> | null = null;
 
 const getSentryModule = async () => {
@@ -27,6 +73,7 @@ if (sentryEnabled) {
       tracesSampleRate: 0.2,
       enableLogs: false,
       sendDefaultPii: true,
+      beforeSend,
     };
 
     if (replayEnabled) {


### PR DESCRIPTION
## 배경
가장 많이 발생하던 Sentry 이슈 **[FRONT-9](https://okdohyuk.sentry.io/issues/OKDOHYUK-FRONT-9)** `TagError: adsbygoogle.push() error: No slot size for availableWidth=0` (누적 2449건 / 1559명, 수익 직결)을 해결하고, 지속 관찰이 불필요한 노이즈 이슈를 전송 전 필터링한다.

## FRONT-9 근본 원인
`GoogleAd.tsx`의 폭 가드가 `<ins>.offsetWidth`를 검사했는데, `<ins>`에 인라인 `min-width:250`이 걸려 있어 **부모(래퍼) 실제 폭이 0이어도 offsetWidth가 항상 ≥250**으로 부풀려짐(min-width overflow) → 가드가 항상 통과 → 0폭 부모에서 mount 즉시 push → AdSense가 `availableWidth=0`을 던짐. (5/17 커밋 `4fcb0c1`의 가드가 이 마스킹 때문에 무력했음)

## 변경
- **GoogleAd.tsx**: 측정 대상을 `<ins>` → **래퍼(실제 가용폭)** 로 변경, Resize/Intersection Observer도 래퍼 관찰. 폭을 가리던 `min-width` 제거하고 `<ins>`는 `width:100%`로 래퍼를 그대로 추종 → 가드와 AdSense 측정 일치. **광고 억제가 아니라 폭 확보 후 정상 push → 노출 복구.**
- **instrumentation-client.ts**: `beforeSend`로 노이즈 필터링
  - 인앱 WebView 주입 스크립트 오류 (FRONT-26/27, `hit_swipe_element` 등 우리 코드 아님)
  - GA/AdSense 비콘 네트워크 실패 (FRONT-20~24, 애드블록/오프라인)
  - 기대된 4xx (FRONT-1J 404, FRONT-3 만료 단축 URL 410)
  - ⚠️ **AdSense TagError는 노출 회귀 감시를 위해 계속 수집** (필터 제외)

## 검증
- `tsc --noEmit`: 에러 0
- ESLint: 통과
- pre-commit vitest: 346 tests 전부 통과

Fixes OKDOHYUK-FRONT-9