### PR TITLE
fix: 어드민 블로그 게시 후 목록 카드 클릭이 동작하지 않는 문제 해결

### DIFF
--- a/src/app/[lng]/admin/blog/page.tsx
+++ b/src/app/[lng]/admin/blog/page.tsx
@@ -90,7 +90,7 @@ function BlogAdminPage({ params }: LanguageParams) {
 
         <div className="flex flex-col gap-3">
           {blogs?.map((blog) => (
-            <BlogCard key={blog.urlSlug} blog={blog as BlogSearch} isAdmin type="board" />
+            <BlogCard key={blog.urlSlug} blog={blog as BlogSearch} isAdmin type="board" lng={lng} />
           ))}
 
           {status === 'loading' ? (

--- a/src/app/[lng]/admin/blog/write/actions.ts
+++ b/src/app/[lng]/admin/blog/write/actions.ts
@@ -6,7 +6,7 @@ import { getTokenServer } from '@libs/server/token';
 import { blogApi } from '@api';
 import { BlogRequest } from './schema';
 
-export const submitBlog = async (blog: BlogRequest, urlSlug?: string) => {
+export const submitBlog = async (blog: BlogRequest, urlSlug?: string, lng?: string) => {
   try {
     const token = await getTokenServer();
     if (!token) return;
@@ -17,13 +17,15 @@ export const submitBlog = async (blog: BlogRequest, urlSlug?: string) => {
     } else {
       await blogApi.patchBlogUrlSlug(urlSlug, token.accessToken, undefined, blog);
     }
-    redirect('/admin/blog');
   } catch (error) {
     if (axios.isAxiosError(error)) {
       throw new Error(error.response?.data.errorMessage ?? '블로그 저장 실패');
     }
     throw error;
   }
+  // 로케일 없는 경로로 redirect 하면 미들웨어 307을 한 번 더 타면서 라우터 상태가 어긋나
+  // 목록 복귀 후 Link 클릭이 동작하지 않는 문제가 있어 lng를 명시한다.
+  redirect(lng ? `/${lng}/admin/blog` : '/admin/blog');
 };
 
 /*

--- a/src/app/[lng]/admin/blog/write/impl.tsx
+++ b/src/app/[lng]/admin/blog/write/impl.tsx
@@ -168,7 +168,7 @@ function BlogWritePageImpl({ lng, blog, category }: BlogWritePageImplProps) {
     if (isSubmitting) return;
     setIsSubmitting(true);
     try {
-      await submitBlog(formData, blog?.urlSlug);
+      await submitBlog(formData, blog?.urlSlug, lng);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/blog/BlogCard/index.tsx
+++ b/src/components/blog/BlogCard/index.tsx
@@ -6,9 +6,12 @@ import Discript from './Discript';
 import Frame from './Frame';
 import { BlogCardFC } from './type';
 
-const BlogCard: BlogCardFC = function BlogCard({ blog, isAdmin = false, type = 'discript' }) {
+const BlogCard: BlogCardFC = function BlogCard({ blog, isAdmin = false, type = 'discript', lng }) {
   const { urlSlug } = blog;
-  const link = isAdmin ? `/admin/blog/write?urlSlug=${urlSlug}` : `/blog/${urlSlug}`;
+  const prefix = lng ? `/${lng}` : '';
+  const link = isAdmin
+    ? `${prefix}/admin/blog/write?urlSlug=${urlSlug}`
+    : `${prefix}/blog/${urlSlug}`;
 
   return (
     <Link

--- a/src/components/blog/BlogCard/type.ts
+++ b/src/components/blog/BlogCard/type.ts
@@ -7,6 +7,8 @@ type BlogCardProps = {
   blog: BlogSearch;
   isAdmin?: boolean;
   type?: BlogCardType;
+  /** 지정 시 로케일 prefix가 붙은 경로로 이동해 미들웨어 리다이렉트를 거치지 않는다 */
+  lng?: string;
 };
 
 type BlogCardTypeProps = {


### PR DESCRIPTION
## 증상
어드민 블로그 관리에서 글을 게시(저장)하고 목록으로 돌아온 뒤, 목록 카드를 클릭해도 편집 페이지로 이동하지 않음.

## 원인
- `submitBlog` 서버 액션이 `redirect('/admin/blog')` — **로케일(lng) 없는 경로**로 리다이렉트
- 어드민 `BlogCard` 링크도 `/admin/blog/write?urlSlug=...`로 lng 미포함
- 로케일 없는 경로는 미들웨어가 307로 `/{lng}/...`에 재리다이렉트하는데, 서버 액션 redirect 직후 이 경유가 겹치면 클라이언트 라우터 상태가 어긋나 이후 Link 클릭이 무시됨

## 변경
- `submitBlog(blog, urlSlug?, lng?)`: `redirect(\`/${lng}/admin/blog\`)`로 로케일 명시, `redirect()`를 try/catch 밖으로 이동(NEXT_REDIRECT가 catch에 걸리지 않도록)
- `BlogCard`에 옵셔널 `lng` prop 추가 — 어드민 목록 카드가 `/{lng}/admin/blog/write?urlSlug=...`로 직행(미들웨어 리다이렉트 미경유)
- 공개 카드 등 lng 미전달 기존 사용처는 동작 불변

## 검증
- `tsc --noEmit`, ESLint 통과
- 배포 후 확인 절차: 어드민에서 글 게시 → 목록 복귀 → 임의 카드 클릭 → 편집 페이지 진입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)