### PR TITLE
feat: 어드민 광고 미노출 및 블로그 목록 재진입 시 리페치

### DIFF
--- a/src/app/[lng]/admin/blog/page.tsx
+++ b/src/app/[lng]/admin/blog/page.tsx
@@ -27,9 +27,14 @@ import { cn } from '@utils/cn';
 
 function BlogAdminPage({ params }: LanguageParams) {
   const { lng } = use(params);
-  const { blogs, getBlogsPage, status, isLastPage } = useStore('blogStore');
+  const { blogs, getBlogsPage, status, isLastPage, reset } = useStore('blogStore');
   const { setIsFetching, isFetching } = useInfiniteScroll();
   const blogCount = blogs?.length ?? 0;
+
+  // 글 작성/게시 후 돌아왔을 때 캐시된 목록이 남지 않도록 진입 시마다 새로 불러온다
+  useEffect(() => {
+    reset();
+  }, [reset]);
 
   useEffect(() => {
     if (!isFetching) return;

--- a/src/components/google/GoogleAdsense.tsx
+++ b/src/components/google/GoogleAdsense.tsx
@@ -1,8 +1,18 @@
+'use client';
+
 import React from 'react';
 import Script from 'next/script';
+import { usePathname } from 'next/navigation';
 
 function GoogleAdsense({ pid }: { pid: string }) {
+  const pathname = usePathname();
+
   if (process.env.NODE_ENV !== 'production') {
+    return null;
+  }
+
+  // 어드민 콘솔에서는 광고를 노출하지 않는다
+  if (pathname?.split('/').includes('admin')) {
     return null;
   }
 

--- a/src/stores/BlogStore/index.ts
+++ b/src/stores/BlogStore/index.ts
@@ -21,6 +21,14 @@ class BlogStore implements BlogStoreState {
     this.blogs = blogs;
   };
 
+  // 목록 페이지 재진입 시 캐시된 목록을 버리고 처음부터 다시 불러오게 한다
+  @action public reset: BlogStoreState['reset'] = () => {
+    this.blogs = null;
+    this.page = 0;
+    this.isLastPage = false;
+    this.status = 'idle';
+  };
+
   @action public getBlogsPage: BlogStoreState['getBlogsPage'] = (limit) => {
     runInAction(() => {
       this.status = 'loading';

--- a/src/stores/BlogStore/type.ts
+++ b/src/stores/BlogStore/type.ts
@@ -11,6 +11,7 @@ type BlogStoreState = {
   page: number;
   setBlogs: (blogs: OptionalBlogs) => void;
   getBlogsPage: (limit: number, authorization?: string) => void;
+  reset: () => void;
 };
 
 export type { BlogStoreState, Status };


### PR DESCRIPTION
## 개요
어드민 콘솔 UX 개선 2건.

## 변경
### 1. 어드민 페이지 광고 미노출
- `GoogleAdsense`가 클라이언트 컴포넌트로 전환되고, `usePathname`으로 `/admin` 경로에서는 AdSense 스크립트를 로드하지 않는다.
- 광고 슬롯(`GoogleAd`)은 어드민에 원래 없었으므로 스크립트 로더만 차단하면 충분.

### 2. 게시 후 블로그 목록 리페치
- `blogStore`가 싱글턴이라 글 작성/게시(`submitBlog` → `redirect('/admin/blog')`) 후 복귀해도 캐시된 목록(`blogs`/`page`/`status`)이 남아 새 글이 안 보이던 문제.
- `BlogStore.reset()` 액션 추가, `/admin/blog` 진입 시 리셋 → `status='idle'` 트리거로 처음부터 다시 조회.

## 검증
- `tsc --noEmit`, 변경 파일 ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)