### PR TITLE
fix: 데스크탑 블로그 카드 제목 2줄까지 노출

### DIFF
--- a/src/components/blog/BlogCard/Discript.tsx
+++ b/src/components/blog/BlogCard/Discript.tsx
@@ -31,10 +31,10 @@ const Discript: BlogCardTypeFC = function Discript({ blog }) {
         <div className="h-[108px] w-[108px] shrink-0 rounded-xl bg-gradient-to-br from-point-4/60 to-violet-100 dark:from-point-1/20 dark:to-violet-900/30 md:h-[196px] md:w-[196px]" />
       )}
       <div className="flex flex-1 flex-col justify-start overflow-hidden text-left">
-        <h2 className="my-1 line-clamp-1 text-base font-bold text-fg-1 md:my-3 md:text-lg">
+        <h2 className="my-1 line-clamp-1 text-base font-bold text-fg-1 md:my-3 md:line-clamp-2 md:text-lg">
           {title}
         </h2>
-        <p className="line-clamp-2 text-sm leading-relaxed text-fg-3 md:line-clamp-4">
+        <p className="line-clamp-2 text-sm leading-relaxed text-fg-3 md:line-clamp-3">
           {MarkdownUtils.removeMarkdown(contents)}
         </p>
         <span

--- a/src/components/blog/BlogCard/Frame.tsx
+++ b/src/components/blog/BlogCard/Frame.tsx
@@ -28,8 +28,8 @@ const Frame: BlogCardTypeFC = function Frame({ blog }) {
         <div className="h-40 w-full bg-gradient-to-r from-point-4/50 via-zinc-100 to-violet-100 dark:from-point-1/15 dark:via-zinc-800 dark:to-violet-900/20 md:h-44" />
       )}
       <div className="flex flex-1 flex-col p-4">
-        <h2 className="line-clamp-1 text-base font-bold text-fg-1">{title}</h2>
-        <p className="mt-2 line-clamp-4 text-sm leading-relaxed text-fg-3">
+        <h2 className="line-clamp-1 text-base font-bold text-fg-1 md:line-clamp-2">{title}</h2>
+        <p className="mt-2 line-clamp-4 text-sm leading-relaxed text-fg-3 md:line-clamp-3">
           {MarkdownUtils.removeMarkdown(contents)}
         </p>
         <span className="mt-auto pt-3 text-xs font-semibold text-fg-5" suppressHydrationWarning>

--- a/src/components/blog/BlogCardSkeleton/Discript.tsx
+++ b/src/components/blog/BlogCardSkeleton/Discript.tsx
@@ -7,12 +7,23 @@ function Discript() {
     <article
       className={`${BLOG_GLASS_PANEL_SOFT} flex gap-4 overflow-hidden p-3 md:min-h-[200px] md:gap-6 md:p-4`}
     >
-      <Skeleton className="relative h-[108px] w-[108px] rounded-xl md:h-[196px] md:w-[196px]" />
+      <Skeleton className="relative h-[108px] w-[108px] shrink-0 rounded-xl md:h-[196px] md:w-[196px]" />
 
-      <div className="flex flex-col flex-1 text-left justify-start overflow-hidden">
-        <Skeleton className="my-1 md:my-4" h={6} />
-        <Skeleton h={16} />
-        <Skeleton className="mt-auto md:mb-4" h={4} w={12} />
+      <div className="flex flex-1 flex-col justify-start overflow-hidden text-left">
+        {/* 제목: 모바일 1줄 / 데스크탑 최대 2줄. 둘째 줄은 짧게 두어 잘린 제목임을 암시 */}
+        <div className="my-1 flex flex-col gap-2 md:my-3">
+          <Skeleton className="h-4 rounded" />
+          <Skeleton className="hidden h-4 w-1/2 rounded md:block" />
+        </div>
+
+        {/* 본문: 모바일 2줄 / 데스크탑 3줄 (line-clamp와 동일한 줄 수) */}
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3.5 rounded" />
+          <Skeleton className="h-3.5 w-3/4 rounded md:w-full" />
+          <Skeleton className="hidden h-3.5 w-2/3 rounded md:block" />
+        </div>
+
+        <Skeleton className="mt-auto h-3 w-16 rounded md:mb-1" />
       </div>
     </article>
   );

--- a/src/components/blog/BlogCardSkeleton/Frame.tsx
+++ b/src/components/blog/BlogCardSkeleton/Frame.tsx
@@ -7,10 +7,22 @@ function Frame() {
     <article className={`${BLOG_GLASS_PANEL_SOFT} flex h-80 flex-col overflow-hidden md:h-96`}>
       <Skeleton className="relative h-40 w-full md:h-44" />
 
-      <div className="flex flex-col flex-1 p-4">
-        <Skeleton h={6} />
-        <Skeleton className="mt-2" h={16} />
-        <Skeleton className="mt-auto" h={4} w={12} />
+      <div className="flex flex-1 flex-col p-4">
+        {/* 제목: 모바일 1줄 / 데스크탑 최대 2줄. 둘째 줄은 짧게 두어 잘린 제목임을 암시 */}
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 rounded" />
+          <Skeleton className="hidden h-4 w-3/5 rounded md:block" />
+        </div>
+
+        {/* 본문: 모바일 4줄 / 데스크탑 3줄 (line-clamp와 동일한 줄 수) */}
+        <div className="mt-2 flex flex-col gap-2">
+          <Skeleton className="h-3.5 rounded" />
+          <Skeleton className="h-3.5 rounded" />
+          <Skeleton className="h-3.5 w-4/5 rounded md:w-2/3" />
+          <Skeleton className="h-3.5 w-2/5 rounded md:hidden" />
+        </div>
+
+        <Skeleton className="mt-auto h-3 w-16 rounded" />
       </div>
     </article>
   );


### PR DESCRIPTION
## 요약

데스크탑(md 이상)에서 블로그 카드 제목이 1줄로 잘려 긴 제목을 알아보기 어려운 문제를 수정했습니다. **카드 높이는 기존과 동일하게 유지**됩니다.

## 변경 내용

### `BlogCard/Frame.tsx` (그리드 뷰)
- 제목: `md:line-clamp-2` 추가 (모바일은 1줄 유지)
- 본문: `md:line-clamp-3` 추가 (기존 4줄)

### `BlogCard/Discript.tsx` (리스트 뷰)
- 제목: `md:line-clamp-2` 추가 (모바일은 1줄 유지)
- 본문: `md:line-clamp-4` → `md:line-clamp-3`

## 높이 유지 근거

- **Frame**: `md:h-96`(384px) 고정. 이미지 176px + 패딩 32px을 뺀 콘텐츠 영역 176px 기준 → 제목 2줄(48) + 간격(8) + 본문 3줄(≈68) + 날짜(28) ≈ 152px로 여유 있음. 본문을 4줄로 두면 ≈175px라 오버플로우 직전이라 3줄로 조정.
- **Discript**: 썸네일 196px가 높이를 결정(`md:min-h-[200px]`보다 큼). 제목 2줄 확장분(+28px)을 본문 1줄 축소(−23px)로 상쇄해 196px 안에 수용.

## 검증

- `npx tsc --noEmit` 통과
- `npx eslint` (변경 파일) 통과
- 모바일 레이아웃은 변경 없음