### PR TITLE
feat: 카테고리/게시 변경 시 공개 페이지 캐시 무효화(updateTag)

### DIFF
--- a/src/app/[lng]/admin/blog/category/actions.ts
+++ b/src/app/[lng]/admin/blog/category/actions.ts
@@ -1,0 +1,54 @@
+'use server';
+
+import axios from 'axios';
+import { updateTag } from 'next/cache';
+import { getTokenServer } from '@libs/server/token';
+import { blogApi } from '@api';
+import { PatchBlogCategoryIdRequest, PostBlogCategoryRequest } from '@api/Blog';
+
+// 블로그 메인(카테고리·태그 목록)과 상세(categoryChain) 캐시를 무효화한다.
+// unstable_cache 태그: blog/(search)/page.tsx → 'blog-search', blog/[urlSlug]/page.tsx → 'blog-post'
+const revalidateBlogCaches = () => {
+  updateTag('blog-search');
+  updateTag('blog-post');
+};
+
+const toActionError = (error: unknown, fallback: string): Error => {
+  if (axios.isAxiosError(error)) {
+    return new Error(error.response?.data.errorMessage ?? fallback);
+  }
+  return error instanceof Error ? error : new Error(fallback);
+};
+
+export const createBlogCategory = async (request: PostBlogCategoryRequest) => {
+  try {
+    const token = await getTokenServer();
+    if (!token) return;
+    await blogApi.postBlogCategory(token.accessToken, request);
+  } catch (error) {
+    throw toActionError(error, '카테고리 생성 실패');
+  }
+  revalidateBlogCaches();
+};
+
+export const updateBlogCategory = async (id: string, request: PatchBlogCategoryIdRequest) => {
+  try {
+    const token = await getTokenServer();
+    if (!token) return;
+    await blogApi.patchBlogCategoryId(id, token.accessToken, request);
+  } catch (error) {
+    throw toActionError(error, '카테고리 수정 실패');
+  }
+  revalidateBlogCaches();
+};
+
+export const deleteBlogCategory = async (id: string) => {
+  try {
+    const token = await getTokenServer();
+    if (!token) return;
+    await blogApi.deleteBlogCategoryId(id, token.accessToken);
+  } catch (error) {
+    throw toActionError(error, '카테고리 삭제 실패');
+  }
+  revalidateBlogCaches();
+};

--- a/src/app/[lng]/admin/blog/write/actions.ts
+++ b/src/app/[lng]/admin/blog/write/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import axios from 'axios';
+import { updateTag } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { getTokenServer } from '@libs/server/token';
 import { blogApi } from '@api';
@@ -23,6 +24,10 @@ export const submitBlog = async (blog: BlogRequest, urlSlug?: string, lng?: stri
     }
     throw error;
   }
+  // 게시/수정 결과가 공개 페이지에 바로 반영되도록 unstable_cache 태그를 무효화한다.
+  // blog/(search)/page.tsx → 'blog-search'(태그 목록), blog/[urlSlug]/page.tsx → 'blog-post'
+  updateTag('blog-search');
+  updateTag('blog-post');
   // 로케일 없는 경로로 redirect 하면 미들웨어 307을 한 번 더 타면서 라우터 상태가 어긋나
   // 목록 복귀 후 Link 클릭이 동작하지 않는 문제가 있어 lng를 명시한다.
   redirect(lng ? `/${lng}/admin/blog` : '/admin/blog');

--- a/src/hooks/blog/useBlogCategory.ts
+++ b/src/hooks/blog/useBlogCategory.ts
@@ -1,7 +1,13 @@
-import { blogApi } from '~/spec/api';
 import { PostBlogCategoryRequest } from '~/spec/api/Blog';
+import {
+  createBlogCategory,
+  deleteBlogCategory,
+  updateBlogCategory,
+} from '~/app/[lng]/admin/blog/category/actions';
 import { UseCategoryProps } from './type';
 
+// 카테고리 변경은 서버 액션을 경유한다 — 성공 시 서버에서
+// revalidateTag('blog-search'/'blog-post')로 공개 페이지 캐시를 무효화하기 위함.
 const useBlogCategory = () => {
   const post = async ({ category, parent }: UseCategoryProps) => {
     if (category.trim() === '') throw new Error();
@@ -11,17 +17,13 @@ const useBlogCategory = () => {
       parentId: parent !== null ? parent.id : undefined,
     };
 
-    await blogApi.postBlogCategory('', postdata);
+    await createBlogCategory(postdata);
   };
 
   const patch = async ({ parent }: UseCategoryProps) => {
     if (!(parent && parent.id && parent.name)) return;
 
-    const postdata: PostBlogCategoryRequest = {
-      name: parent.name,
-    };
-
-    await blogApi.patchBlogCategoryId(parent.id, '', postdata);
+    await updateBlogCategory(parent.id, { name: parent.name });
   };
 
   const remove = async ({ parent }: UseCategoryProps) => {
@@ -29,7 +31,7 @@ const useBlogCategory = () => {
     // eslint-disable-next-line no-alert
     if (!window.confirm('정말 삭제 하시겠습니까?')) return;
 
-    await blogApi.deleteBlogCategoryId(parent.id, '');
+    await deleteBlogCategory(parent.id);
   };
 
   return { post, patch, remove };


### PR DESCRIPTION
## 증상
어드민에서 블로그 카테고리를 수정해도 블로그 메인의 카테고리 리스트가 갱신되지 않음 — **재빌드 후에도** 그대로.

## 원인
- 블로그 메인 `blog/(search)/page.tsx`의 `unstable_cache`(태그 `blog-search`, TTL 7일)와 상세 `blog/[urlSlug]/page.tsx`(태그 `blog-post`, TTL 4시간)는 **Data Cache**에 저장되어 재빌드로 초기화되지 않음. 빌드 시 프리렌더도 유효한 캐시 항목을 그대로 사용.
- 코드 어디에도 `revalidateTag`/`updateTag` 호출이 없어 어드민 변경이 캐시를 무효화하지 못하고 TTL 만료만 기다리는 구조.

## 변경
- **카테고리 CRUD를 서버 액션으로 전환**: `admin/blog/category/actions.ts` 신설 (`createBlogCategory` / `updateBlogCategory` / `deleteBlogCategory`), `useBlogCategory` 훅이 이를 호출. 인증도 기존 클라이언트 인터셉터 의존에서 `getTokenServer` 명시로 통일.
- 성공 시 `updateTag('blog-search')` + `updateTag('blog-post')` 호출 (Next 16 서버 액션의 read-your-own-writes 시맨틱)
- **글 게시/수정(`submitBlog`)에도 동일 무효화 추가** — 게시 직후 공개 메인/상세에 바로 반영

## 검증
- `tsc --noEmit`, ESLint 통과
- 배포 후: 어드민 카테고리 이름 변경 → 블로그 메인 새로고침 → 즉시 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)