### PR TITLE
feat: 재방문자 서비스 개선 설문 배너 추가

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,5 +15,6 @@ yarn run generate-api -- --name=Guestbook
 yarn run generate-api -- --name=Solve
 yarn run generate-api -- --name=Pokemon
 yarn run generate-api -- --name=PokemonTeam
+yarn run generate-api -- --name=Survey
 yarn run build
 yarn run postbuild

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -12,6 +12,7 @@ import { ReactQueryProvider } from '@components/complex/Layout/QueryClient';
 import GoogleAdsense from '@components/google/GoogleAdsense';
 import AgentWebMcp from '@components/agent/AgentWebMcp';
 import ConsentBanner from '@components/complex/Consent/ConsentBanner';
+import SurveyBanner from '@components/complex/Survey/SurveyBanner';
 import WebVitalsReporter from '@components/analytics/WebVitalsReporter';
 import ScrollDepthTracker from '@components/analytics/ScrollDepthTracker';
 import OutboundLinkTracker from '@components/analytics/OutboundLinkTracker';
@@ -80,6 +81,7 @@ export default async function RootLayout({ children, params }: RootLayoutProps) 
             <CommonLayout>{children}</CommonLayout>
             <Footer lng={language} />
             <AgentWebMcp language={language} />
+            <SurveyBanner />
             {enableThirdPartyTracking && (
               <>
                 <Analytics />

--- a/src/app/i18n/i18next.d.ts
+++ b/src/app/i18n/i18next.d.ts
@@ -62,6 +62,7 @@ import shortener from 'assets/locales/ko/shortener.json';
 import copykiller from 'assets/locales/ko/copykiller.json';
 import solve from 'assets/locales/ko/solve.json';
 import guestbook from 'assets/locales/ko/guestbook.json';
+import survey from 'assets/locales/ko/survey.json';
 
 declare module 'i18next' {
   // Extend CustomTypeOptions
@@ -130,6 +131,7 @@ declare module 'i18next' {
       copykiller: typeof copykiller;
       solve: typeof solve;
       guestbook: typeof guestbook;
+      survey: typeof survey;
     };
   }
 }

--- a/src/assets/locales/en/survey.json
+++ b/src/assets/locales/en/survey.json
@@ -1,0 +1,15 @@
+{
+  "title": "Got a minute? Share your feedback",
+  "description": "Help us improve by taking this quick survey.",
+  "npsQuestion": "How likely are you to recommend this service to a friend or colleague?",
+  "npsLow": "0 · Not at all",
+  "npsHigh": "10 · Extremely likely",
+  "scoreAriaLabel": "Score {{score}}",
+  "commentPlaceholder": "Tell us what we could do better (optional)",
+  "submit": "Submit",
+  "dismiss": "Dismiss",
+  "thanks": "Thanks for your feedback!",
+  "ariaLabel": "Service improvement survey",
+  "submitAriaLabel": "Submit survey",
+  "dismissAriaLabel": "Dismiss survey"
+}

--- a/src/assets/locales/ja/survey.json
+++ b/src/assets/locales/ja/survey.json
@@ -1,0 +1,15 @@
+{
+  "title": "少しだけご意見をお聞かせください",
+  "description": "より良いサービスのため、短いアンケートにご協力ください。",
+  "npsQuestion": "このサービスを友人や同僚におすすめする可能性はどのくらいですか？",
+  "npsLow": "0 · まったく思わない",
+  "npsHigh": "10 · とてもそう思う",
+  "scoreAriaLabel": "{{score}}点",
+  "commentPlaceholder": "改善してほしい点があればご自由にお書きください（任意）",
+  "submit": "送信",
+  "dismiss": "閉じる",
+  "thanks": "貴重なご意見ありがとうございます！",
+  "ariaLabel": "サービス改善アンケート",
+  "submitAriaLabel": "アンケートを送信",
+  "dismissAriaLabel": "アンケートを閉じる"
+}

--- a/src/assets/locales/ko/survey.json
+++ b/src/assets/locales/ko/survey.json
@@ -1,0 +1,15 @@
+{
+  "title": "잠깐, 의견을 들려주세요",
+  "description": "더 나은 서비스를 만들기 위해 짧은 설문에 참여해 주세요.",
+  "npsQuestion": "이 서비스를 친구나 동료에게 추천하실 가능성은 어느 정도인가요?",
+  "npsLow": "0 · 전혀 아님",
+  "npsHigh": "10 · 매우 그럼",
+  "scoreAriaLabel": "{{score}}점",
+  "commentPlaceholder": "개선하면 좋을 점을 자유롭게 남겨 주세요 (선택)",
+  "submit": "제출",
+  "dismiss": "닫기",
+  "thanks": "소중한 의견 감사합니다!",
+  "ariaLabel": "서비스 개선 설문",
+  "submitAriaLabel": "설문 제출",
+  "dismissAriaLabel": "설문 닫기"
+}

--- a/src/assets/locales/zh/survey.json
+++ b/src/assets/locales/zh/survey.json
@@ -1,0 +1,15 @@
+{
+  "title": "花点时间，分享您的意见",
+  "description": "参与这项简短的问卷，帮助我们改进服务。",
+  "npsQuestion": "您向朋友或同事推荐本服务的可能性有多大？",
+  "npsLow": "0 · 完全不会",
+  "npsHigh": "10 · 非常愿意",
+  "scoreAriaLabel": "{{score}} 分",
+  "commentPlaceholder": "欢迎留下您希望我们改进的建议（选填）",
+  "submit": "提交",
+  "dismiss": "关闭",
+  "thanks": "感谢您的宝贵意见！",
+  "ariaLabel": "服务改进问卷",
+  "submitAriaLabel": "提交问卷",
+  "dismissAriaLabel": "关闭问卷"
+}

--- a/src/components/complex/Survey/SurveyBanner.tsx
+++ b/src/components/complex/Survey/SurveyBanner.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import * as React from 'react';
+import { useParams } from 'next/navigation';
+import { Button } from '@components/basic/Button/Button';
+import { Textarea } from '@components/basic/Textarea/Textarea';
+import { sendGAEvent } from '@libs/client/gtag';
+import { surveyApi } from '@api';
+import UserTokenUtil from '@utils/userTokenUtil';
+import LocalStorage from '@utils/localStorage';
+import logger from '@utils/logger';
+import { cn } from '@utils/cn';
+import { useTranslation } from '~/app/i18n/client';
+import { Language } from '~/app/i18n/settings';
+
+// 재방문 트리거 파라미터
+const MIN_VISITS = 2; // 2회차 방문부터 노출
+const VISIT_COUNT_KEY = 'survey_visit_count'; // localStorage 누적 방문 수
+const VISIT_SESSION_FLAG = 'survey_visit_counted'; // sessionStorage: 탭 세션당 1회만 카운트
+const STATE_KEY = 'survey_state_v1'; // localStorage: 응답/닫음 상태 + timestamp
+
+// 상태별 TTL. 응답은 장기간 재노출 차단, 닫음은 비교적 짧게 두어 재문의 여지를 남긴다.
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RESPONDED_TTL_MS = 180 * DAY_MS;
+const DISMISSED_TTL_MS = 30 * DAY_MS;
+
+const THANKS_AUTO_HIDE_MS = 1600;
+const MAX_COMMENT_LENGTH = 500;
+const NPS_SCORES = Array.from({ length: 11 }, (_, i) => i); // 0~10
+
+type SurveyStatus = 'responded' | 'dismissed';
+
+type StoredSurveyState = {
+  status: SurveyStatus;
+  at: number;
+};
+
+function ttlFor(status: SurveyStatus): number {
+  return status === 'responded' ? RESPONDED_TTL_MS : DISMISSED_TTL_MS;
+}
+
+// 저장된 응답/닫음 상태를 읽고, TTL 만료 시 제거 후 null 반환 (ConsentBanner TTL 패턴)
+function readSurveyState(): StoredSurveyState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = LocalStorage.getItem(STATE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredSurveyState;
+    const validStatus = parsed?.status === 'responded' || parsed?.status === 'dismissed';
+    if (!validStatus || typeof parsed?.at !== 'number') return null;
+    if (Date.now() - parsed.at > ttlFor(parsed.status)) {
+      LocalStorage.removeItem(STATE_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeSurveyState(status: SurveyStatus) {
+  try {
+    const payload: StoredSurveyState = { status, at: Date.now() };
+    LocalStorage.setItem(STATE_KEY, JSON.stringify(payload));
+  } catch {
+    // localStorage 사용 불가 환경 — 무시
+  }
+}
+
+// 탭 세션당 1회만 카운트를 올려 "방문 횟수"를 근사한다.
+// SessionId 쿠키는 재방문 전반에 걸쳐 안정적으로 유지되므로 방문 구분자로는 부적합하여
+// 세션 스토리지 플래그를 방문 경계로 사용한다. (SessionId는 gtag 이벤트 상관관계로 이미 활용됨)
+function registerVisit(): number {
+  const current = Number(LocalStorage.getItem(VISIT_COUNT_KEY)) || 0;
+  if (typeof window === 'undefined') return current;
+
+  let alreadyCounted = false;
+  try {
+    alreadyCounted = window.sessionStorage.getItem(VISIT_SESSION_FLAG) === '1';
+  } catch {
+    // sessionStorage 사용 불가 — 카운트 유지
+  }
+  if (alreadyCounted) return current || 1;
+
+  const next = current + 1;
+  LocalStorage.setItem(VISIT_COUNT_KEY, String(next));
+  try {
+    window.sessionStorage.setItem(VISIT_SESSION_FLAG, '1');
+  } catch {
+    // 무시
+  }
+  return next;
+}
+
+export default function SurveyBanner() {
+  const params = useParams<{ lng?: string }>();
+  const language = (params?.lng ?? 'ko') as Language;
+  const { t } = useTranslation(language, 'survey');
+
+  const [mounted, setMounted] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
+  const [score, setScore] = React.useState<number | null>(null);
+  const [comment, setComment] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [done, setDone] = React.useState(false);
+  const shownReportedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+    // 이미 응답했거나 닫은 상태(TTL 내)면 노출하지 않음
+    if (readSurveyState()) return;
+    const visits = registerVisit();
+    if (visits >= MIN_VISITS) {
+      setVisible(true);
+    }
+  }, []);
+
+  // 노출 시 1회만 survey_shown 계측
+  React.useEffect(() => {
+    if (visible && !shownReportedRef.current) {
+      shownReportedRef.current = true;
+      sendGAEvent('survey_shown', 'shown');
+    }
+  }, [visible]);
+
+  const handleDismiss = React.useCallback(() => {
+    writeSurveyState('dismissed');
+    sendGAEvent('survey_dismissed', 'dismissed');
+    setVisible(false);
+  }, []);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (score === null || submitting) return;
+    setSubmitting(true);
+    const pagePath = typeof window !== 'undefined' ? window.location.pathname : '';
+    // 로그인 상태면 토큰 전달, 없으면 익명(undefined). apiInstance 인터셉터도 토큰을 자동 첨부한다.
+    const authorization = UserTokenUtil.getAccessToken() || undefined;
+    const trimmed = comment.trim();
+    try {
+      await surveyApi.postSurvey(
+        {
+          npsScore: score,
+          comment: trimmed || null,
+          language,
+          pagePath,
+        },
+        authorization,
+      );
+      writeSurveyState('responded');
+      sendGAEvent('survey_submitted', String(score), { npsScore: score });
+      setDone(true);
+      window.setTimeout(() => setVisible(false), THANKS_AUTO_HIDE_MS);
+    } catch (err) {
+      logger.error('SurveyBanner: 설문 제출 실패', err);
+      setSubmitting(false);
+    }
+  }, [score, comment, language, submitting]);
+
+  if (!mounted || !visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label={t('ariaLabel')}
+      aria-live="polite"
+      className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-4 sm:pb-6"
+    >
+      <div className="w-full max-w-xl rounded-2xl border border-basic-3 bg-basic-0 p-4 shadow-[0_16px_40px_rgba(0,0,0,0.18)] sm:p-5">
+        {done ? (
+          <p className="py-2 text-center text-sm text-fg-1 sm:text-base">{t('thanks')}</p>
+        ) : (
+          <>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-base font-semibold text-fg-1">{t('title')}</p>
+                <p className="mt-1 text-sm text-fg-2">{t('description')}</p>
+              </div>
+              <button
+                type="button"
+                onClick={handleDismiss}
+                aria-label={t('dismissAriaLabel')}
+                className="shrink-0 rounded-md p-1 text-fg-3 transition-colors hover:bg-basic-2 hover:text-fg-1"
+              >
+                <span aria-hidden>✕</span>
+              </button>
+            </div>
+
+            <p className="mt-3 text-sm text-fg-1">{t('npsQuestion')}</p>
+            <div
+              role="radiogroup"
+              aria-label={t('npsQuestion')}
+              className="mt-2 flex flex-wrap gap-1"
+            >
+              {NPS_SCORES.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  role="radio"
+                  aria-checked={score === n}
+                  aria-label={t('scoreAriaLabel', { score: n })}
+                  onClick={() => setScore(n)}
+                  className={cn(
+                    'h-9 min-w-9 flex-1 rounded-md border text-sm transition-colors',
+                    score === n
+                      ? 'border-point-2 bg-point-2 text-white'
+                      : 'border-basic-3 bg-basic-1 text-fg-1 hover:border-point-2 hover:bg-basic-2',
+                  )}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+            <div className="mt-1 flex justify-between text-xs text-fg-3">
+              <span>{t('npsLow')}</span>
+              <span>{t('npsHigh')}</span>
+            </div>
+
+            <Textarea
+              className="mt-3"
+              rows={2}
+              value={comment}
+              maxLength={MAX_COMMENT_LENGTH}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder={t('commentPlaceholder')}
+            />
+
+            <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                onClick={handleDismiss}
+                className="bg-basic-2 text-fg-1 hover:bg-basic-3"
+                aria-label={t('dismissAriaLabel')}
+              >
+                {t('dismiss')}
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={score === null || submitting}
+                aria-label={t('submitAriaLabel')}
+              >
+                {t('submit')}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/libs/client/gtag.ts
+++ b/src/libs/client/gtag.ts
@@ -83,6 +83,8 @@ type MiscEvent = 'legal_section_jump';
 
 type AdEvent = 'ad_render_result';
 
+type SurveyEvent = 'survey_shown' | 'survey_submitted' | 'survey_dismissed';
+
 export type Event =
   | GlobalEvent
   | NavEvent
@@ -95,6 +97,7 @@ export type Event =
   | UiEvent
   | MiscEvent
   | AdEvent
+  | SurveyEvent
   | LegacyEvent;
 
 // =============================================================================

--- a/src/spec/api/index.ts
+++ b/src/spec/api/index.ts
@@ -14,6 +14,7 @@ import { SessionApi } from './Session';
 import { ShortUrlApi } from './ShortUrl';
 import { SolveApi } from './Solve';
 import { StorageApi } from './Storage';
+import { SurveyApi } from './Survey';
 import { UserApi } from './User';
 
 // 환경 변수에서 API URL을 가져옵니다.
@@ -93,6 +94,7 @@ export const sessionApi = new SessionApi(undefined, API_URL, apiInstance);
 export const shortUrlApi = new ShortUrlApi(undefined, API_URL, apiInstance);
 export const solveApi = new SolveApi(undefined, API_URL, apiInstance);
 export const storageApi = new StorageApi(undefined, API_URL, apiInstance);
+export const surveyApi = new SurveyApi(undefined, API_URL, apiInstance);
 export const userApi = new UserApi(undefined, API_URL, apiInstance);
 
 // access token을 refresh하는 함수


### PR DESCRIPTION
## 개요
재방문 사용자에게 하단 비침습 배너로 NPS + 자유서술 설문을 노출하고 응답을 백엔드(POST /survey)에 저장.

## 변경
- `SurveyBanner`(components/complex/Survey) — ConsentBanner 패턴 복제. NPS 0~10 버튼 + Textarea + 제출/닫기. 기존 basic 컴포넌트·디자인 토큰 재사용.
- 재방문 트리거: localStorage `survey_visit_count`(탭 세션당 1회 증가) 2회차 이상 && 미응답 시 노출. `survey_state_v1`에 상태+TTL(응답 180일/닫음 30일) 저장 → 재노출 차단.
- i18n: `survey.json` ko/en/ja/zh 4개 + i18next.d.ts 등록
- 계측: gtag `survey_shown`/`survey_submitted`(value=npsScore)/`survey_dismissed`
- generated client `surveyApi` export + `scripts/build.sh`에 Survey 생성 추가(CI 배선)
- 전역 레이아웃(app/[lng]/layout.tsx) 마운트
- api-spec 포인터 → 백엔드와 동일 커밋

## 검증
- `tsc --noEmit` 통과, husky lint-staged + vitest 355 tests 통과

## 참고
- 배너는 애널리틱스 동의 게이트 밖(항상 노출)에 마운트 — 설문은 동의와 무관한 제품 기능으로 판단. 동의 후 노출 원하면 게이트 안으로 이동 가능.
- 현 스펙상 sessionId 입력 파라미터 없음(백엔드 sessionId 항상 null) — 후속 확장 여지.

## 의존
- 백엔드 PR: okdohyuk/okdohyuk-api#191, 스펙 PR: okdohyuk/okdohyuk-api-spec#47 (선머지 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)