### PR TITLE
fix: ad_render_result 측정이 스크립트 lazyOnload 지연을 놓치던 문제 수정

### DIFF
--- a/src/components/google/GoogleAd.tsx
+++ b/src/components/google/GoogleAd.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import { sendGAEvent } from '@libs/client/gtag';
+import { ADSENSE_SCRIPT_LOADED_EVENT, isAdsenseScriptLoaded } from '@libs/client/adsenseScript';
 
 declare global {
   interface Window {
@@ -15,7 +16,11 @@ type GoogleAdProps = {
 };
 
 const MIN_AD_WIDTH = 250;
-// push 후 AdSense가 슬롯 처리를 끝내고 data-adsbygoogle-status를 갱신할 때까지 기다리는 최대 시간.
+// adsbygoogle.js는 lazyOnload로 로드되어 push() 시점엔 아직 로드 전일 수 있다.
+// 스크립트 로드 자체를 기다리는 최대 시간. 이 시간 안에 로드 신호가 없으면
+// 네트워크 레벨 차단(애드블록 등)으로 보고 곧바로 empty로 집계한다.
+const SCRIPT_LOAD_TIMEOUT = 8000;
+// 스크립트 로드 이후 AdSense가 슬롯 처리를 끝내고 data-adsbygoogle-status를 갱신할 때까지 기다리는 최대 시간.
 // 이 시간 안에 상태 갱신이 없으면(애드블로커의 코스메틱 필터로 슬롯이 붕괴된 경우 포함) empty로 집계한다.
 const RENDER_RESULT_TIMEOUT = 5000;
 
@@ -33,19 +38,23 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
     let io: IntersectionObserver | null = null;
     let resultMo: MutationObserver | null = null;
     let resultTimer: ReturnType<typeof setTimeout> | null = null;
+    let scriptLoadTimer: ReturnType<typeof setTimeout> | null = null;
+    let removeScriptListener: (() => void) | null = null;
+    let settled = false;
 
     // 실제 광고 노출 성공률(= 애드블로커 등에 의한 미노출 비율의 근사치)을 GA4로 측정.
     // '고침' 대상이 아니라 관찰 대상: push 성공 여부와 별개로 슬롯이 실제로 채워졌는지를 본다.
-    const observeRenderResult = () => {
-      let settled = false;
-      const finish = (status: 'filled' | 'empty') => {
-        if (settled) return;
-        settled = true;
-        resultMo?.disconnect();
-        if (resultTimer) clearTimeout(resultTimer);
-        sendGAEvent('ad_render_result', status, { slot_id: slotId });
-      };
+    const finish = (status: 'filled' | 'empty') => {
+      if (settled) return;
+      settled = true;
+      resultMo?.disconnect();
+      if (resultTimer) clearTimeout(resultTimer);
+      if (scriptLoadTimer) clearTimeout(scriptLoadTimer);
+      removeScriptListener?.();
+      sendGAEvent('ad_render_result', status, { slot_id: slotId });
+    };
 
+    const observeRenderResult = () => {
       resultMo = new MutationObserver(() => {
         if (el.getAttribute('data-adsbygoogle-status') === 'done') {
           finish(el.querySelector('iframe') ? 'filled' : 'empty');
@@ -58,6 +67,24 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
       });
 
       resultTimer = setTimeout(() => finish('empty'), RENDER_RESULT_TIMEOUT);
+    };
+
+    // adsbygoogle.js가 이미 로드되어 있으면(같은 페이지의 이전 광고가 로드를 끝낸 경우 등)
+    // 곧바로 관찰을 시작하고, 아니라면 로드 완료 이벤트를 기다린다.
+    const startObservingRenderResult = () => {
+      if (isAdsenseScriptLoaded()) {
+        observeRenderResult();
+        return;
+      }
+      const onScriptLoaded = () => {
+        removeScriptListener?.();
+        if (scriptLoadTimer) clearTimeout(scriptLoadTimer);
+        observeRenderResult();
+      };
+      window.addEventListener(ADSENSE_SCRIPT_LOADED_EVENT, onScriptLoaded);
+      removeScriptListener = () =>
+        window.removeEventListener(ADSENSE_SCRIPT_LOADED_EVENT, onScriptLoaded);
+      scriptLoadTimer = setTimeout(() => finish('empty'), SCRIPT_LOAD_TIMEOUT);
     };
 
     // 폭이 확보되고 뷰포트에 들어왔을 때 1회만 push.
@@ -77,7 +104,7 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
       }
       ro?.disconnect();
       io?.disconnect();
-      observeRenderResult();
+      startObservingRenderResult();
     };
 
     if (typeof ResizeObserver !== 'undefined') {
@@ -98,6 +125,8 @@ function GoogleAd({ slotId, className = '' }: GoogleAdProps) {
       io?.disconnect();
       resultMo?.disconnect();
       if (resultTimer) clearTimeout(resultTimer);
+      if (scriptLoadTimer) clearTimeout(scriptLoadTimer);
+      removeScriptListener?.();
     };
   }, []);
 

--- a/src/components/google/GoogleAdsense.tsx
+++ b/src/components/google/GoogleAdsense.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Script from 'next/script';
 import { usePathname } from 'next/navigation';
+import { markAdsenseScriptLoaded } from '@libs/client/adsenseScript';
 
 function GoogleAdsense({ pid }: { pid: string }) {
   const pathname = usePathname();
@@ -22,6 +23,7 @@ function GoogleAdsense({ pid }: { pid: string }) {
       src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${pid}`}
       crossOrigin="anonymous"
       strategy="lazyOnload"
+      onLoad={markAdsenseScriptLoaded}
     />
   );
 }

--- a/src/components/google/__tests__/GoogleAd.test.tsx
+++ b/src/components/google/__tests__/GoogleAd.test.tsx
@@ -3,13 +3,21 @@
  *
  * push() 자체는 성공해도 이후 애드블로커의 코스메틱 필터 등으로 슬롯이
  * 비어버리는 케이스(FRONT-9)가 있어, "고치는" 대신 filled/empty 비율을
- * GA4로 관찰하기로 했다. data-adsbygoogle-status 변화 관찰과 타임아웃
- * fallback이 각 케이스에서 올바른 값을 보내는지 검증한다.
+ * GA4로 관찰하기로 했다.
+ *
+ * 초기 구현은 push() 호출 시점부터 5초 타임아웃으로 결과를 기다렸는데,
+ * adsbygoogle.js가 next/script의 lazyOnload로 늦게 로드되는 사이트라
+ * 실제로는 광고가 정상 채워져도 스크립트 로드 자체가 5초를 넘겨 항상
+ * empty로 오분류됐다(운영 데이터 141건 중 filled 0건). 그래서 관찰 시작
+ * 시점을 push() 호출이 아니라 "스크립트 로드 완료" 시점으로 옮겼다.
+ * 이 파일은 스크립트가 이미 로드된 경우 / 로드가 늦게 도착하는 경우 /
+ * 끝까지 로드되지 않는 경우(네트워크 차단) 세 경로를 모두 검증한다.
  */
 import React from 'react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { sendGAEvent } from '@libs/client/gtag';
+import { markAdsenseScriptLoaded } from '@libs/client/adsenseScript';
 import GoogleAd from '../GoogleAd';
 
 vi.mock('@libs/client/gtag', () => ({
@@ -47,6 +55,8 @@ describe('<GoogleAd />', () => {
   beforeEach(() => {
     sendGAEventMock.mockClear();
     window.adsbygoogle = [];
+    // 테스트 간 스크립트 로드 상태 격리 (markAdsenseScriptLoaded는 window에 플래그를 남긴다).
+    window.adsenseScriptLoaded = false;
     vi.stubGlobal('ResizeObserver', MockResizeObserver);
     vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
     // jsdom의 offsetWidth는 항상 0이라 폭 가드(MIN_AD_WIDTH)를 통과시키기 위해 스텁한다.
@@ -61,7 +71,8 @@ describe('<GoogleAd />', () => {
     vi.useRealTimers();
   });
 
-  it('슬롯에 iframe이 채워지면 filled를 보낸다', async () => {
+  it('스크립트가 이미 로드돼 있으면 곧바로 관찰을 시작해 filled를 보낸다', async () => {
+    markAdsenseScriptLoaded();
     render(<GoogleAd slotId="1234" />);
     const ins = getInsEl();
     ins.appendChild(document.createElement('iframe'));
@@ -74,7 +85,25 @@ describe('<GoogleAd />', () => {
     });
   });
 
+  it('스크립트 로드가 마운트 이후 도착해도 그 뒤 상태 변화를 관찰해 filled를 보낸다', async () => {
+    render(<GoogleAd slotId="2222" />);
+    // 아직 스크립트 로드 전 — push는 큐잉만 되고 관찰은 로드 이벤트를 기다리는 중이어야 한다.
+    expect(sendGAEventMock).not.toHaveBeenCalled();
+
+    markAdsenseScriptLoaded();
+    const ins = getInsEl();
+    ins.appendChild(document.createElement('iframe'));
+    ins.setAttribute('data-adsbygoogle-status', 'done');
+
+    await vi.waitFor(() => {
+      expect(sendGAEventMock).toHaveBeenCalledWith('ad_render_result', 'filled', {
+        slot_id: '2222',
+      });
+    });
+  });
+
   it('상태는 done인데 iframe이 없으면 empty를 보낸다', async () => {
+    markAdsenseScriptLoaded();
     render(<GoogleAd slotId="5678" />);
     const ins = getInsEl();
     ins.setAttribute('data-adsbygoogle-status', 'done');
@@ -86,8 +115,9 @@ describe('<GoogleAd />', () => {
     });
   });
 
-  it('타임아웃까지 상태 갱신이 없으면(차단 추정) empty를 보낸다', () => {
+  it('스크립트 로드 후 타임아웃까지 상태 갱신이 없으면 empty를 보낸다', () => {
     vi.useFakeTimers();
+    markAdsenseScriptLoaded();
     render(<GoogleAd slotId="9999" />);
 
     vi.advanceTimersByTime(5000);
@@ -97,7 +127,19 @@ describe('<GoogleAd />', () => {
     });
   });
 
+  it('스크립트 자체가 끝내 로드되지 않으면(네트워크 차단 추정) empty를 보낸다', () => {
+    vi.useFakeTimers();
+    render(<GoogleAd slotId="3333" />);
+
+    vi.advanceTimersByTime(8000);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith('ad_render_result', 'empty', {
+      slot_id: '3333',
+    });
+  });
+
   it('결과가 확정된 후에는 추가로 이벤트를 보내지 않는다', async () => {
+    markAdsenseScriptLoaded();
     render(<GoogleAd slotId="1111" />);
     const ins = getInsEl();
     ins.appendChild(document.createElement('iframe'));

--- a/src/libs/client/__tests__/adsenseScript.test.ts
+++ b/src/libs/client/__tests__/adsenseScript.test.ts
@@ -1,0 +1,37 @@
+/**
+ * adsenseScript 유틸 회귀 테스트.
+ *
+ * markAdsenseScriptLoaded가 플래그를 세우고 이벤트를 발화하는지,
+ * isAdsenseScriptLoaded가 그 플래그를 정확히 반영하는지 검증한다.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  ADSENSE_SCRIPT_LOADED_EVENT,
+  isAdsenseScriptLoaded,
+  markAdsenseScriptLoaded,
+} from '../adsenseScript';
+
+describe('adsenseScript', () => {
+  beforeEach(() => {
+    window.adsenseScriptLoaded = false;
+  });
+
+  it('초기 상태는 로드되지 않은 것으로 본다', () => {
+    expect(isAdsenseScriptLoaded()).toBe(false);
+  });
+
+  it('markAdsenseScriptLoaded 호출 후 isAdsenseScriptLoaded가 true를 반환한다', () => {
+    markAdsenseScriptLoaded();
+    expect(isAdsenseScriptLoaded()).toBe(true);
+  });
+
+  it('markAdsenseScriptLoaded는 ADSENSE_SCRIPT_LOADED_EVENT를 발화한다', () => {
+    const listener = vi.fn();
+    window.addEventListener(ADSENSE_SCRIPT_LOADED_EVENT, listener);
+
+    markAdsenseScriptLoaded();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(ADSENSE_SCRIPT_LOADED_EVENT, listener);
+  });
+});

--- a/src/libs/client/adsenseScript.ts
+++ b/src/libs/client/adsenseScript.ts
@@ -1,0 +1,20 @@
+// adsbygoogle.js는 GoogleAdsense 컴포넌트에서 next/script의 lazyOnload 전략으로 로드된다.
+// 즉 페이지 로드가 끝나고 브라우저가 idle 상태가 될 때까지 로딩 자체가 미뤄질 수 있다.
+// GoogleAd는 이 로드 완료 시점을 알아야 "언제부터 슬롯 처리 결과를 기다릴지" 정확히 잴 수 있다.
+export const ADSENSE_SCRIPT_LOADED_EVENT = 'adsbygoogle-script-loaded';
+
+declare global {
+  interface Window {
+    adsenseScriptLoaded?: boolean;
+  }
+}
+
+export function markAdsenseScriptLoaded() {
+  if (typeof window === 'undefined') return;
+  window.adsenseScriptLoaded = true;
+  window.dispatchEvent(new Event(ADSENSE_SCRIPT_LOADED_EVENT));
+}
+
+export function isAdsenseScriptLoaded(): boolean {
+  return typeof window !== 'undefined' && window.adsenseScriptLoaded === true;
+}


### PR DESCRIPTION
## 배경

#536(e7a226f, `ad_render_result` GA4 측정 도입)이 배포된 뒤 4일간(7/10~7/13) 141건이 수집됐는데 **filled 0건 / empty 141건(100%)** 이었습니다. 실제 애드블록 사용률이 100%일 수는 없어 측정 로직 자체의 버그로 판단했습니다.

원인: `GoogleAdsense`가 `adsbygoogle.js`를 `next/script`의 `strategy="lazyOnload"`로 로드합니다 — 페이지 로드가 끝나고 브라우저가 idle 상태가 될 때까지 스크립트 로딩 자체를 미루는 전략입니다. 반면 기존 관찰 로직은 `push()` 호출 시점부터 5초 타임아웃으로 결과를 기다렸습니다. `push()`는 스크립트 로드 전에도 먼저 호출될 수 있어(큐잉 방식) 문제는 없지만, `lazyOnload`로 스크립트 자체가 5초 넘게 늦게 로드되면 광고가 나중에 정상적으로 채워지더라도 타임아웃이 먼저 끝나 무조건 `empty`로 잘못 집계됐습니다.

## 변경 사항

- `src/libs/client/adsenseScript.ts` (신규): `adsbygoogle.js` 로드 완료를 표시하는 플래그 + 커스텀 이벤트 유틸
- `src/components/google/GoogleAdsense.tsx`: `Script`의 `onLoad`에서 로드 완료를 표시
- `src/components/google/GoogleAd.tsx`: 관찰 시작 시점을 `push()` 호출 시점 → **스크립트 로드 완료 시점**으로 이동
  - 이미 로드돼 있으면(같은 페이지의 이전 광고가 로드를 끝낸 경우) 즉시 관찰 시작
  - 아직이면 로드 이벤트를 기다리고, 8초 안에 오지 않으면(네트워크 레벨 차단 추정) `empty`로 집계
  - 로드 이후엔 기존과 동일하게 5초 안에 `data-adsbygoogle-status` 갱신을 기다림
- 테스트: 이미 로드된 경우 / 로드가 마운트 이후 늦게 도착하는 경우 / 끝내 로드되지 않는 경우(네트워크 차단) 세 경로 전부 검증 + `adsenseScript` 유틸 자체 테스트 추가

## 테스트 플랜

- [x] `npx tsc --noEmit` 통과
- [x] `eslint` 통과 (변경 파일 전체)
- [x] `vitest run` 전체 스위트 52 files / 355 tests 통과 (신규 5개 포함)

## 배포 후 확인

이 PR은 GA4 커스텀 측정기준 등록 등 추가 관리자 설정은 필요 없습니다(#536에서 이미 완료). 배포 후 며칠 트래픽이 쌓이면 `ad_render_result`의 `filled`/`empty` 비율이 이제 현실적인 값으로 나오는지 재확인하면 됩니다.