### PR TITLE
feat: 단축 URL 만료 연장 기능 추가

### DIFF
--- a/src/app/[lng]/(mobile)/shortener/me/MyShortUrlsTable.tsx
+++ b/src/app/[lng]/(mobile)/shortener/me/MyShortUrlsTable.tsx
@@ -4,6 +4,13 @@ import React from 'react';
 import { Loader2, Trash2 } from 'lucide-react';
 import { Button } from '@components/basic/Button';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/basic/Select';
+import {
   Table,
   TableBody,
   TableCell,
@@ -11,7 +18,12 @@ import {
   TableHeader,
   TableRow,
 } from '@components/basic/Table';
-import { useDeleteShortUrl, useMyShortUrls } from '@queries/useShortUrlQueries';
+import { ShortUrlExpireUpdateRequestExpirePresetEnum } from '@api/ShortUrl';
+import {
+  useDeleteShortUrl,
+  useMyShortUrls,
+  useUpdateShortUrlExpiration,
+} from '@queries/useShortUrlQueries';
 import UserTokenUtil from '@utils/userTokenUtil';
 import logger from '@utils/logger';
 import { buildShortUrl } from '@libs/shared/agentDiscovery';
@@ -39,6 +51,52 @@ export default function MyShortUrlsTable({ lng }: MyShortUrlsTableProps) {
 
   const { data, isLoading, isError } = useMyShortUrls(accessToken);
   const deleteMutation = useDeleteShortUrl();
+  const extendMutation = useUpdateShortUrlExpiration();
+
+  const isExpired = (value: string | null | undefined) => {
+    if (!value) return false;
+    const date = new Date(value);
+    return !Number.isNaN(date.getTime()) && date.getTime() < Date.now();
+  };
+
+  const presetOptions = [
+    {
+      value: ShortUrlExpireUpdateRequestExpirePresetEnum.OneDay,
+      label: t('form.expirePreset.options.oneDay'),
+    },
+    {
+      value: ShortUrlExpireUpdateRequestExpirePresetEnum.SevenDays,
+      label: t('form.expirePreset.options.sevenDays'),
+    },
+    {
+      value: ShortUrlExpireUpdateRequestExpirePresetEnum.ThirtyDays,
+      label: t('form.expirePreset.options.thirtyDays'),
+    },
+    {
+      value: ShortUrlExpireUpdateRequestExpirePresetEnum.OneYear,
+      label: t('form.expirePreset.options.oneYear'),
+    },
+    {
+      value: ShortUrlExpireUpdateRequestExpirePresetEnum.Never,
+      label: t('form.expirePreset.options.never'),
+    },
+  ];
+
+  const handleExtend = (code: string, preset: string) => {
+    extendMutation.mutate(
+      {
+        code,
+        request: { expirePreset: preset as ShortUrlExpireUpdateRequestExpirePresetEnum },
+      },
+      {
+        onError: (err) => {
+          logger.error('단축 URL 만료 연장 실패', code, err);
+          // eslint-disable-next-line no-alert
+          window.alert(t('me.extendError'));
+        },
+      },
+    );
+  };
 
   const handleDelete = (code: string) => {
     // eslint-disable-next-line no-alert
@@ -88,12 +146,15 @@ export default function MyShortUrlsTable({ lng }: MyShortUrlsTableProps) {
           <TableHead className="w-[80px] text-right">{t('me.table.hitCount')}</TableHead>
           <TableHead className="w-[160px]">{t('me.table.createdAt')}</TableHead>
           <TableHead className="w-[160px]">{t('me.table.expiresAt')}</TableHead>
-          <TableHead className="w-[80px]">{t('me.table.actions')}</TableHead>
+          <TableHead className="w-[190px]">{t('me.table.actions')}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {items.map((item) => {
           const isDeleting = deleteMutation.isPending && deleteMutation.variables === item.code;
+          const isExtending =
+            extendMutation.isPending && extendMutation.variables?.code === item.code;
+          const expired = isExpired(item.expiresAt);
           // 백엔드 shortUrl 대신 NEXT_PUBLIC_URL 기반 절대 URL 로 표시한다.
           const displayShortUrl = buildShortUrl(item.code);
           return (
@@ -112,23 +173,54 @@ export default function MyShortUrlsTable({ lng }: MyShortUrlsTableProps) {
               <TableCell className="text-right tabular-nums">{item.hitCount}</TableCell>
               <TableCell className="text-xs text-fg-4">{formatDateTime(item.createdAt)}</TableCell>
               <TableCell className="text-xs text-fg-4">
-                {item.expiresAt ? formatDateTime(item.expiresAt) : t('result.expiresNever')}
+                {expired ? (
+                  <span className="font-semibold text-red-500">
+                    {t('me.expired')} · {formatDateTime(item.expiresAt)}
+                  </span>
+                ) : (
+                  (item.expiresAt && formatDateTime(item.expiresAt)) || t('result.expiresNever')
+                )}
               </TableCell>
               <TableCell>
-                <Button
-                  type="button"
-                  onClick={() => handleDelete(item.code)}
-                  disabled={isDeleting}
-                  analyticsKey="shortener_delete"
-                  className="min-h-[28px] bg-red-500 px-2 text-xs hover:bg-red-600"
-                  aria-label={`${t('me.deleteButton')} ${item.code}`}
-                >
-                  {isDeleting ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Trash2 className="h-3.5 w-3.5" />
-                  )}
-                </Button>
+                <div className="flex items-center gap-1.5">
+                  <Select
+                    key={item.expiresAt ?? 'never'}
+                    onValueChange={(preset) => handleExtend(item.code, preset)}
+                    disabled={isExtending}
+                  >
+                    <SelectTrigger
+                      className="h-[28px] w-[92px] bg-basic-0/90 px-2 text-xs font-semibold"
+                      aria-label={`${t('me.extendButton')} ${item.code}`}
+                    >
+                      {isExtending ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <SelectValue placeholder={t('me.extendButton')} />
+                      )}
+                    </SelectTrigger>
+                    <SelectContent>
+                      {presetOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    onClick={() => handleDelete(item.code)}
+                    disabled={isDeleting}
+                    analyticsKey="shortener_delete"
+                    className="min-h-[28px] bg-red-500 px-2 text-xs hover:bg-red-600"
+                    aria-label={`${t('me.deleteButton')} ${item.code}`}
+                  >
+                    {isDeleting ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </div>
               </TableCell>
             </TableRow>
           );

--- a/src/assets/locales/en/shortener.json
+++ b/src/assets/locales/en/shortener.json
@@ -55,7 +55,10 @@
     },
     "deleteConfirm": "Delete short URL {{code}}?",
     "deleteError": "Failed to delete the short URL. Please try again shortly.",
-    "deleteButton": "Delete"
+    "deleteButton": "Delete",
+    "extendButton": "Extend",
+    "extendError": "Failed to extend the short URL. Please try again later.",
+    "expired": "Expired"
   },
   "notFound": {
     "status": "404 / 410",

--- a/src/assets/locales/ja/shortener.json
+++ b/src/assets/locales/ja/shortener.json
@@ -55,7 +55,10 @@
     },
     "deleteConfirm": "短縮URL {{code}} を削除しますか?",
     "deleteError": "短縮URLの削除に失敗しました。しばらくしてから再度お試しください。",
-    "deleteButton": "削除"
+    "deleteButton": "削除",
+    "extendButton": "延長",
+    "extendError": "短縮URLの延長に失敗しました。しばらくしてからもう一度お試しください。",
+    "expired": "期限切れ"
   },
   "notFound": {
     "status": "404 / 410",

--- a/src/assets/locales/ko/shortener.json
+++ b/src/assets/locales/ko/shortener.json
@@ -55,7 +55,10 @@
     },
     "deleteConfirm": "정말로 {{code}} 단축 URL 을 삭제할까요?",
     "deleteError": "단축 URL 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.",
-    "deleteButton": "삭제"
+    "deleteButton": "삭제",
+    "extendButton": "연장",
+    "extendError": "단축 URL 만료 연장에 실패했어요. 잠시 후 다시 시도해 주세요.",
+    "expired": "만료됨"
   },
   "notFound": {
     "status": "404 / 410",

--- a/src/assets/locales/zh/shortener.json
+++ b/src/assets/locales/zh/shortener.json
@@ -55,7 +55,10 @@
     },
     "deleteConfirm": "确定要删除短链接 {{code}} 吗?",
     "deleteError": "短链接删除失败,请稍后重试。",
-    "deleteButton": "删除"
+    "deleteButton": "删除",
+    "extendButton": "续期",
+    "extendError": "短链接续期失败，请稍后重试。",
+    "expired": "已过期"
   },
   "notFound": {
     "status": "404 / 410",

--- a/src/queries/useShortUrlQueries.ts
+++ b/src/queries/useShortUrlQueries.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { shortUrlApi } from '@api';
-import type { ShortUrlCreateRequest } from '@api/ShortUrl';
+import type { ShortUrlCreateRequest, ShortUrlExpireUpdateRequest } from '@api/ShortUrl';
 import UserTokenUtil from '@utils/userTokenUtil';
 
 export const SHORT_URL_KEYS = {
@@ -35,6 +35,28 @@ export const useMyShortUrls = (accessToken: string | null) => {
       return data;
     },
     enabled: !!accessToken,
+  });
+};
+
+// 만료 연장/변경: 새 만료 시각은 요청 시점 기준으로 재계산된다.
+export const useUpdateShortUrlExpiration = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      code,
+      request,
+    }: {
+      code: string;
+      request: ShortUrlExpireUpdateRequest;
+    }) => {
+      const accessToken = UserTokenUtil.getAccessToken();
+      const { data } = await shortUrlApi.patchShortUrlCode(code, accessToken, request);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SHORT_URL_KEYS.me() });
+    },
   });
 };
 


### PR DESCRIPTION
## 개요
내 단축 URL 목록에서 만료된(또는 만료 예정인) 링크의 만료를 연장할 수 있는 기능을 추가합니다.

## 변경 내용
- `api-spec` 포인터 갱신: `PATCH /short-url/{code}` + `ShortUrlExpireUpdateRequest` (백엔드와 동일 커밋 `f331a85`)
- `useUpdateShortUrlExpiration` mutation 추가 (성공 시 `/me` 목록 캐시 무효화)
- `MyShortUrlsTable`(공통 `@components/basic/Table` 사용):
  - 관리 열에 프리셋(1일/7일/30일/1년/무제한) 선택형 연장 Select 추가 — 공통 `@components/basic/Select` 사용
  - 만료된 링크는 만료일 열에 빨간색 "만료됨" 표시
- 번역(ko/en/ja/zh): `me.extendButton` / `me.extendError` / `me.expired` 추가

목록 테이블은 기존부터 공통 Table 컴포넌트(`@components/basic/Table`)를 사용하고 있어 그대로 유지했고, 신규 UI 도 공통 컴포넌트(Select/Button)로 구성했습니다.

## 검증
- `npx tsc --noEmit` / ESLint 통과
- `yarn test --run` 355개 전부 통과

## 연관
- 스펙: okdohyuk/okdohyuk-api-spec#46
- 백엔드: okdohyuk/okdohyuk-api#189 (프론트보다 먼저 머지 필요)
