### PR TITLE
feat: 블로그 정렬에 조회수순 옵션 추가

### DIFF
--- a/src/assets/locales/en/blog/index.json
+++ b/src/assets/locales/en/blog/index.json
@@ -13,7 +13,8 @@
     "tag": "Tags",
     "orderBy": {
       "resent": "Resent",
-      "title": "Title"
+      "title": "Title",
+      "views": "Most viewed"
     }
   }
 }

--- a/src/assets/locales/ja/blog/index.json
+++ b/src/assets/locales/ja/blog/index.json
@@ -13,7 +13,8 @@
     "tag": "タグ",
     "orderBy": {
       "resent": "最新順",
-      "title": "タイトル"
+      "title": "タイトル",
+      "views": "閲覧数順"
     }
   }
 }

--- a/src/assets/locales/ko/blog/index.json
+++ b/src/assets/locales/ko/blog/index.json
@@ -13,7 +13,8 @@
     "tag": "태그",
     "orderBy": {
       "resent": "최신순",
-      "title": "제목"
+      "title": "제목",
+      "views": "조회수순"
     }
   }
 }

--- a/src/assets/locales/zh/blog/index.json
+++ b/src/assets/locales/zh/blog/index.json
@@ -13,7 +13,8 @@
     "tag": "标签",
     "orderBy": {
       "resent": "最新",
-      "title": "标题"
+      "title": "标题",
+      "views": "浏览量"
     }
   }
 }

--- a/src/components/blog/BlogSearchBar.tsx
+++ b/src/components/blog/BlogSearchBar.tsx
@@ -32,7 +32,11 @@ function BlogSearchBar({ toggleDrawer, lng }: BlogSearchBarProps) {
 
   const onOrderByChange = useCallback(
     (value: string) => {
-      if (value === BlogOrderByEnum.Resent || value === BlogOrderByEnum.Title) {
+      if (
+        value === BlogOrderByEnum.Resent ||
+        value === BlogOrderByEnum.Title ||
+        value === BlogOrderByEnum.Views
+      ) {
         setOrderBy(value as (typeof BlogOrderByEnum)[keyof typeof BlogOrderByEnum]);
         sendGAEvent('blog_sort_change', value, { sort_value: value });
       }
@@ -115,6 +119,7 @@ function BlogSearchBar({ toggleDrawer, lng }: BlogSearchBarProps) {
         <SelectContent>
           <SelectItem value={BlogOrderByEnum.Resent}>{t('filter.orderBy.resent')}</SelectItem>
           <SelectItem value={BlogOrderByEnum.Title}>{t('filter.orderBy.title')}</SelectItem>
+          <SelectItem value={BlogOrderByEnum.Views}>{t('filter.orderBy.views')}</SelectItem>
         </SelectContent>
       </Select>
     </motion.div>

--- a/src/hooks/blog/useBlogSearch.ts
+++ b/src/hooks/blog/useBlogSearch.ts
@@ -72,7 +72,7 @@ const useBlogSearch = (
       setTitle('');
     }
 
-    if (orderByQuery === 'RESENT' || orderByQuery === 'TITLE') {
+    if (orderByQuery === 'RESENT' || orderByQuery === 'TITLE' || orderByQuery === 'VIEWS') {
       setOrderBy(orderByQuery);
     } else {
       setOrderBy('RESENT');

--- a/src/hooks/blog/useBlogSearchClient.ts
+++ b/src/hooks/blog/useBlogSearchClient.ts
@@ -60,7 +60,9 @@ function applySearchParamsToStore({
 
   setTitle(keyword || '');
   setOrderBy(
-    orderBy === BlogOrderByEnum.Resent || orderBy === BlogOrderByEnum.Title
+    orderBy === BlogOrderByEnum.Resent ||
+      orderBy === BlogOrderByEnum.Title ||
+      orderBy === BlogOrderByEnum.Views
       ? (orderBy as BlogOrderByEnum)
       : BlogOrderByEnum.Resent,
   );


### PR DESCRIPTION
## 개요
블로그 목록 정렬 옵션에 조회수순을 추가합니다.

## 변경 내용
- `api-spec` 포인터 갱신: `BlogOrderByEnum`에 `VIEWS` 추가 (백엔드와 동일 커밋 `e5d08ae`)
- `BlogSearchBar`: 정렬 Select에 조회수순 항목 추가 + onChange 허용값에 `VIEWS` 추가
- `useBlogSearch` / `useBlogSearchClient`: URL `orderBy` 쿼리 파싱 허용값에 `VIEWS` 추가
- 번역(ko/en/ja/zh): `filter.orderBy.views` 키 추가 (조회수순 / Most viewed / 閲覧数順 / 浏览量)

생성 클라이언트(`src/spec/api`)는 gitignore 대상이라 빌드 시 `yarn generate-api`로 재생성됩니다.

## 검증
- `npx tsc --noEmit` 통과
- ESLint 통과
- `yarn test --run` 355개 전부 통과

## 연관
- 스펙: okdohyuk/okdohyuk-api-spec#45
- 백엔드: okdohyuk/okdohyuk-api#187 (VIEWS → viewCount DESC 정렬 구현, 프론트보다 먼저 머지 필요)
