### PR TITLE
feat: AdSense 슬롯 렌더 결과 GA4 측정 추가

### DIFF
--- a/src/components/google/GoogleAd.tsx
+++ b/src/components/google/GoogleAd.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
+import { sendGAEvent } from '@libs/client/gtag';
 
 declare global {
   interface Window {
@@ -14,6 +15,9 @@ type GoogleAdProps = {
 };
 
 const MIN_AD_WIDTH = 250;
+// push 후 AdSense가 슬롯 처리를 끝내고 data-adsbygoogle-status를 갱신할 때까지 기다리는 최대 시간.
+// 이 시간 안에 상태 갱신이 없으면(애드블로커의 코스메틱 필터로 슬롯이 붕괴된 경우 포함) empty로 집계한다.
+const RENDER_RESULT_TIMEOUT = 5000;
 
 function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
   const wrapRef = useRef<HTMLDivElement>(null);
@@ -27,6 +31,34 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
     let pushed = false;
     let ro: ResizeObserver | null = null;
     let io: IntersectionObserver | null = null;
+    let resultMo: MutationObserver | null = null;
+    let resultTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // 실제 광고 노출 성공률(= 애드블로커 등에 의한 미노출 비율의 근사치)을 GA4로 측정.
+    // '고침' 대상이 아니라 관찰 대상: push 성공 여부와 별개로 슬롯이 실제로 채워졌는지를 본다.
+    const observeRenderResult = () => {
+      let settled = false;
+      const finish = (status: 'filled' | 'empty') => {
+        if (settled) return;
+        settled = true;
+        resultMo?.disconnect();
+        if (resultTimer) clearTimeout(resultTimer);
+        sendGAEvent('ad_render_result', status, { slot_id: slotId });
+      };
+
+      resultMo = new MutationObserver(() => {
+        if (el.getAttribute('data-adsbygoogle-status') === 'done') {
+          finish(el.querySelector('iframe') ? 'filled' : 'empty');
+        }
+      });
+      resultMo.observe(el, {
+        attributes: true,
+        attributeFilter: ['data-adsbygoogle-status'],
+        childList: true,
+      });
+
+      resultTimer = setTimeout(() => finish('empty'), RENDER_RESULT_TIMEOUT);
+    };
 
     // 폭이 확보되고 뷰포트에 들어왔을 때 1회만 push.
     // AdSense가 계산하는 availableWidth는 <ins>가 아니라 부모(래퍼)의 콘텐츠 폭이다.
@@ -45,6 +77,7 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
       }
       ro?.disconnect();
       io?.disconnect();
+      observeRenderResult();
     };
 
     if (typeof ResizeObserver !== 'undefined') {
@@ -63,6 +96,8 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
     return () => {
       ro?.disconnect();
       io?.disconnect();
+      resultMo?.disconnect();
+      if (resultTimer) clearTimeout(resultTimer);
     };
   }, []);
 

--- a/src/components/google/__tests__/GoogleAd.test.tsx
+++ b/src/components/google/__tests__/GoogleAd.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * GoogleAd 노출 결과 측정(ad_render_result) 회귀 테스트.
+ *
+ * push() 자체는 성공해도 이후 애드블로커의 코스메틱 필터 등으로 슬롯이
+ * 비어버리는 케이스(FRONT-9)가 있어, "고치는" 대신 filled/empty 비율을
+ * GA4로 관찰하기로 했다. data-adsbygoogle-status 변화 관찰과 타임아웃
+ * fallback이 각 케이스에서 올바른 값을 보내는지 검증한다.
+ */
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { sendGAEvent } from '@libs/client/gtag';
+import GoogleAd from '../GoogleAd';
+
+vi.mock('@libs/client/gtag', () => ({
+  sendGAEvent: vi.fn(),
+}));
+
+const sendGAEventMock = vi.mocked(sendGAEvent);
+
+// 클래스 대신 생성자 함수 + 명시적 객체 반환으로 구현(new 호출 시 반환 객체가 사용됨).
+function MockResizeObserver(callback: ResizeObserverCallback) {
+  return {
+    observe: () => callback([], {} as ResizeObserver),
+    disconnect: () => {},
+    unobserve: () => {},
+  };
+}
+
+function MockIntersectionObserver(callback: IntersectionObserverCallback) {
+  return {
+    observe: (target: Element) =>
+      callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      ),
+    disconnect: () => {},
+    unobserve: () => {},
+  };
+}
+
+function getInsEl() {
+  return document.querySelector('ins.adsbygoogle') as HTMLModElement;
+}
+
+describe('<GoogleAd />', () => {
+  beforeEach(() => {
+    sendGAEventMock.mockClear();
+    window.adsbygoogle = [];
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    // jsdom의 offsetWidth는 항상 0이라 폭 가드(MIN_AD_WIDTH)를 통과시키기 위해 스텁한다.
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 300,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('슬롯에 iframe이 채워지면 filled를 보낸다', async () => {
+    render(<GoogleAd slotId="1234" />);
+    const ins = getInsEl();
+    ins.appendChild(document.createElement('iframe'));
+    ins.setAttribute('data-adsbygoogle-status', 'done');
+
+    await vi.waitFor(() => {
+      expect(sendGAEventMock).toHaveBeenCalledWith('ad_render_result', 'filled', {
+        slot_id: '1234',
+      });
+    });
+  });
+
+  it('상태는 done인데 iframe이 없으면 empty를 보낸다', async () => {
+    render(<GoogleAd slotId="5678" />);
+    const ins = getInsEl();
+    ins.setAttribute('data-adsbygoogle-status', 'done');
+
+    await vi.waitFor(() => {
+      expect(sendGAEventMock).toHaveBeenCalledWith('ad_render_result', 'empty', {
+        slot_id: '5678',
+      });
+    });
+  });
+
+  it('타임아웃까지 상태 갱신이 없으면(차단 추정) empty를 보낸다', () => {
+    vi.useFakeTimers();
+    render(<GoogleAd slotId="9999" />);
+
+    vi.advanceTimersByTime(5000);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith('ad_render_result', 'empty', {
+      slot_id: '9999',
+    });
+  });
+
+  it('결과가 확정된 후에는 추가로 이벤트를 보내지 않는다', async () => {
+    render(<GoogleAd slotId="1111" />);
+    const ins = getInsEl();
+    ins.appendChild(document.createElement('iframe'));
+    ins.setAttribute('data-adsbygoogle-status', 'done');
+
+    await vi.waitFor(() => {
+      expect(sendGAEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    ins.setAttribute('data-adsbygoogle-status', 'done');
+    ins.removeChild(ins.firstChild as ChildNode);
+    await Promise.resolve();
+
+    expect(sendGAEventMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/libs/client/gtag.ts
+++ b/src/libs/client/gtag.ts
@@ -81,6 +81,8 @@ type LegacyEvent = 'button_click' | 'link_click';
 
 type MiscEvent = 'legal_section_jump';
 
+type AdEvent = 'ad_render_result';
+
 export type Event =
   | GlobalEvent
   | NavEvent
@@ -92,6 +94,7 @@ export type Event =
   | ToolEvent
   | UiEvent
   | MiscEvent
+  | AdEvent
   | LegacyEvent;
 
 // =============================================================================


### PR DESCRIPTION
## 배경

[OKDOHYUK-FRONT-9](https://okdohyuk.sentry.io/issues/OKDOHYUK-FRONT-9)(`TagError: No slot size for availableWidth=0`)는 #532(495af45)에서 폭 측정 버그를 고친 뒤에도 `regressed` 상태로 계속 발생 중이었습니다.

- 발생 브라우저가 Edge/Chrome/Mobile Safari/Edge Mobile 등 전반에 고르게 퍼져 있어 특정 OS/엔진 문제가 아님
- 에러가 AdSense 내부 **비동기**(`setTimeout`) 재계산 시점에서 발생 (`mechanism: auto.browser.browserapierrors.setTimeout`)

→ 우리 쪽 폭 체크 통과 직후 ~ AdSense 내부 재계산 사이의 짧은 창에서 애드블로커의 코스메틱 CSS가 슬롯을 붕괴시키는 패턴과 일치. 코드로 "고칠" 대상이 아니라고 판단해 **발생 비율을 GA4로 관찰**하는 쪽으로 방향을 바꿨습니다. 기존 폭 가드/Sentry 캡처 로직은 변경하지 않았습니다(이슈는 계속 오픈 상태로 둡니다).

## 변경 사항

- `src/libs/client/gtag.ts`: `ad_render_result` 이벤트 타입 추가
- `src/components/google/GoogleAd.tsx`: `push()` 이후 `data-adsbygoogle-status` 변화를 `MutationObserver`로 관찰 → `filled`(iframe 채워짐) / `empty`(상태만 done이거나 5초 내 무응답, 애드블로커 케이스 포함)를 `slot_id`와 함께 `sendGAEvent('ad_render_result', ...)`로 전송
- `src/components/google/__tests__/GoogleAd.test.tsx`: filled / empty / timeout / 중복 전송 방지 케이스 신규 테스트

## 테스트 플랜

- [x] `npx tsc --noEmit` 통과
- [x] `eslint` 통과 (변경 파일 전체)
- [x] `vitest run` 전체 스위트 51 files / 350 tests 통과 (신규 4개 포함)

## 배포 후 가이드 (그대로 따라 하면 됨)

이 PR이 배포되면 이벤트 수집은 바로 시작되지만(DebugView/실시간 리포트에서 즉시 확인 가능), **GA4 관리자 콘솔에서 아래 1개 항목은 반드시 등록**해야 filled/empty 비율을 표준 리포트·Explore·Data API에서 조회할 수 있습니다(등록 안 된 이벤트 파라미터는 GA4에서 차원으로 못 씀 + 등록은 소급 적용 안 됨 → 배포 직후 바로 등록 권장).

1. GA4 속성(`okdohyuk.dev`, property `316981463`) 접속 → **관리(Admin) → 맞춤 정의(Custom definitions) → 맞춤 측정기준 만들기**
2. **[필수]** 다음 값으로 생성:
   - 측정기준 이름: `Ad Render Result` (자유롭게 지어도 됨)
   - 범위: `이벤트`
   - 이벤트 매개변수: `value`
3. **[선택]** 슬롯/페이지별로 쪼개보고 싶다면 하나 더 생성:
   - 측정기준 이름: `Ad Slot ID`
   - 범위: `이벤트`
   - 이벤트 매개변수: `slot_id`
4. 등록 후 GA4 탐색 분석(Explore)에서 이벤트 이름 `ad_render_result` + 위 측정기준으로 `empty` 비율 추이를 확인

### 측정치 해석 시 참고 (설정과 무관, 읽을 때 감안할 점)

- Consent Mode 기본값이 `analytics_storage: denied`라 분석 동의를 거부한 방문자는 이 이벤트 자체가 안 잡힘 — 전체 방문자가 아니라 "동의한 사용자" 표본 기준
- 일부 애드블록 필터(EasyPrivacy 등)는 `google-analytics.com` 수집 요청도 함께 막기 때문에, 측정되는 `empty` 비율은 실제 애드블록 사용률의 **하한선**으로 보는 게 안전