### PR TITLE
feat: 메뉴 외부링크에 노그미·MuxPad 추가, 프로필·티스토리·보관함 해몽 제거

### DIFF
--- a/src/assets/datas/menus.tsx
+++ b/src/assets/datas/menus.tsx
@@ -29,7 +29,7 @@ import {
   Linkedin,
   List,
   MessageSquareText,
-  MonitorPlay,
+  Mic,
   Moon,
   Music,
   Network,
@@ -41,10 +41,9 @@ import {
   Search,
   Server,
   ShieldAlert,
-  Smile,
-  Sparkles,
   Swords,
   Table,
+  Terminal,
   TextCursorInput,
   Timer,
   Tv,
@@ -562,23 +561,23 @@ const menus: Menus = {
   out: [
     {
       title: {
-        ko: '프로필',
-        en: 'Profile',
-        ja: 'プロフィール',
-        zh: '个人资料',
+        ko: '노그미',
+        en: 'Nogmi',
+        ja: 'Nogmi',
+        zh: 'Nogmi',
       },
-      icon: <Smile />,
-      link: 'https://okdohyuk.notion.site/',
+      icon: <Mic />,
+      link: 'https://git.okdohyuk.dev/nogmi/',
     },
     {
       title: {
-        ko: '티스토리',
-        en: 'Tistory',
-        ja: 'Tistory',
-        zh: 'Tistory',
+        ko: 'MuxPad',
+        en: 'MuxPad',
+        ja: 'MuxPad',
+        zh: 'MuxPad',
       },
-      icon: <MonitorPlay />,
-      link: 'https://blog.okdohyuk.dev/',
+      icon: <Terminal />,
+      link: 'https://git.okdohyuk.dev/muxpad/',
     },
     {
       title: {
@@ -621,18 +620,7 @@ const menus: Menus = {
       link: 'https://github.com/sponsors/okdohyuk?frequency=recurring',
     },
   ],
-  trash: [
-    {
-      title: {
-        ko: '해몽',
-        en: 'Dream Resolver',
-        ja: '夢占い',
-        zh: '解梦',
-      },
-      icon: <Sparkles />,
-      link: '/dream-resolver',
-    },
-  ],
+  trash: [],
 };
 
 export type { MenuItem, Menus };


### PR DESCRIPTION
## 변경 내용
- 외부링크(out)에 노그미(https://git.okdohyuk.dev/nogmi/, Mic 아이콘)·MuxPad(https://git.okdohyuk.dev/muxpad/, Terminal 아이콘) 추가
- 프로필(notion.site), 티스토리(blog.okdohyuk.dev) 외부링크 제거
- 보관함(trash)에서 해몽 제거 — `menus.trash` 참조 유지를 위해 빈 배열로 유지, 항목 0개면 보관함 섹션 미렌더링
- 미사용 아이콘 import(Smile, MonitorPlay, Sparkles) 정리

## 검증
- `tsc --noEmit` 통과
- `eslint src/assets/datas/menus.tsx` 통과