### PR TITLE
enhance: 블로그 목록 기본 뷰를 태블릿/PC에서 그리드로 설정

### DIFF
--- a/src/components/blog/BlogSearchListClient.tsx
+++ b/src/components/blog/BlogSearchListClient.tsx
@@ -25,8 +25,13 @@ const BlogSearchListClient = function BlogSearchListClient({
   tags,
 }: BlogSearchListClientProps) {
   useBlogSearchClient(category, tags);
-  const { blogs, count, viewType, status } = useStore('blogSearchStore');
+  const { blogs, count, viewType, status, initViewTypeByViewport } = useStore('blogSearchStore');
   const { t } = useTranslation(lng, 'blog/index');
+
+  // 최초 마운트 시 뷰포트에 맞춰 기본 뷰 결정(태블릿/PC=그리드). 하이드레이션 이후 실행.
+  useEffect(() => {
+    initViewTypeByViewport();
+  }, [initViewTypeByViewport]);
 
   // blog_load_more: status가 success로 전환되고, 이전보다 항목이 늘어난 경우 추가 로드로 간주
   const prevLengthRef = useRef<number>(0);

--- a/src/stores/BlogSearchStore/index.ts
+++ b/src/stores/BlogSearchStore/index.ts
@@ -20,6 +20,9 @@ class BlogSearchStore implements BlogSearchStoreState {
 
   @observable public viewType: BlogCardType = 'discript';
 
+  // 뷰포트 기반 기본 뷰 초기화를 1회만 수행하기 위한 가드(관찰 대상 아님).
+  private viewTypeInitialized = false;
+
   @observable public category: FilterDropdownItem[] = [];
 
   @observable public tags: FilterDropdownItem[] = [];
@@ -168,6 +171,19 @@ class BlogSearchStore implements BlogSearchStoreState {
     runInAction(() => {
       this.viewType = viewType;
     });
+  };
+
+  // 최초 진입 시 뷰포트에 따라 기본 뷰를 정한다.
+  // 태블릿/PC(≥768px, Tailwind md)는 그리드(frame), 모바일은 리스트(discript) 유지.
+  // 1회만 적용해 이후 사용자의 수동 토글은 덮어쓰지 않는다.
+  public initViewTypeByViewport = () => {
+    if (typeof window === 'undefined' || this.viewTypeInitialized) return;
+    this.viewTypeInitialized = true;
+    if (window.matchMedia('(min-width: 768px)').matches) {
+      runInAction(() => {
+        this.viewType = 'frame';
+      });
+    }
   };
 
   public setPrevPath = (prevPath: string | null) => {

--- a/src/stores/BlogSearchStore/type.ts
+++ b/src/stores/BlogSearchStore/type.ts
@@ -38,6 +38,7 @@ type BlogSearchStoreState = {
   changeTagType: (value: string, type: FilterType) => void;
 
   setViewType: (viewType: BlogCardType) => void;
+  initViewTypeByViewport: () => void;
   setPrevPath: (prevPath: string | null) => void;
 };
 


### PR DESCRIPTION
## 요구
블로그 검색 목록의 기본 보기를 **태블릿/PC(≥768px, Tailwind `md`)에서 그리드(`frame`)** 로 설정한다. 모바일은 기존 리스트(`discript`) 유지.

## 변경
- **BlogSearchStore**: `initViewTypeByViewport()` 추가 — 최초 진입 1회, `matchMedia('(min-width: 768px)')`이면 `viewType='frame'`. 이후 사용자의 수동 토글은 덮어쓰지 않음. `window` 가드로 SSR-safe.
- **BlogSearchListClient**: 마운트 `useEffect`에서 호출(하이드레이션 이후 실행).
- 스토어 기본값 `'discript'`는 유지 → SSR/초기 렌더와 하이드레이션 일치(미스매치 없음). 데이터는 클라이언트 로드(스켈레톤)라 전환이 자연스러움.

## 검증
- `tsc --noEmit`: 에러 0
- ESLint: 통과
- pre-commit vitest: 346 tests 전부 통과