### PR TITLE
fix: 블로그 상세 페이지 수정 버튼 제거

### DIFF
--- a/src/components/blog/BlogDetail/BlogHeader.tsx
+++ b/src/components/blog/BlogDetail/BlogHeader.tsx
@@ -9,7 +9,7 @@ import ViewCount from './ViewCount';
 
 function BlogHeader() {
   const { blog } = useBlogDetail();
-  const { thumbnailImage, title, createdAt, urlSlug, categoryChain } = blog;
+  const { thumbnailImage, title, createdAt, categoryChain } = blog;
   const createdDate = createdAt ? new Date(createdAt) : new Date();
 
   const categoryRender = (category: string, index: number) => (
@@ -48,12 +48,6 @@ function BlogHeader() {
           <span className="inline-flex items-center rounded-full bg-black/30 px-3 py-1">
             <ViewCount />
           </span>
-          <Link
-            href={`/admin/blog/write?urlSlug=${urlSlug}`}
-            className="rounded-full border border-white/25 bg-black/25 px-3 py-1 text-white/60 transition-colors duration-150 hover:border-point-2/80 hover:text-white"
-          >
-            수정
-          </Link>
         </Text>
       </div>
     </header>


### PR DESCRIPTION
## 개요
블로그 상세 페이지 헤더에 노출되던 수정 버튼(어드민 글쓰기 링크)을 제거합니다.

## 변경 내용
- `BlogHeader`: 조회수 옆 수정 링크(`/admin/blog/write?urlSlug=…`) 제거 및 미사용 `urlSlug` 정리

## 검증
- `npx tsc --noEmit` 통과
- ESLint 통과